### PR TITLE
feat: `with_column` now accepts Column struct

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # v0.2 (eta January 2025)
 
 - [x] Swap to sqlx
-- [ ] Allow use of custom columns
+- [x] Allow use of custom columns
 - [ ] "returning `id` should properly choose ID column"
 - [ ] Add thread safety (currently tests in bakery_api fail)
 - [ ] Implement transaction support


### PR DESCRIPTION
Added ability to use column as an argument to add_column:

```rust
table
  .with_column("name")
  .with_column(Column::new(..));
```

also added SqlColumn trait so anything that implemens into<SqlColumn> can be passed. This would allow me to implement ChronoColumn next that would deal with date/time/duration types and also enable serialisation of the data types into non-string SQL columns.