### PR TITLE
base implementation of query-builders v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vantage-sql"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "indexmap 2.10.0",
+ "serde_json",
+ "vantage-expressions",
+]
+
+[[package]]
+name = "vantage-surrealdb"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "indexmap 2.10.0",
+ "serde_json",
+ "vantage-expressions",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
-members = ["vantage", "vantage-expressions", "bakery_model", "bakery_api"]
+members = [
+    "vantage",
+    "vantage-expressions",
+    "vantage-sql",
+    "vantage-surrealdb",
+    "bakery_model",
+    "bakery_api",
+]
 resolver = "2"

--- a/vantage-expressions/src/lib.rs
+++ b/vantage-expressions/src/lib.rs
@@ -7,3 +7,7 @@ pub mod expression;
 pub mod protocol;
 pub mod util;
 pub mod value;
+
+pub use expression::lazy::LazyExpression;
+pub use expression::owned::OwnedExpression;
+pub use protocol::Expressive;

--- a/vantage-expressions/src/protocol.rs
+++ b/vantage-expressions/src/protocol.rs
@@ -3,6 +3,8 @@ use std::fmt::Debug;
 use async_trait::async_trait;
 use serde_json::Value;
 
+use crate::OwnedExpression;
+
 /// DataSource is implemented by vantage-sql, vantage-surrealdb and vantage-graphql
 /// but can also be extended by 3rd party persistence vendors, if the persistence
 /// allows use of expressions
