### PR TITLE
Add Field projection construct (v2)

### DIFF
--- a/vantage-surrealdb/src/field_projection.rs
+++ b/vantage-surrealdb/src/field_projection.rs
@@ -1,0 +1,221 @@
+//! # SurrealDB Field Projection
+//!
+//! Provides field projection functionality for SurrealDB queries, allowing
+//! construction of object projections like `{field: value, alias: expression}`.
+
+use vantage_expressions::{OwnedExpression, expr};
+
+use crate::{identifier::Identifier, operation::Expressive};
+
+/// Represents a field in a field projection
+///
+/// Used within FieldProjection to represent individual field mappings
+/// like `alias: expression`.
+#[derive(Debug, Clone)]
+pub struct FieldProjectionField {
+    alias: String,
+    expression: OwnedExpression,
+}
+
+impl FieldProjectionField {
+    /// Creates a new field projection field
+    pub fn new(alias: impl Into<String>, expression: impl Into<OwnedExpression>) -> Self {
+        Self {
+            alias: alias.into(),
+            expression: expression.into(),
+        }
+    }
+}
+
+impl Expressive for FieldProjectionField {
+    fn expr(&self) -> OwnedExpression {
+        expr!(
+            "{}: {}",
+            Identifier::new(self.alias.clone()),
+            self.expression.expr()
+        )
+    }
+}
+
+impl Into<OwnedExpression> for FieldProjectionField {
+    fn into(self) -> OwnedExpression {
+        self.expr()
+    }
+}
+
+/// Field projection builder for SurrealDB object construction
+///
+/// Builds field projections in the format `{field1: value1, field2: value2}`.
+/// Used for transforming query results into structured objects.
+///
+/// # Examples
+///
+/// ```rust
+/// use vantage_surrealdb::field_projection::FieldProjection;
+/// use vantage_expressions::expr;
+///
+/// let projection = FieldProjection::new(expr!("lines[*]"))
+///     .with_field("quantity")
+///     .with_expression(expr!("product.name"), "product_name")
+///     .with_expression(expr!("quantity * price"), "subtotal");
+/// ```
+#[derive(Debug, Clone)]
+pub struct FieldProjection {
+    base: Option<OwnedExpression>,
+    fields: Vec<FieldProjectionField>,
+}
+
+impl FieldProjection {
+    /// Creates a new field projection with a base expression
+    pub fn new(base: impl Into<OwnedExpression>) -> Self {
+        Self {
+            base: Some(base.into()),
+            fields: Vec::new(),
+        }
+    }
+
+    /// Adds a field that maps to itself (field_name: field_name)
+    ///
+    /// # Arguments
+    ///
+    /// * `field_name` - The field name that will be both the key and value
+    pub fn with_field(mut self, field_name: impl Into<String>) -> Self {
+        self.add_field(field_name);
+        self
+    }
+
+    /// Adds a field with an expression (alternative method signature)
+    ///
+    /// # Arguments
+    ///
+    /// * `expression` - The expression to evaluate for this field
+    /// * `alias` - The field name/alias in the resulting object
+    pub fn with_expression(
+        mut self,
+        expression: impl Into<OwnedExpression>,
+        alias: impl Into<String>,
+    ) -> Self {
+        self.add_expression(expression, alias);
+        self
+    }
+
+    /// Adds a field that maps to itself (mutable version)
+    ///
+    /// # Arguments
+    ///
+    /// * `field_name` - The field name that will be both the key and value
+    pub fn add_field(&mut self, field_name: impl Into<String>) {
+        let field_name = field_name.into();
+        self.fields.push(FieldProjectionField::new(
+            field_name.clone(),
+            expr!(field_name),
+        ));
+    }
+
+    /// Adds a field with an expression (mutable version, alternative signature)
+    ///
+    /// # Arguments
+    ///
+    /// * `expression` - The expression to evaluate for this field
+    /// * `alias` - The field name/alias in the resulting object
+    pub fn add_expression(
+        &mut self,
+        expression: impl Into<OwnedExpression>,
+        alias: impl Into<String>,
+    ) {
+        self.fields
+            .push(FieldProjectionField::new(alias, expression));
+    }
+}
+
+impl Expressive for FieldProjection {
+    fn expr(&self) -> OwnedExpression {
+        let field_expressions =
+            OwnedExpression::from_vec(self.fields.iter().map(|f| f.expr()).collect(), ", ");
+        let base = self.base.clone().unwrap();
+
+        if base.preview().is_empty() {
+            OwnedExpression::new("{{}}", vec![field_expressions.into()])
+        } else {
+            OwnedExpression::new("{}.{{}}", vec![base.into(), field_expressions.into()])
+        }
+    }
+}
+
+impl Into<OwnedExpression> for FieldProjection {
+    fn into(self) -> OwnedExpression {
+        self.expr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vantage_expressions::expr;
+
+    #[test]
+    fn test_empty_projection() {
+        let projection = FieldProjection::new(expr!("lines[*]"));
+        assert_eq!(projection.expr().preview(), "lines[*].{}");
+    }
+
+    #[test]
+    fn test_single_field() {
+        let projection = FieldProjection::new(expr!("lines[*]")).with_field("quantity");
+
+        assert_eq!(projection.expr().preview(), "lines[*].{quantity: quantity}");
+    }
+
+    #[test]
+    fn test_multiple_fields() {
+        let projection = FieldProjection::new(expr!("lines[*]"))
+            .with_field("quantity")
+            .with_field("price")
+            .with_expression(expr!("product.name"), "product_name")
+            .with_expression(expr!("quantity * price"), "subtotal");
+
+        let expected = "lines[*].{quantity: quantity, price: price, product_name: product.name, subtotal: quantity * price}";
+
+        assert_eq!(projection.expr().preview(), expected);
+    }
+
+    #[test]
+    fn test_mutable_methods() {
+        let mut projection = FieldProjection::new(expr!("items[*]"));
+        projection.add_field("name");
+        projection.add_expression(expr!("count(*)"), "total");
+
+        let expected = "items[*].{name: name, total: count(*)}";
+
+        assert_eq!(projection.expr().preview(), expected);
+    }
+
+    #[test]
+    fn test_example_from_query07() {
+        let projection = FieldProjection::new(expr!("lines[*]"))
+            .with_field("quantity")
+            .with_field("price")
+            .with_expression(expr!("product.name"), "product_name")
+            .with_expression(expr!("quantity * price"), "subtotal");
+
+        let expected = "lines[*].{quantity: quantity, price: price, product_name: product.name, subtotal: quantity * price}";
+        assert_eq!(projection.expr().preview(), expected);
+    }
+
+    #[test]
+    fn test_empty_base() {
+        let projection = FieldProjection::new(expr!(""))
+            .with_field("quantity")
+            .with_field("price")
+            .with_expression(expr!("product.name"), "product_name");
+
+        let expected = "{quantity: quantity, price: price, product_name: product.name}";
+        assert_eq!(projection.expr().preview(), expected);
+    }
+
+    #[test]
+    fn test_empty_base_empty_fields() {
+        let projection = FieldProjection::new(expr!(""));
+        assert_eq!(projection.expr().preview(), "{}");
+    }
+}

--- a/vantage-surrealdb/src/lib.rs
+++ b/vantage-surrealdb/src/lib.rs
@@ -33,6 +33,7 @@
 
 pub mod associated_query;
 pub mod conditional;
+pub mod field_projection;
 pub mod identifier;
 pub mod operation;
 pub mod protocol;

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -108,6 +108,14 @@ impl SurrealSelect {
         self.set_source(source, Some(alias.into()));
         self
     }
+    pub fn with_field(mut self, field: impl Into<String>) -> Self {
+        self.add_field(field);
+        self
+    }
+    pub fn with_expression(mut self, expression: OwnedExpression, alias: Option<String>) -> Self {
+        self.add_expression(expression, alias);
+        self
+    }
 
     pub fn with_condition(mut self, condition: OwnedExpression) -> Self {
         self.add_where_condition(condition);

--- a/vantage-surrealdb/src/select/select_field.rs
+++ b/vantage-surrealdb/src/select/select_field.rs
@@ -67,20 +67,10 @@ impl SelectField {
 
 impl Into<OwnedExpression> for SelectField {
     fn into(self) -> OwnedExpression {
-        let base_expr = self.expression.preview();
-
         match (&self.alias, self.is_value) {
-            (Some(alias), true) => expr!(
-                "VALUE {} AS {}",
-                Identifier::new(base_expr),
-                Identifier::new(alias)
-            ),
-            (Some(alias), false) => expr!(
-                "{} AS {}",
-                Identifier::new(base_expr),
-                Identifier::new(alias)
-            ),
-            (None, true) => expr!("VALUE {}", Identifier::new(base_expr)),
+            (Some(alias), true) => expr!("VALUE {} AS {}", self.expression, Identifier::new(alias)),
+            (Some(alias), false) => expr!("{} AS {}", self.expression, Identifier::new(alias)),
+            (None, true) => expr!("VALUE {}", self.expression),
             (None, false) => self.expression,
         }
     }


### PR DESCRIPTION
Added FieldProjection struct, that allows to create a Json field expression.

```rust
let projection = FieldProjection::new(expr!("lines[*]"))
    .with_expression(expr!("product.name"), "product_name")
    .with_field("quantity")
    .with_field("price")
    .with_expression(expr!("quantity * price"), "subtotal");

let select = SurrealSelect::new()
    .with_source("order")
    .with_field("id")
    .with_field("created_at")
    .with_expression(projection.into(), Some("items".to_string()));
assert_eq!(
    select.preview(),
    "SELECT id, created_at, lines[*].{product_name: product.name, " \
    "quantity: quantity, price: price, subtotal: quantity * price} AS items FROM order"
)
```