### PR TITLE
Implement "Selectable" for surrealdb select query

### DIFF
--- a/vantage-expressions/src/lib.rs
+++ b/vantage-expressions/src/lib.rs
@@ -11,4 +11,4 @@ pub mod value;
 pub use expression::lazy::LazyExpression;
 pub use expression::owned::OwnedExpression;
 pub use protocol::Expressive;
-pub use protocol::select::Select;
+pub use protocol::selectable::Selectable;

--- a/vantage-expressions/src/protocol.rs
+++ b/vantage-expressions/src/protocol.rs
@@ -1,4 +1,4 @@
-pub mod select;
+pub mod selectable;
 
 use std::fmt::Debug;
 

--- a/vantage-expressions/src/protocol/selectable.rs
+++ b/vantage-expressions/src/protocol/selectable.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use crate::OwnedExpression;
 
 #[async_trait]
-pub trait Select: Send + Sync + Debug {
+pub trait Selectable: Send + Sync + Debug {
     fn set_source(&mut self, source: OwnedExpression, alias: Option<String>);
     fn add_field(&mut self, field: String);
     fn add_expression(&mut self, expression: OwnedExpression, alias: Option<String>);
@@ -13,18 +13,15 @@ pub trait Select: Send + Sync + Debug {
     fn set_distinct(&mut self, distinct: bool);
     fn add_order_by(&mut self, expression: OwnedExpression, ascending: bool);
     fn add_group_by(&mut self, expression: OwnedExpression);
-    fn add_having_condition(&mut self, condition: OwnedExpression);
     fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>);
     fn clear_fields(&mut self);
     fn clear_where_conditions(&mut self);
     fn clear_order_by(&mut self);
     fn clear_group_by(&mut self);
-    fn clear_having_conditions(&mut self);
     fn has_fields(&self) -> bool;
     fn has_where_conditions(&self) -> bool;
     fn has_order_by(&self) -> bool;
     fn has_group_by(&self) -> bool;
-    fn has_having_conditions(&self) -> bool;
     fn is_distinct(&self) -> bool;
     fn get_limit(&self) -> Option<i64>;
     fn get_skip(&self) -> Option<i64>;

--- a/vantage-mongodb/examples/basic_usage.rs
+++ b/vantage-mongodb/examples/basic_usage.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use vantage_expressions::protocol::select::Select;
+use vantage_expressions::protocol::selectable::Selectable;
 use vantage_mongodb::{Document, count, delete, insert, select, update};
 
 fn main() {

--- a/vantage-mongodb/src/lib.rs
+++ b/vantage-mongodb/src/lib.rs
@@ -3,7 +3,7 @@ pub mod protocol;
 pub mod query;
 
 use serde_json::Value;
-use vantage_expressions::{OwnedExpression, expr, protocol::select::Select};
+use vantage_expressions::{OwnedExpression, expr, protocol::selectable::Selectable};
 
 pub use field::Field;
 pub use query::{MongoCount, MongoDelete, MongoInsert, MongoSelect, MongoUpdate};

--- a/vantage-mongodb/src/query/select.rs
+++ b/vantage-mongodb/src/query/select.rs
@@ -1,7 +1,7 @@
 use crate::field::Field;
 use async_trait::async_trait;
 use std::fmt::Debug;
-use vantage_expressions::{OwnedExpression, expr, protocol::select::Select};
+use vantage_expressions::{OwnedExpression, expr, protocol::selectable::Selectable};
 
 #[derive(Debug, Clone)]
 pub struct MongoSelect {
@@ -11,7 +11,6 @@ pub struct MongoSelect {
     where_conditions: Vec<OwnedExpression>,
     order_by: Vec<(OwnedExpression, bool)>,
     group_by: Vec<OwnedExpression>,
-    having_conditions: Vec<OwnedExpression>,
     distinct: bool,
     limit: Option<i64>,
     skip: Option<i64>,
@@ -26,7 +25,6 @@ impl MongoSelect {
             where_conditions: Vec::new(),
             order_by: Vec::new(),
             group_by: Vec::new(),
-            having_conditions: Vec::new(),
             distinct: false,
             limit: None,
             skip: None,
@@ -179,7 +177,7 @@ impl MongoSelect {
 }
 
 #[async_trait]
-impl Select for MongoSelect {
+impl Selectable for MongoSelect {
     fn set_source(&mut self, source: OwnedExpression, alias: Option<String>) {
         self.source = Some(source);
         self.source_alias = alias;
@@ -209,10 +207,6 @@ impl Select for MongoSelect {
         self.group_by.push(expression);
     }
 
-    fn add_having_condition(&mut self, condition: OwnedExpression) {
-        self.having_conditions.push(condition);
-    }
-
     fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>) {
         self.limit = limit;
         self.skip = skip;
@@ -234,10 +228,6 @@ impl Select for MongoSelect {
         self.group_by.clear();
     }
 
-    fn clear_having_conditions(&mut self) {
-        self.having_conditions.clear();
-    }
-
     fn has_fields(&self) -> bool {
         !self.fields.is_empty()
     }
@@ -252,10 +242,6 @@ impl Select for MongoSelect {
 
     fn has_group_by(&self) -> bool {
         !self.group_by.is_empty()
-    }
-
-    fn has_having_conditions(&self) -> bool {
-        !self.having_conditions.is_empty()
     }
 
     fn is_distinct(&self) -> bool {

--- a/vantage-surrealdb/examples/select.rs
+++ b/vantage-surrealdb/examples/select.rs
@@ -1,0 +1,59 @@
+use vantage_expressions::{expr, protocol::selectable::Selectable};
+use vantage_surrealdb::select::Select;
+
+fn main() {
+    // Create a new Select instance
+    let mut select = Select::new();
+
+    // Use Selectable trait methods
+    select.set_source(expr!("users"), None);
+    select.add_field("department".to_string());
+    select.add_expression(expr!("count()"), Some("total".to_string()));
+    select.add_where_condition(expr!("age > 18"));
+    select.add_order_by(expr!("total"), false);
+    select.add_group_by(expr!("department"));
+    select.add_where_condition(expr!("count() > 5"));
+    select.set_limit(Some(10), Some(5));
+    select.set_distinct(true);
+
+    println!("SurrealDB Select with Selectable trait:");
+    let expr: vantage_expressions::OwnedExpression = select.clone().into();
+    println!("{}", expr.preview());
+    println!();
+
+    // Test trait query methods
+    println!("Trait query methods:");
+    println!("Has fields: {}", select.has_fields());
+    println!("Has where conditions: {}", select.has_where_conditions());
+    println!("Has order by: {}", select.has_order_by());
+    println!("Has group by: {}", select.has_group_by());
+    println!("Is distinct: {}", select.is_distinct());
+    println!("Limit: {:?}", select.get_limit());
+    println!("Skip: {:?}", select.get_skip());
+    println!();
+
+    // Test clear methods
+    select.clear_fields();
+    select.clear_where_conditions();
+    select.clear_order_by();
+    select.clear_group_by();
+
+    println!("After clearing:");
+    println!("Has fields: {}", select.has_fields());
+    println!("Has where conditions: {}", select.has_where_conditions());
+    println!("Has order by: {}", select.has_order_by());
+    println!("Has group by: {}", select.has_group_by());
+    println!();
+
+    // Basic select example
+    let mut basic_select = Select::new();
+    basic_select.set_source(expr!("products"), None);
+    basic_select.add_field("name".to_string());
+    basic_select.add_field("price".to_string());
+    basic_select.add_where_condition(expr!("price > 100"));
+    basic_select.set_limit(Some(5), None);
+
+    println!("Basic SurrealDB select:");
+    let expr: vantage_expressions::OwnedExpression = basic_select.into();
+    println!("{}", expr.preview());
+}

--- a/vantage-surrealdb/src/select/field.rs
+++ b/vantage-surrealdb/src/select/field.rs
@@ -1,4 +1,4 @@
-use vantage_expressions::{OwnedExpression, expr};
+use vantage_expressions::OwnedExpression;
 
 use crate::identifier::Identifier;
 


### PR DESCRIPTION
Now surrealdb also implement Selectable (renamed from Select trait). I have removed "add_having_condition" since it is SQL only. Basically we now have an identical query building interface for MongoDB and SurrealDB and it woudl be easy to implement it for SQL next. 