@@ -22,13 +24,18 @@ pub trait PreparableValue: Send + Sync + Debug {
 /// There are several expressions provided by this crate - LazyExpression and OwnedExpressions.
 /// Also - DataSource vendors will add their own versions of expressions of extended syntax.
 ///
-/// All of them should implement basic Expression trait, that guarantees that expressions could be
-/// prepared and executed.
+/// All of those implement an Expressive trait - meaning they can be part of
+/// other expressions. Expressive trait can also be applied to other objects,
+/// such as "Field" or "Query" allowing those to become part of expression
+/// too.
 #[async_trait]
-pub trait Expression: Send + Sync + Debug {}
+pub trait Expressive: Send + Sync + Debug {
+    /// All parts of expressions should be able to convert into OwnedExpression
+    async fn prepare(&self, data_source: &dyn DataSource) -> OwnedExpression;
+}
 
 /// Trait can be used for arguments to pass arbitrary arguments, that can be converted
 /// into expression
 pub trait IntoExpression {
-    fn into_expression(self) -> Box<dyn Expression>;
+    fn into_expression(self) -> Box<dyn Expressive>;
 }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2024"
+name = "vantage-sql"
+version = "0.3.0"
+license = "MIT OR Apache-2.0"
+authors = ["Romans Malinovskis <me@nearly.guru>"]
+description = "Vendor agnostic SQL query builder"
+documentation = "https://docs.rs/vantage"
+homepage = "https://romaninsh.github.io/vantage"
+repository = "https://github.com/romaninsh/vantage"
+readme = "../README.md"
+
+
+[dependencies]
+async-trait = "0.1"
+vantage-expressions = { path = "../vantage-expressions" }
+indexmap = { version = "2.10.0", features = ["serde"] }
+serde_json = { version = "1", features = [
+    "preserve_order",
+    "raw_value",
+    "arbitrary_precision",
+] }

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -1,0 +1,23 @@
+pub mod protocol;
+pub mod query;
+
+use vantage_expressions::{OwnedExpression, expr};
+
+#[derive(Debug, Clone)]
+pub struct Identifier {
+    identifier: String,
+}
+
+impl Identifier {
+    pub fn new(identifier: impl Into<String>) -> Self {
+        Self {
+            identifier: identifier.into(),
+        }
+    }
+}
+
+impl Into<OwnedExpression> for Identifier {
+    fn into(self) -> OwnedExpression {
+        expr!(format!("`{}`", self.identifier))
+    }
+}

--- a/vantage-sql/src/protocol.rs
+++ b/vantage-sql/src/protocol.rs
@@ -1,0 +1,1 @@
+pub trait Query {}

--- a/vantage-sql/src/query/expressive.rs
+++ b/vantage-sql/src/query/expressive.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use vantage_expressions::{Expressive, OwnedExpression, protocol::DataSource};
+
+use crate::query::Query;
+
+#[async_trait]
+impl Expressive for Query {
+    async fn prepare(&self, _data_source: &dyn DataSource) -> OwnedExpression {
+        self.clone().into()
+    }
+}

--- a/vantage-sql/src/query/join_query.rs
+++ b/vantage-sql/src/query/join_query.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JoinQuery;

--- a/vantage-sql/src/query/mod.rs
+++ b/vantage-sql/src/query/mod.rs
@@ -1,0 +1,169 @@
+pub mod expressive;
+pub mod join_query;
+pub mod query_conditions;
+pub mod query_source;
+pub mod query_type;
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use serde_json::Value;
+use vantage_expressions::{Expressive, LazyExpression, OwnedExpression, expr};
+
+use crate::Identifier;
+use join_query::JoinQuery;
+use query_conditions::QueryConditions;
+use query_source::QuerySource;
+use query_type::QueryType;
+
+#[derive(Debug, Clone)]
+pub struct Query {
+    from: Vec<QuerySource>,
+    with: IndexMap<String, QuerySource>,
+    distinct: bool,
+    query_type: QueryType,
+    fields: IndexMap<Option<String>, Arc<Box<dyn Expressive>>>,
+    set_fields: IndexMap<String, Value>,
+
+    where_conditions: QueryConditions,
+    having_conditions: QueryConditions,
+    joins: Vec<JoinQuery>,
+
+    skip_items: Option<i64>,
+    limit_items: Option<i64>,
+
+    group_by: Vec<LazyExpression>,
+    order_by: Vec<LazyExpression>,
+}
+
+impl Query {
+    pub fn new() -> Self {
+        Self {
+            from: Vec::new(),
+            with: IndexMap::new(),
+            distinct: false,
+            query_type: QueryType,
+            fields: IndexMap::new(),
+            set_fields: IndexMap::new(),
+            where_conditions: QueryConditions,
+            having_conditions: QueryConditions,
+            joins: Vec::new(),
+            skip_items: None,
+            limit_items: None,
+            group_by: Vec::new(),
+            order_by: Vec::new(),
+        }
+    }
+
+    pub fn fields(mut self, fields: IndexMap<Option<String>, Arc<Box<dyn Expressive>>>) -> Self {
+        self.fields = fields;
+        self
+    }
+
+    pub fn from(mut self, sources: Vec<QuerySource>) -> Self {
+        self.from = sources;
+        self
+    }
+
+    fn render_fields(&self) -> OwnedExpression {
+        if self.fields.is_empty() {
+            expr!("*")
+        } else {
+            let field_expressions: Vec<OwnedExpression> = self
+                .fields
+                .iter()
+                .map(|(alias, _field)| {
+                    if let Some(alias) = alias {
+                        Identifier::new(alias.clone()).into()
+                    } else {
+                        expr!("field")
+                    }
+                })
+                .collect();
+            OwnedExpression::from_vec(field_expressions, ", ")
+        }
+    }
+
+    fn render_from(&self) -> OwnedExpression {
+        if self.from.is_empty() {
+            expr!("")
+        } else {
+            let from_expressions: Vec<OwnedExpression> = self
+                .from
+                .iter()
+                .map(|source| source.clone().into())
+                .collect();
+            expr!(
+                " FROM {}",
+                OwnedExpression::from_vec(from_expressions, ", ")
+            )
+        }
+    }
+}
+
+impl Into<OwnedExpression> for Query {
+    fn into(self) -> OwnedExpression {
+        expr!("SELECT {}{}", self.render_fields(), self.render_from())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_query() {
+        let query = Query::new();
+        let expr: OwnedExpression = query.into();
+        let sql = expr.preview();
+        assert_eq!(sql, "SELECT *");
+    }
+
+    #[test]
+    fn test_query_with_fields() {
+        let mut fields = IndexMap::new();
+        fields.insert(
+            Some("name".to_string()),
+            Arc::new(Box::new(expr!("name")) as Box<dyn Expressive>),
+        );
+        fields.insert(
+            Some("age".to_string()),
+            Arc::new(Box::new(expr!("age")) as Box<dyn Expressive>),
+        );
+
+        let query = Query::new().fields(fields);
+        let expr: OwnedExpression = query.into();
+        let sql = expr.preview();
+        assert_eq!(sql, "SELECT `name`, `age`");
+    }
+
+    #[test]
+    fn test_query_with_from() {
+        let query = Query::new().from(vec![QuerySource::new(Identifier::new("users"))]);
+
+        let expr: OwnedExpression = query.into();
+        let sql = expr.preview();
+        assert_eq!(sql, "SELECT * FROM `users`");
+    }
+
+    #[test]
+    fn test_query_with_fields_and_from() {
+        let mut fields = IndexMap::new();
+        fields.insert(
+            Some("name".to_string()),
+            Arc::new(Box::new(expr!("name")) as Box<dyn Expressive>),
+        );
+        fields.insert(
+            Some("age".to_string()),
+            Arc::new(Box::new(expr!("age")) as Box<dyn Expressive>),
+        );
+
+        let query = Query::new()
+            .fields(fields)
+            .from(vec![QuerySource::new(Identifier::new("users"))]);
+
+        let expr: OwnedExpression = query.into();
+        let sql = expr.preview();
+        assert_eq!(sql, "SELECT `name`, `age` FROM `users`");
+    }
+}

--- a/vantage-sql/src/query/query_conditions.rs
+++ b/vantage-sql/src/query/query_conditions.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryConditions;

--- a/vantage-sql/src/query/query_source.rs
+++ b/vantage-sql/src/query/query_source.rs
@@ -1,0 +1,20 @@
+use vantage_expressions::OwnedExpression;
+
+#[derive(Debug, Clone)]
+pub struct QuerySource {
+    source: OwnedExpression,
+}
+
+impl QuerySource {
+    pub fn new(source: impl Into<OwnedExpression>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+impl Into<OwnedExpression> for QuerySource {
+    fn into(self) -> OwnedExpression {
+        self.source
+    }
+}

--- a/vantage-sql/src/query/query_type.rs
+++ b/vantage-sql/src/query/query_type.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryType;

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2024"
+name = "vantage-surrealdb"
+version = "0.3.0"
+license = "MIT OR Apache-2.0"
+authors = ["Romans Malinovskis <me@nearly.guru>"]
+description = "Vantage extension for SurrealDB"
+documentation = "https://docs.rs/vantage"
+homepage = "https://romaninsh.github.io/vantage"
+repository = "https://github.com/romaninsh/vantage"
+readme = "../README.md"
+
+
+[dependencies]
+async-trait = "0.1"
+vantage-expressions = { path = "../vantage-expressions" }
+indexmap = { version = "2.10.0", features = ["serde"] }
+serde_json = { version = "1", features = [
+    "preserve_order",
+    "raw_value",
+    "arbitrary_precision",
+] }

--- a/vantage-surrealdb/src/conditional.rs
+++ b/vantage-surrealdb/src/conditional.rs
@@ -1,0 +1,33 @@
+use vantage_expressions::{OwnedExpression, expr};
+
+#[derive(Debug, Clone)]
+pub struct Conditional {
+    condition: OwnedExpression,
+    then_expr: OwnedExpression,
+    else_expr: OwnedExpression,
+}
+
+impl Conditional {
+    pub fn new(
+        condition: impl Into<OwnedExpression>,
+        then_expr: impl Into<OwnedExpression>,
+        else_expr: impl Into<OwnedExpression>,
+    ) -> Self {
+        Self {
+            condition: condition.into(),
+            then_expr: then_expr.into(),
+            else_expr: else_expr.into(),
+        }
+    }
+}
+
+impl Into<OwnedExpression> for Conditional {
+    fn into(self) -> OwnedExpression {
+        expr!(
+            "IF ({}) THEN ({}) ELSE ({}) END",
+            self.condition,
+            self.then_expr,
+            self.else_expr
+        )
+    }
+}

--- a/vantage-surrealdb/src/identifier.rs
+++ b/vantage-surrealdb/src/identifier.rs
@@ -1,0 +1,36 @@
+use vantage_expressions::{OwnedExpression, expr};
+
+#[derive(Debug, Clone)]
+pub struct Identifier {
+    identifier: String,
+}
+
+impl Identifier {
+    pub fn new(identifier: impl Into<String>) -> Self {
+        Self {
+            identifier: identifier.into(),
+        }
+    }
+
+    fn needs_escaping(&self) -> bool {
+        let reserved_keywords = [
+            "DEFINE", "CREATE", "SELECT", "UPDATE", "DELETE", "FROM", "WHERE", "SET", "ONLY",
+            "TABLE",
+        ];
+
+        let upper_identifier = self.identifier.to_uppercase();
+
+        // Check if it contains spaces or is a reserved keyword
+        self.identifier.contains(' ') || reserved_keywords.contains(&upper_identifier.as_str())
+    }
+}
+
+impl Into<OwnedExpression> for Identifier {
+    fn into(self) -> OwnedExpression {
+        if self.needs_escaping() {
+            expr!(format!("⟨{}⟩", self.identifier))
+        } else {
+            expr!(self.identifier)
+        }
+    }
+}

--- a/vantage-surrealdb/src/lib.rs
+++ b/vantage-surrealdb/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod conditional;
+pub mod identifier;
+pub mod protocol;
+pub mod query;
+pub mod select;
+pub mod thing;
+pub mod variable;

--- a/vantage-surrealdb/src/protocol.rs
+++ b/vantage-surrealdb/src/protocol.rs
@@ -1,0 +1,1 @@
+pub trait Query {}

--- a/vantage-surrealdb/src/query/expressive.rs
+++ b/vantage-surrealdb/src/query/expressive.rs
@@ -1,0 +1,11 @@
+use async_trait::async_trait;
+use vantage_expressions::{Expressive, OwnedExpression, expr, protocol::DataSource};
+
+use crate::query::Query;
+
+#[async_trait]
+impl Expressive for Query {
+    async fn prepare(&self, _data_source: &dyn DataSource) -> OwnedExpression {
+        expr!("QUERY!")
+    }
+}

--- a/vantage-surrealdb/src/query/join_query.rs
+++ b/vantage-surrealdb/src/query/join_query.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JoinQuery;

--- a/vantage-surrealdb/src/query/mod.rs
+++ b/vantage-surrealdb/src/query/mod.rs
@@ -1,0 +1,36 @@
+pub mod expressive;
+pub mod join_query;
+pub mod query_conditions;
+pub mod query_source;
+pub mod query_type;
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use serde_json::Value;
+use vantage_expressions::{Expressive, LazyExpression};
+
+use join_query::JoinQuery;
+use query_conditions::QueryConditions;
+use query_source::QuerySource;
+use query_type::QueryType;
+
+#[derive(Debug, Clone)]
+pub struct Query {
+    table: QuerySource,
+    with: IndexMap<String, QuerySource>,
+    distinct: bool,
+    query_type: QueryType,
+    fields: IndexMap<Option<String>, Arc<Box<dyn Expressive>>>,
+    set_fields: IndexMap<String, Value>,
+
+    where_conditions: QueryConditions,
+    having_conditions: QueryConditions,
+    joins: Vec<JoinQuery>,
+
+    skip_items: Option<i64>,
+    limit_items: Option<i64>,
+
+    group_by: Vec<LazyExpression>,
+    order_by: Vec<LazyExpression>,
+}

--- a/vantage-surrealdb/src/query/query_conditions.rs
+++ b/vantage-surrealdb/src/query/query_conditions.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryConditions;

--- a/vantage-surrealdb/src/query/query_source.rs
+++ b/vantage-surrealdb/src/query/query_source.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QuerySource;

--- a/vantage-surrealdb/src/query/query_type.rs
+++ b/vantage-surrealdb/src/query/query_type.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryType;

--- a/vantage-surrealdb/src/select/field.rs
+++ b/vantage-surrealdb/src/select/field.rs
@@ -1,0 +1,22 @@
+use vantage_expressions::{OwnedExpression, expr};
+
+use crate::identifier::Identifier;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Field {
+    field: String,
+}
+
+impl Field {
+    pub fn new(field: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+        }
+    }
+}
+
+impl Into<OwnedExpression> for Field {
+    fn into(self) -> OwnedExpression {
+        Identifier::new(self.field).into()
+    }
+}

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -1,0 +1,118 @@
+// pub mod expressive;
+pub mod field;
+pub mod select_field;
+pub mod target;
+
+use field::Field;
+use select_field::SelectField;
+use target::Target;
+
+use vantage_expressions::{OwnedExpression, expr};
+
+#[derive(Debug, Clone)]
+pub struct Select {
+    pub fields: Vec<SelectField>, // SELECT clause fields
+    pub fields_omit: Vec<Field>,
+    pub from: Vec<Target>, // FROM clause targets
+    pub from_omit: bool,
+    // pub with: Vec<Index>,
+
+    // pub where_conditions: Option<Expression>,
+    // pub split: Vec<Field>,
+    // pub group_by: Vec<Field>,
+    // pub order_by: Vec<OrderField>,
+    // pub limit: Option<u64>,
+    // pub start: Option<u64>,
+    // pub fetch: Vec<Field>,
+    // pub timeout: Option<Duration>,
+    // pub version: Option<DateTime>,
+}
+
+impl Select {
+    pub fn new() -> Self {
+        Self {
+            fields: Vec::new(),
+            fields_omit: Vec::new(),
+            from: Vec::new(),
+            from_omit: false,
+        }
+    }
+
+    pub fn fields(mut self, fields: Vec<SelectField>) -> Self {
+        self.fields = fields;
+        self
+    }
+
+    pub fn from(mut self, targets: Vec<Target>) -> Self {
+        self.from = targets;
+        self
+    }
+
+    fn render_fields(&self) -> OwnedExpression {
+        if self.fields.is_empty() {
+            expr!("*")
+        } else {
+            let field_expressions: Vec<OwnedExpression> = self
+                .fields
+                .iter()
+                .map(|field| field.clone().into())
+                .collect();
+            OwnedExpression::from_vec(field_expressions, ", ")
+        }
+    }
+
+    fn render_from(&self) -> OwnedExpression {
+        if self.from.is_empty() {
+            expr!("")
+        } else {
+            let from_expressions: Vec<OwnedExpression> = self
+                .from
+                .iter()
+                .map(|target| target.clone().into())
+                .collect();
+            expr!(
+                " FROM {}",
+                OwnedExpression::from_vec(from_expressions, ", ")
+            )
+        }
+    }
+}
+
+impl Into<OwnedExpression> for Select {
+    fn into(self) -> OwnedExpression {
+        expr!("SELECT {}{}", self.render_fields(), self.render_from())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::select::field::Field;
+    use crate::select::select_field::SelectField;
+    use crate::select::target::Target;
+
+    #[test]
+    fn test_basic_select() {
+        let select = Select::new()
+            .fields(vec![
+                SelectField::new(Field::new("name")),
+                SelectField::new(Field::new("set")),
+            ])
+            .from(vec![Target::new(expr!("users"))]);
+
+        let expr: OwnedExpression = select.into();
+        let sql = expr.preview();
+
+        assert_eq!(sql, "SELECT name, ⟨set⟩ FROM users");
+    }
+
+    #[test]
+    fn test_select_all() {
+        let select = Select::new().from(vec![Target::new(expr!("users"))]);
+
+        let expr: OwnedExpression = select.into();
+        let sql = expr.preview();
+
+        assert_eq!(sql, "SELECT * FROM users");
+    }
+}

--- a/vantage-surrealdb/src/select/select_field.rs
+++ b/vantage-surrealdb/src/select/select_field.rs
@@ -1,0 +1,51 @@
+use vantage_expressions::{OwnedExpression, expr};
+
+use crate::identifier::Identifier;
+
+#[derive(Debug, Clone)]
+pub struct SelectField {
+    expression: OwnedExpression,
+    alias: Option<String>,
+    is_value: bool, // For VALUE clause
+}
+
+impl SelectField {
+    pub fn new(expression: impl Into<OwnedExpression>) -> Self {
+        Self {
+            expression: expression.into(),
+            alias: None,
+            is_value: false,
+        }
+    }
+
+    pub fn with_alias(mut self, alias: String) -> Self {
+        self.alias = Some(alias);
+        self
+    }
+
+    pub fn as_value(mut self) -> Self {
+        self.is_value = true;
+        self
+    }
+}
+
+impl Into<OwnedExpression> for SelectField {
+    fn into(self) -> OwnedExpression {
+        let base_expr = self.expression.preview();
+
+        match (&self.alias, self.is_value) {
+            (Some(alias), true) => expr!(
+                "VALUE {} AS {}",
+                Identifier::new(base_expr),
+                Identifier::new(alias)
+            ),
+            (Some(alias), false) => expr!(
+                "{} AS {}",
+                Identifier::new(base_expr),
+                Identifier::new(alias)
+            ),
+            (None, true) => expr!("VALUE {}", Identifier::new(base_expr)),
+            (None, false) => self.expression,
+        }
+    }
+}

--- a/vantage-surrealdb/src/select/target.rs
+++ b/vantage-surrealdb/src/select/target.rs
@@ -1,0 +1,20 @@
+use vantage_expressions::OwnedExpression;
+
+#[derive(Debug, Clone)]
+pub struct Target {
+    target: OwnedExpression,
+}
+
+impl Target {
+    pub fn new(target: impl Into<OwnedExpression>) -> Self {
+        Self {
+            target: target.into(),
+        }
+    }
+}
+
+impl Into<OwnedExpression> for Target {
+    fn into(self) -> OwnedExpression {
+        self.target
+    }
+}

--- a/vantage-surrealdb/src/thing.rs
+++ b/vantage-surrealdb/src/thing.rs
@@ -1,0 +1,32 @@
+use async_trait::async_trait;
+use vantage_expressions::{Expressive, OwnedExpression, expr, protocol::DataSource};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Thing {
+    table: String,
+    id: String,
+}
+
+impl Thing {
+    pub fn new(table: String, id: String) -> Self {
+        Self { table, id }
+    }
+
+    pub fn from_str(thing_str: &str) -> Option<Self> {
+        if let Some((table, id)) = thing_str.split_once(':') {
+            Some(Self {
+                table: table.to_string(),
+                id: id.to_string(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[async_trait]
+impl Expressive for Thing {
+    async fn prepare(&self, _data_source: &dyn DataSource) -> OwnedExpression {
+        expr!(format!("{}:{}", self.table, self.id))
+    }
+}

--- a/vantage-surrealdb/src/variable.rs
+++ b/vantage-surrealdb/src/variable.rs
@@ -1,0 +1,18 @@
+use vantage_expressions::{OwnedExpression, expr};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Variable {
+    name: String,
+}
+
+impl Variable {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl Into<OwnedExpression> for Variable {
+    fn into(self) -> OwnedExpression {
+        expr!(format!("${}", self.name))
+    }
+}

--- a/vantage/src/sql/expression/expression2.rs
+++ b/vantage/src/sql/expression/expression2.rs
@@ -242,18 +242,18 @@ mod tests {
     use super::*;
     use sqlx::{Connection, Execute, PgConnection, Postgres};
 
-    // Test basic creation of Expression2
-    #[tokio::test]
-    async fn test_expression2_creation() -> Result<()> {
-        let expr = expr2!("SELECT * FROM users WHERE id = ? AND age > ?", 42, 100);
+    // // Test basic creation of Expression2
+    // #[tokio::test]
+    // async fn test_expression2_creation() -> Result<()> {
+    //     let expr = expr2!("SELECT * FROM users WHERE id = ? AND age > ?", 42, 100);
 
-        let query = expr.render_sqlx().unwrap();
+    //     let query = expr.render_sqlx().unwrap();
 
-        let mut conn: PgConnection = PgConnection::connect("<Database URL>").await?;
-        let result = query.execute(&mut conn).await?;
+    //     let mut conn: PgConnection = PgConnection::connect("<Database URL>").await?;
+    //     let result = query.execute(&mut conn).await?;
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     // Test rendering a simple query with parameters
     #[test]


### PR DESCRIPTION
Based on `vantage-expressions` I have implemented vendor-specific query-builder implementations (v0.3). Currently query builders look similar, but do not implement any commont interfaces, which might be OK. 

 - [x] SQL support
 - [x] SurrealQL support
 - [ ] GraphQL support 

Going forward - i'll implement Query-builder interface which is compatible to the existing interface, while relying on vantage-expressions.