### PR TITLE
Implement operators for `table->ref->othertable` using rref() and lref()

### DIFF
--- a/vantage-surrealdb/src/lib.rs
+++ b/vantage-surrealdb/src/lib.rs
@@ -33,6 +33,7 @@
 
 pub mod conditional;
 pub mod identifier;
+pub mod operation;
 pub mod protocol;
 // pub mod query;
 pub mod select;

--- a/vantage-surrealdb/src/operation.rs
+++ b/vantage-surrealdb/src/operation.rs
@@ -1,0 +1,161 @@
+//! SurrealDB operations for expressions
+//!
+//! This module provides operations that extend expressions with SurrealDB-specific functionality.
+
+use vantage_expressions::{OwnedExpression, expr};
+
+/// Trait for types that can be converted to OwnedExpression
+pub trait Expressive: Into<OwnedExpression> {
+    /// Convert to OwnedExpression
+    fn expr(&self) -> OwnedExpression;
+}
+
+/// Extension trait to add reference traversal methods to expressions
+pub trait RefOperation: Expressive {
+    /// Creates a right reference traversal expression in the format: self->ref->table
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - The reference/edge name to traverse
+    /// * `table` - The target table name
+    ///
+    /// # Returns
+    ///
+    /// An expression that renders as "self->reference->table"
+    fn rref(&self, reference: impl Into<String>, table: impl Into<String>) -> OwnedExpression;
+
+    /// Creates a left reference traversal expression in the format: self<-ref<-table
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - The reference/edge name to traverse
+    /// * `table` - The target table name
+    ///
+    /// # Returns
+    ///
+    /// An expression that renders as "self<-reference<-table"
+    fn lref(&self, reference: impl Into<String>, table: impl Into<String>) -> OwnedExpression;
+}
+
+// Default implementations for RefOperation
+impl<T> RefOperation for T
+where
+    T: Expressive,
+{
+    fn rref(&self, reference: impl Into<String>, table: impl Into<String>) -> OwnedExpression {
+        expr!(
+            "{}->{}->{}",
+            self.expr(),
+            OwnedExpression::new(reference.into(), vec![]),
+            OwnedExpression::new(table.into(), vec![])
+        )
+    }
+
+    fn lref(&self, reference: impl Into<String>, table: impl Into<String>) -> OwnedExpression {
+        expr!(
+            "{}<-{}<-{}",
+            self.expr(),
+            OwnedExpression::new(reference.into(), vec![]),
+            OwnedExpression::new(table.into(), vec![])
+        )
+    }
+}
+
+impl Expressive for OwnedExpression {
+    fn expr(&self) -> OwnedExpression {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vantage_expressions::expr;
+
+    #[test]
+    fn test_rref_operation_basic() {
+        let expr = expr!("bakery");
+        let trav = expr.rref("owns", "product");
+
+        let result = trav.preview();
+        assert_eq!(result, "bakery->owns->product");
+    }
+
+    #[test]
+    fn test_lref_operation_basic() {
+        let expr = expr!("bakery");
+        let trav = expr.lref("owns", "product");
+
+        let result = trav.preview();
+        assert_eq!(result, "bakery<-owns<-product");
+    }
+
+    #[test]
+    fn test_rref_operation_with_complex_expr() {
+        let expr = expr!("bakery:hill_valley");
+        let trav = expr.rref("owns", "product");
+
+        let result = trav.preview();
+        assert_eq!(result, "bakery:hill_valley->owns->product");
+    }
+
+    #[test]
+    fn test_lref_operation_with_complex_expr() {
+        let expr = expr!("product:1");
+        let trav = expr.lref("owns", "bakery");
+
+        let result = trav.preview();
+        assert_eq!(result, "product:1<-owns<-bakery");
+    }
+
+    #[test]
+    fn test_rref_operation_chaining() {
+        let expr = expr!("user");
+        let trav = expr.rref("owns", "company").rref("has", "employees");
+
+        let result = trav.preview();
+        assert_eq!(result, "user->owns->company->has->employees");
+    }
+
+    #[test]
+    fn test_mixed_ref_operation_chaining() {
+        let expr = expr!("product:1");
+        let trav = expr.lref("owns", "bakery").rref("located_in", "city");
+
+        let result = trav.preview();
+        assert_eq!(result, "product:1<-owns<-bakery->located_in->city");
+    }
+
+    #[test]
+    fn test_comprehensive_api_usage() {
+        use crate::thing::Thing;
+
+        // Test with expressions
+        let bakery_expr = expr!("bakery");
+        let product_traversal = bakery_expr.rref("owns", "product");
+        assert_eq!(product_traversal.preview(), "bakery->owns->product");
+
+        // Test with Thing
+        let bakery_thing = Thing::new("bakery", "hill_valley");
+        let product_from_thing = bakery_thing.rref("owns", "product");
+        assert_eq!(
+            product_from_thing.preview(),
+            "bakery:hill_valley->owns->product"
+        );
+
+        // Test left reference
+        let product_expr = expr!("product:1");
+        let bakery_from_product = product_expr.lref("owns", "bakery");
+        assert_eq!(bakery_from_product.preview(), "product:1<-owns<-bakery");
+
+        // Test chaining
+        let complex_traversal = expr!("user")
+            .rref("owns", "company")
+            .lref("employs", "employee")
+            .rref("lives_in", "city");
+        assert_eq!(
+            complex_traversal.preview(),
+            "user->owns->company<-employs<-employee->lives_in->city"
+        );
+    }
+}

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -38,7 +38,6 @@ pub struct SurrealSelect {
     pub where_conditions: Vec<OwnedExpression>,
     pub order_by: Vec<(OwnedExpression, bool)>,
     pub group_by: Vec<OwnedExpression>,
-    pub having_conditions: Vec<OwnedExpression>,
     pub distinct: bool,
     pub limit: Option<i64>,
     pub skip: Option<i64>,
@@ -57,7 +56,6 @@ impl SurrealSelect {
             where_conditions: Vec::new(),
             order_by: Vec::new(),
             group_by: Vec::new(),
-            having_conditions: Vec::new(),
             distinct: false,
             limit: None,
             skip: None,
@@ -143,26 +141,6 @@ impl SurrealSelect {
         }
     }
 
-    /// Renders the HAVING clause
-    ///
-    /// doc wip
-    fn render_having(&self) -> OwnedExpression {
-        if self.having_conditions.is_empty() {
-            expr!("")
-        } else if self.having_conditions.len() == 1 {
-            expr!(" HAVING {}", self.having_conditions[0].clone())
-        } else {
-            // Combine multiple conditions with AND
-            let conditions: Vec<OwnedExpression> = self
-                .having_conditions
-                .iter()
-                .map(|c| expr!("({})", c.clone()))
-                .collect();
-            let combined = OwnedExpression::from_vec(conditions, " AND ");
-            expr!(" HAVING {}", combined)
-        }
-    }
-
     /// Renders the ORDER BY clause
     ///
     /// doc wip
@@ -201,12 +179,11 @@ impl SurrealSelect {
     /// Renders entire statement into an expression
     fn render(&self) -> OwnedExpression {
         expr!(
-            "SELECT {}{}{}{}{}{}{}",
+            "SELECT {}{}{}{}{}{}",
             self.render_fields(),
             self.render_from(),
             self.render_where(),
             self.render_group_by(),
-            self.render_having(),
             self.render_order_by(),
             self.render_limit()
         )

--- a/vantage-surrealdb/src/thing.rs
+++ b/vantage-surrealdb/src/thing.rs
@@ -2,6 +2,7 @@
 //!
 //! doc wip
 
+use crate::operation::Expressive;
 use vantage_expressions::{OwnedExpression, expr, protocol::expressive::IntoExpressive};
 
 /// SurrealDB Thing (record ID) representation
@@ -62,14 +63,20 @@ impl Thing {
     }
 }
 
+impl Expressive for Thing {
+    fn expr(&self) -> OwnedExpression {
+        expr!(format!("{}:{}", self.table, self.id))
+    }
+}
+
 impl Into<OwnedExpression> for Thing {
     fn into(self) -> OwnedExpression {
-        expr!(format!("{}:{}", self.table, self.id))
+        self.expr()
     }
 }
 
 impl From<Thing> for IntoExpressive<OwnedExpression> {
     fn from(thing: Thing) -> Self {
-        IntoExpressive::nested(thing.into())
+        IntoExpressive::nested(thing.expr())
     }
 }

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -1,5 +1,5 @@
 use vantage_expressions::{expr, protocol::selectable::Selectable};
-use vantage_surrealdb::{select::SurrealSelect, thing::Thing};
+use vantage_surrealdb::{operation::RefOperation, select::SurrealSelect, thing::Thing};
 
 #[test]
 fn query01() {
@@ -17,7 +17,26 @@ fn query01() {
         result,
         "SELECT * FROM product WHERE bakery = bakery:hill_valley AND is_deleted = false ORDER BY name"
     );
+
+    let mut select = SurrealSelect::new();
+
+    select.set_source(
+        Thing::new("bakery", "hill_valley").rref("owns", "product"),
+        None,
+    );
+    select.add_where_condition(expr!("is_deleted = {}", false));
+    select.add_order_by("name", true);
+
+    let result2 = select.preview();
+
+    assert_eq!(
+        result2,
+        "SELECT * FROM (bakery:hill_valley->owns->product) WHERE is_deleted = false ORDER BY name"
+    );
 }
+
+#[test]
+fn query02() {}
 
 #[test]
 fn test_set_source_accepts_string_and_expression() {


### PR DESCRIPTION
allows to create expressions traversing graphs.