### PR TITLE
Implement support for Arc and Mutex params in templates

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -35,6 +35,6 @@ jobs:
       - name: Build
         run: cargo build
       - name: Run tests
-        run: cd vantage && cargo test
+        run: cargo test --workspace --exclude bakery_model --exclude bakery_api
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,6 +3329,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-test",
 ]
 
 [[package]]

--- a/vantage-expressions/Cargo.toml
+++ b/vantage-expressions/Cargo.toml
@@ -20,3 +20,4 @@ thiserror = "2.0.12"
 
 [dev-dependencies]
 tokio = { version = "1.46", features = ["full"] }
+tokio-test = "0.4"

--- a/vantage-expressions/src/expression/mod.rs
+++ b/vantage-expressions/src/expression/mod.rs
@@ -1,3 +1,4 @@
-// pub mod flatten;
+pub mod flatten;
 // pub mod lazy;
+pub mod mutable;
 pub mod owned;

--- a/vantage-expressions/src/expression/mutable.rs
+++ b/vantage-expressions/src/expression/mutable.rs
@@ -1,0 +1,109 @@
+//! Mutable expressions allow multiple expressions to reference the same mutable value.
+//! The value is stored in an Arc<Mutex<T>> and evaluated at render time.
+
+use crate::expression::owned::OwnedExpression;
+use crate::protocol::expressive::IntoExpressive;
+
+use std::sync::{Arc, Mutex};
+
+impl<T> From<Arc<Mutex<T>>> for IntoExpressive<OwnedExpression>
+where
+    T: Into<IntoExpressive<OwnedExpression>> + Clone + Send + Sync + 'static,
+{
+    fn from(arc_mutex: Arc<Mutex<T>>) -> Self {
+        IntoExpressive::deferred(move || {
+            let arc_mutex = arc_mutex.clone();
+            Box::pin(async move { arc_mutex.lock().unwrap().clone().into() })
+        })
+    }
+}
+
+impl<T> From<&Arc<Mutex<T>>> for IntoExpressive<OwnedExpression>
+where
+    T: Into<IntoExpressive<OwnedExpression>> + Clone + Send + Sync + 'static,
+{
+    fn from(arc_mutex: &Arc<Mutex<T>>) -> Self {
+        let arc_mutex = arc_mutex.clone();
+        IntoExpressive::deferred(move || {
+            let arc_mutex = arc_mutex.clone();
+            Box::pin(async move { arc_mutex.lock().unwrap().clone().into() })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::expr;
+    use crate::expression::owned::OwnedExpression;
+
+    #[test]
+    fn test_from_arc_mutex() {
+        let arc_mutex = Arc::new(Mutex::new(42i32));
+        let _expr: IntoExpressive<OwnedExpression> = arc_mutex.into();
+        // The conversion should work without panicking
+    }
+
+    #[tokio::test]
+    async fn test_mutable_in_expression() {
+        let shared_var = Arc::new(Mutex::new(10i32));
+        let expr = expr!("hello {}", &shared_var);
+
+        // The preview should show the deferred placeholder
+        let preview = expr.preview();
+        assert!(preview.contains("**deferred()"));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_expressions_same_arc_mutex() {
+        let shared_var = Arc::new(Mutex::new(25i32));
+        let expr1 = expr!("value1: {}", &shared_var);
+        let expr2 = expr!("value2: {}", &shared_var);
+
+        // Modify the shared value
+        {
+            let mut guard = shared_var.lock().unwrap();
+            *guard = 50;
+        }
+
+        // Both expressions reference the same Arc<Mutex<T>>
+        let preview1 = expr1.preview();
+        let preview2 = expr2.preview();
+
+        assert!(preview1.contains("**deferred()"));
+        assert!(preview2.contains("**deferred()"));
+    }
+
+    #[test]
+    fn test_mutable_string() {
+        let shared_str = Arc::new(Mutex::new("test".to_string()));
+        let expr = expr!("message: {}", &shared_str);
+
+        // Modify the string
+        {
+            let mut guard = shared_str.lock().unwrap();
+            *guard = "modified".to_string();
+        }
+
+        let preview = expr.preview();
+        assert!(preview.contains("**deferred()"));
+    }
+
+    #[test]
+    fn test_mutation_affects_expressions() {
+        let shared_var = Arc::new(Mutex::new(100i32));
+        let _expr1 = expr!("first: {}", &shared_var);
+        let _expr2 = expr!("second: {}", &shared_var);
+
+        // Modify the shared value
+        {
+            let mut guard = shared_var.lock().unwrap();
+            *guard = 200;
+        }
+
+        // The actual value should be updated (though we can't easily test
+        // the deferred evaluation without a full DataSource mock)
+        let current_value = *shared_var.lock().unwrap();
+        assert_eq!(current_value, 200);
+    }
+}

--- a/vantage-expressions/src/lib.rs
+++ b/vantage-expressions/src/lib.rs
@@ -9,6 +9,7 @@ pub mod util;
 pub mod value;
 
 // pub use expression::lazy::LazyExpression;
+pub use expression::flatten::{Flatten, OwnedExpressionFlattener};
 pub use expression::owned::OwnedExpression;
-pub use protocol::expressive::IntoExpressive;
+pub use protocol::expressive::{DataSource, IntoExpressive};
 pub use protocol::selectable::Selectable;

--- a/vantage-expressions/tests/arc_expression_tests.rs
+++ b/vantage-expressions/tests/arc_expression_tests.rs
@@ -1,0 +1,87 @@
+use std::sync::Arc;
+use vantage_expressions::expr;
+
+#[test]
+fn test_arc_immutable_values() {
+    // Test with integers
+    let shared_var = Arc::new(42i64);
+    let expr1 = expr!("hello {}", &shared_var);
+    let expr2 = expr!("value is {}", shared_var.clone());
+
+    // Both expressions should show the same value immediately
+    assert_eq!(expr1.preview(), "hello 42");
+    assert_eq!(expr2.preview(), "value is 42");
+
+    // Test with string
+    let shared_str = Arc::new("test".to_string());
+    let expr3 = expr!("message: {}", &shared_str);
+    assert_eq!(expr3.preview(), "message: \"test\"");
+}
+
+#[test]
+fn test_arc_with_different_types() {
+    // Test with bool
+    let shared_bool = Arc::new(true);
+    let expr1 = expr!("active: {}", &shared_bool);
+    assert_eq!(expr1.preview(), "active: true");
+
+    // Test with i32
+    let shared_i32 = Arc::new(123i32);
+    let expr2 = expr!("count: {}", &shared_i32);
+    assert_eq!(expr2.preview(), "count: 123");
+
+    // Test with f64
+    let shared_float = Arc::new(3.14f64);
+    let expr3 = expr!("pi: {}", &shared_float);
+    assert_eq!(expr3.preview(), "pi: 3.14");
+}
+
+#[test]
+fn test_multiple_expressions_same_arc() {
+    let shared_name = Arc::new("Alice".to_string());
+
+    let greeting = expr!("Hello {}", &shared_name);
+    let farewell = expr!("Goodbye {}", &shared_name);
+    let question = expr!("How are you, {}?", shared_name.clone());
+
+    assert_eq!(greeting.preview(), "Hello \"Alice\"");
+    assert_eq!(farewell.preview(), "Goodbye \"Alice\"");
+    assert_eq!(question.preview(), "How are you, \"Alice\"?");
+}
+
+#[test]
+fn test_arc_reference_vs_clone() {
+    let shared_value = Arc::new(999i64);
+
+    // Using reference
+    let expr_ref = expr!("ref: {}", &shared_value);
+
+    // Using clone
+    let expr_clone = expr!("clone: {}", shared_value.clone());
+
+    assert_eq!(expr_ref.preview(), "ref: 999");
+    assert_eq!(expr_clone.preview(), "clone: 999");
+
+    // Original Arc should still be usable
+    assert_eq!(*shared_value, 999);
+}
+
+#[test]
+fn test_nested_arc_expressions() {
+    let shared_table = Arc::new("users".to_string());
+    let shared_id = Arc::new(42i64);
+
+    let table_expr = expr!("FROM {}", &shared_table);
+    let condition_expr = expr!("id = {}", &shared_id);
+
+    let full_query = expr!(
+        "SELECT * {} WHERE {}",
+        vantage_expressions::IntoExpressive::nested(table_expr),
+        vantage_expressions::IntoExpressive::nested(condition_expr)
+    );
+
+    assert_eq!(
+        full_query.preview(),
+        "SELECT * FROM \"users\" WHERE id = 42"
+    );
+}

--- a/vantage-expressions/tests/owned_expression_tests.rs
+++ b/vantage-expressions/tests/owned_expression_tests.rs
@@ -1,0 +1,214 @@
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+use vantage_expressions::expression::flatten::{Flatten, OwnedExpressionFlattener};
+use vantage_expressions::{DataSource, IntoExpressive, OwnedExpression, expr};
+
+// Helper function for pattern matching against database mock patterns
+fn find_matching_pattern(
+    patterns: &[(String, serde_json::Value)],
+    query: &str,
+) -> serde_json::Value {
+    patterns
+        .iter()
+        .find(|(pattern, _)| query.contains(pattern))
+        .map(|(_, value)| value.clone())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+// Helper function for executing deferred parameters and flattening
+async fn execute_and_flatten_owned_expression(expr: &OwnedExpression) -> OwnedExpression {
+    let mut expr = expr.clone();
+
+    // Execute all deferred parameters
+    for param in &mut expr.parameters {
+        if let IntoExpressive::Deferred(f) = param {
+            *param = f().await;
+        }
+    }
+
+    // Flatten nested expressions
+    let flattener = OwnedExpressionFlattener::new();
+    flattener.flatten_nested(&expr)
+}
+
+#[test]
+fn test_arc_mutex_with_database_execution() {
+    use serde_json::Value;
+    use std::future::Future;
+    use std::pin::Pin;
+    use tokio;
+
+    // DataSource implementation for OwnedExpression
+    #[derive(Clone)]
+    struct MockOwnedDatabase {
+        patterns: Vec<(String, Value)>,
+    }
+
+    impl MockOwnedDatabase {
+        fn new(patterns: Vec<(&str, Value)>) -> Self {
+            Self {
+                patterns: patterns
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect(),
+            }
+        }
+    }
+
+    impl DataSource<OwnedExpression> for MockOwnedDatabase {
+        async fn execute(&self, expr: &OwnedExpression) -> Value {
+            let expr = execute_and_flatten_owned_expression(expr).await;
+
+            // Simulate async database query execution
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+            let query = expr.preview();
+            find_matching_pattern(&self.patterns, &query)
+        }
+
+        fn defer(
+            &self,
+            expr: OwnedExpression,
+        ) -> impl Fn() -> Pin<Box<dyn Future<Output = Value> + Send>> + Send + Sync + 'static
+        {
+            let db = self.clone();
+            move || {
+                let db = db.clone();
+                let expr = expr.clone();
+                Box::pin(async move { db.execute(&expr).await })
+            }
+        }
+    }
+
+    tokio_test::block_on(async {
+        // Create database mock with patterns for different values
+        let db = MockOwnedDatabase::new(vec![
+            ("hello 10", json!("greeting_10")),
+            ("select spelling from numbers where num=10", json!("ten")),
+            (
+                "select spelling from numbers where num=15",
+                json!("fifteen"),
+            ),
+        ]);
+
+        // Create shared mutable variable
+        let shared_var = Arc::new(Mutex::new(10i32));
+
+        // Create expressions using OwnedExpression
+        let expr1 = expr!("hello {}", &shared_var);
+        let expr2 = expr!("select spelling from numbers where num={}", &shared_var);
+
+        // Execute first query
+        let result1 = db.execute(&expr1).await;
+        assert_eq!(result1, json!("greeting_10"));
+
+        let result2_before = db.execute(&expr2).await;
+        assert_eq!(result2_before, json!("ten"));
+
+        // Modify the shared value
+        {
+            let mut guard = shared_var.lock().unwrap();
+            *guard = 15;
+        }
+
+        // Execute same expression again - deferred evaluation will see new value
+        let result2_after = db.execute(&expr2).await;
+        assert_eq!(result2_after, json!("fifteen"));
+    });
+}
+
+#[test]
+fn test_arc_mutex_with_nested_expression() {
+    use serde_json::Value;
+    use std::future::Future;
+    use std::pin::Pin;
+    use tokio;
+
+    #[derive(Debug, Clone)]
+    struct GreetingQuery {
+        name: String,
+    }
+
+    impl From<&GreetingQuery> for OwnedExpression {
+        fn from(greeting: &GreetingQuery) -> OwnedExpression {
+            expr!("Hello {}", greeting.name.clone())
+        }
+    }
+
+    impl From<GreetingQuery> for IntoExpressive<OwnedExpression> {
+        fn from(greeting: GreetingQuery) -> Self {
+            IntoExpressive::nested(OwnedExpression::from(&greeting))
+        }
+    }
+
+    // DataSource implementation
+    #[derive(Clone)]
+    struct MockDatabase {
+        patterns: Vec<(String, Value)>,
+    }
+
+    impl MockDatabase {
+        fn new(patterns: Vec<(&str, Value)>) -> Self {
+            Self {
+                patterns: patterns
+                    .into_iter()
+                    .map(|(k, v)| (k.to_string(), v))
+                    .collect(),
+            }
+        }
+    }
+
+    impl DataSource<OwnedExpression> for MockDatabase {
+        async fn execute(&self, expr: &OwnedExpression) -> Value {
+            let expr = execute_and_flatten_owned_expression(expr).await;
+
+            // Simulate async database query execution
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+            let query = expr.preview();
+            find_matching_pattern(&self.patterns, &query)
+        }
+
+        fn defer(
+            &self,
+            expr: OwnedExpression,
+        ) -> impl Fn() -> Pin<Box<dyn Future<Output = Value> + Send>> + Send + Sync + 'static
+        {
+            let db = self.clone();
+            move || {
+                let db = db.clone();
+                let expr = expr.clone();
+                Box::pin(async move { db.execute(&expr).await })
+            }
+        }
+    }
+
+    tokio_test::block_on(async {
+        // Create database mock
+        let db = MockDatabase::new(vec![
+            ("select Hello \"world\"", json!("greeting_world")),
+            ("select Hello \"vantage\"", json!("greeting_vantage")),
+        ]);
+
+        // Create mutable greeting struct
+        let greeting = Arc::new(Mutex::new(GreetingQuery {
+            name: "world".to_string(),
+        }));
+
+        let expr = expr!("select {}", &greeting);
+
+        // Execute first query
+        let result1 = db.execute(&expr).await;
+        assert_eq!(result1, json!("greeting_world"));
+
+        // Modify the greeting name
+        {
+            let mut guard = greeting.lock().unwrap();
+            guard.name = "vantage".to_string();
+        }
+
+        // Execute same expression again - should see new nested expression result
+        let result2 = db.execute(&expr).await;
+        assert_eq!(result2, json!("greeting_vantage"));
+    });
+}


### PR DESCRIPTION
Now parameters into expressions can be Arc or even Mutex:

```rust
    let shared_id = Arc::new(42i64);
    let condition_expr = expr!("id = {}", &shared_id);
```

This works really well on a complex objects, which me might not have ownership of. More importantly, though, we have `Mutex` support too:

Suppose you have a custom struct:

```rust
    struct GreetingQuery {
        name: String,
    }
```

a struct would generate a custom query with current name if it is part of a template:

```rust
    impl From<&GreetingQuery> for OwnedExpression {
        fn from(greeting: &GreetingQuery) -> OwnedExpression {
            expr!("Hello {}", greeting.name.clone())
        }
    }
    impl From<GreetingQuery> for IntoExpressive<OwnedExpression> {
        fn from(greeting: GreetingQuery) -> Self {
            IntoExpressive::nested(OwnedExpression::from(&greeting))
        }
    }
```

Lets construct our struct:

```rust
        let greeting = Arc::new(Mutex::new(GreetingQuery {
            name: "world".to_string(),
        }));
```

this can now be cloned and shared all throughout the app. Some expressions may rely on it:

```rust
        let expr = expr!("select {}", &greeting);
```

now every time expression is executed it will acquire a value from a mutex:

```rust
        let result1 = db.execute(&expr).await;
     
        {
            let mut guard = greeting.lock().unwrap();
            guard.name = "vantage".to_string();
        }

        let result2 = db.execute(&expr).await;
 ```
 
 