### PR TITLE
add vantage-dataset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,6 +2286,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11825,6 +11846,21 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "vantage-dataset"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "csv",
+ "indexmap 2.11.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.16",
+ "tokio",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ members = [
     "bakery_api",
     "surreal-client",
     # "vantage-admin",
-    "vantage-ui-adapters",
+    "vantage-ui-adapters", "vantage-dataset",
 ]
 resolver = "2"

--- a/vantage-dataset/Cargo.toml
+++ b/vantage-dataset/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "vantage-dataset"
+version = "0.3.0"
+edition = "2024"
+
+[lib]
+doctest = false
+
+[dependencies]
+anyhow = "1.0"
+async-trait = "0.1.89"
+indexmap = "2.11.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "2.0.16"
+uuid = { version = "1.18.0", features = ["v4"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+csv = "1.3.1"

--- a/vantage-dataset/README.md
+++ b/vantage-dataset/README.md
@@ -1,0 +1,67 @@
+# vantage-dataset
+
+Internal crate providing traits for dataset operations across different data sources.
+
+## Overview
+
+This crate defines generic traits that can be implemented by datasets associated with specific data sources. Each trait represents a different capability or access pattern.
+
+## Traits
+
+### `ReadableDataSet`
+
+For read-only data sources that can fetch and deserialize records.
+
+```rust
+// Example: CSV file dataset
+let csv_data: CsvDataSet = CsvDataSet::new("users.csv");
+let users: Vec<User> = csv_data.get().await?;
+let first_user: User = csv_data.get_some().await?;
+```
+
+### `InsertableDataSet`
+
+For append-only data sources like queues, logs, or event streams.
+
+```rust
+// Example: Message queue topic
+let topic: Topic<Event> = queue.topic("user_events");
+topic.insert(Event { user_id: 123, action: "login" }).await?;
+```
+
+### `WritableDataSet`
+
+For full read-write data sources with update and delete capabilities. Extends `InsertableDataSet`.
+
+```rust
+// Example: Database table
+let users: Table<User> = db.table("users");
+users.update::<User, _>(|user| {
+    user.last_seen = Utc::now();
+}).await?;
+users.delete().await?;
+```
+
+### `IndexableDataSet`
+
+For key-value stores and indexed data sources that operate on specific identifiers.
+
+```rust
+// Example: Redis-like key-value store
+let cache: KeyStore<String, User> = redis.keystore();
+cache.get_by_key("user:123").await?;
+cache.set_by_key("user:456", user).await?;
+cache.delete_by_key("user:789").await?;
+```
+
+## Use Cases
+
+- **Queue/Topic** (`Topic<Entity>`): Implements `InsertableDataSet` only
+- **Read-only CSV**: Implements `ReadableDataSet` only
+- **Database Table**: Implements `WritableDataSet` (which includes insertable)
+- **Key-Value Store**: Implements `IndexableDataSet`
+- **Document Store**: May implement multiple traits depending on capabilities
+
+## Error Handling
+
+All traits use a configurable `Error` associated type. The crate provides `DataSetError` for common error scenarios, built with `thiserror` for clean error handling.

--- a/vantage-dataset/examples/csv.rs
+++ b/vantage-dataset/examples/csv.rs
@@ -1,0 +1,77 @@
+// examples/csv.rs
+
+mod mocks;
+use mocks::csv_mock::{CsvFile, MockCsv};
+
+use serde::{Deserialize, Serialize};
+use vantage_dataset::dataset::ReadableDataSet;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct User {
+    id: u32,
+    name: String,
+    email: String,
+    age: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Product {
+    id: u32,
+    name: String,
+    price: f64,
+    category: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let csv_ds = MockCsv::new();
+
+    let users = CsvFile::<User>::new(&csv_ds, "users.csv");
+    let products = CsvFile::<Product>::new(&csv_ds, "products.csv");
+
+    // Read all users
+    let all_users: Vec<User> = users.get().await?;
+    println!("All users ({}):", all_users.len());
+    for user in &all_users {
+        println!(
+            "  {} - {} ({}, age {})",
+            user.id, user.name, user.email, user.age
+        );
+    }
+
+    // Read just the first user
+    let first_user = users.get_some().await?.unwrap();
+    println!("\nFirst user: {} - {}", first_user.name, first_user.email);
+
+    // Read all products
+    let all_products: Vec<Product> = products.get().await?;
+    println!("\nAll products ({}):", all_products.len());
+    for product in &all_products {
+        println!(
+            "  {} - {} (${}, {})",
+            product.id, product.name, product.price, product.category
+        );
+    }
+
+    // Demonstrate partial deserialization - only get user names and emails
+    #[derive(Debug, Deserialize)]
+    struct UserContact {
+        name: String,
+        email: String,
+    }
+
+    let contacts: Vec<UserContact> = users.get_as().await?;
+    println!("\nUser contacts only:");
+    for contact in contacts {
+        println!("  {} - {}", contact.name, contact.email);
+    }
+
+    // Try to read a non-existent file
+    let missing_file = CsvFile::<User>::new(&csv_ds, "missing.csv");
+    match missing_file.get_some().await {
+        Ok(_) => println!("Unexpected success"),
+        Err(e) => println!("\nExpected error for missing file: {}", e),
+    }
+
+    Ok(())
+}

--- a/vantage-dataset/examples/im.rs
+++ b/vantage-dataset/examples/im.rs
@@ -1,0 +1,142 @@
+// examples/im_example.rs
+
+use serde::{Deserialize, Serialize};
+use vantage_dataset::dataset::{InsertableDataSet, ReadableDataSet};
+use vantage_dataset::im::{ImDataSource, Table};
+
+mod mocks;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct User {
+    id: Option<String>,
+    name: String,
+    email: String,
+    age: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Product {
+    name: String,
+    price: f64,
+    category: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let im_data_source = ImDataSource::new();
+
+    let users = Table::<User>::new(&im_data_source, "users");
+    let mut products = Table::<Product>::new(&im_data_source, "products");
+
+    // Insert some users
+    users
+        .insert(User {
+            id: Some("user-1".to_string()),
+            name: "Alice".to_string(),
+            email: "alice@example.com".to_string(),
+            age: 30,
+        })
+        .await?;
+
+    users
+        .insert(User {
+            id: None, // This will get an auto-generated ID
+            name: "Bob".to_string(),
+            email: "bob@example.com".to_string(),
+            age: 25,
+        })
+        .await?;
+
+    users
+        .insert(User {
+            id: Some("charlie-456".to_string()),
+            name: "Charlie".to_string(),
+            email: "charlie@example.com".to_string(),
+            age: 35,
+        })
+        .await?;
+
+    // Insert some products (no ID field needed - auto-generated)
+    let csv_products =
+        mocks::csv_mock::CsvFile::<Product>::new(&mocks::csv_mock::MockCsv::new(), "products.csv");
+
+    products.import(csv_products).await?;
+
+    // Retrieve and display all users
+    let all_users = users.get().await?;
+    println!("All users ({}):", all_users.len());
+    for user in &all_users {
+        let id_display = user.id.as_ref().map(|s| s.as_str()).unwrap_or("<no-id>");
+        println!(
+            "  [{}] {} - {} (age {})",
+            id_display, user.name, user.email, user.age
+        );
+    }
+
+    // Get first user
+    let first_user = users.get_some().await?.unwrap();
+    println!("\nFirst user: {}", first_user.name);
+
+    // Retrieve and display all products (no ID field, but still stored with auto-generated IDs)
+    let all_products: Vec<Product> = products.get().await?;
+    println!("\nAll products ({}):", all_products.len());
+    for product in &all_products {
+        println!(
+            "  {} - ${} ({})",
+            product.name, product.price, product.category
+        );
+    }
+    println!("Note: Products have auto-generated IDs internally, but don't expose them");
+
+    // Demonstrate partial deserialization - only get user names and ages
+    #[derive(Debug, Deserialize)]
+    struct UserSummary {
+        name: String,
+        age: u32,
+    }
+
+    let summaries: Vec<UserSummary> = users.get_as().await?;
+    println!("\nUser summaries:");
+    for summary in summaries {
+        println!("  {} is {} years old", summary.name, summary.age);
+    }
+
+    // Show that insertion order is preserved and IDs are properly handled
+    println!("\nInsertion order is preserved and IDs are handled:");
+    println!(
+        "First user inserted: {} (ID: {})",
+        all_users[0].name,
+        all_users[0].id.as_ref().unwrap()
+    ); // Should be Alice with user-1
+    println!(
+        "Second user inserted: {} (ID: {})",
+        all_users[1].name,
+        all_users[1].id.as_ref().unwrap()
+    ); // Should be Bob with auto-generated ID
+    println!(
+        "Third user inserted: {} (ID: {})",
+        all_users[2].name,
+        all_users[2].id.as_ref().unwrap()
+    ); // Should be Charlie with charlie-456
+
+    // Demonstrate overwriting by inserting user with existing ID
+    users
+        .insert(User {
+            id: Some("user-1".to_string()), // Same ID as Alice - should overwrite
+            name: "Alice Updated".to_string(),
+            email: "alice.new@example.com".to_string(),
+            age: 31,
+        })
+        .await?;
+
+    let updated_users: Vec<User> = users.get().await?;
+    println!("\nAfter overwriting user-1:");
+    println!("Total users: {} (should still be 3)", updated_users.len());
+    for user in &updated_users {
+        if user.id.as_ref().unwrap() == "user-1" {
+            println!("  Overwritten user: {} - {}", user.name, user.email);
+        }
+    }
+
+    Ok(())
+}

--- a/vantage-dataset/examples/mocks/csv_mock.rs
+++ b/vantage-dataset/examples/mocks/csv_mock.rs
@@ -1,0 +1,116 @@
+// examples/mocks/csv_mock.rs
+
+use csv::ReaderBuilder;
+use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use vantage_dataset::dataset::{DataSetError, ReadableDataSet, Result};
+
+/// MockCsv contains hardcoded CSV data as strings
+#[derive(Debug, Clone)]
+pub struct MockCsv {
+    files: HashMap<String, String>,
+}
+
+impl MockCsv {
+    pub fn new() -> Self {
+        let mut files = HashMap::new();
+
+        // Add users.csv data
+        files.insert(
+            "users.csv".to_string(),
+            "id,name,email,age\n1,Alice,alice@example.com,25\n2,Bob,bob@example.com,30\n3,Charlie,charlie@example.com,35".to_string(),
+        );
+
+        // Add products.csv data
+        files.insert(
+            "products.csv".to_string(),
+            "id,name,price,category\n1,Laptop,999.99,Electronics\n2,Chair,149.99,Furniture\n3,Book,19.99,Education".to_string(),
+        );
+
+        Self { files }
+    }
+
+    pub fn get_file_content(&self, filename: &str) -> Option<&String> {
+        self.files.get(filename)
+    }
+}
+
+/// CsvFile represents a typed CSV file dataset
+pub struct CsvFile<T> {
+    csv_ds: MockCsv,
+    filename: String,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> CsvFile<T>
+where
+    T: DeserializeOwned,
+{
+    pub fn new(csv_ds: &MockCsv, filename: &str) -> Self {
+        Self {
+            csv_ds: csv_ds.clone(),
+            filename: filename.to_string(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T> ReadableDataSet<T> for CsvFile<T>
+where
+    T: DeserializeOwned + Send + Sync,
+{
+    async fn get(&self) -> Result<Vec<T>> {
+        self.get_as().await
+    }
+
+    async fn get_some(&self) -> Result<Option<T>> {
+        self.get_some_as().await
+    }
+
+    async fn get_as<U>(&self) -> Result<Vec<U>>
+    where
+        U: DeserializeOwned,
+    {
+        let content = self
+            .csv_ds
+            .get_file_content(&self.filename)
+            .ok_or_else(|| DataSetError::other(format!("File '{}' not found", self.filename)))?;
+
+        let mut reader = ReaderBuilder::new()
+            .has_headers(true)
+            .from_reader(content.as_bytes());
+
+        let mut records = Vec::new();
+        for result in reader.deserialize() {
+            let record: U = result
+                .map_err(|e| DataSetError::other(format!("CSV deserialization error: {}", e)))?;
+            records.push(record);
+        }
+
+        Ok(records)
+    }
+
+    async fn get_some_as<U>(&self) -> Result<Option<U>>
+    where
+        U: DeserializeOwned,
+    {
+        let content = self
+            .csv_ds
+            .get_file_content(&self.filename)
+            .ok_or_else(|| DataSetError::other(format!("File '{}' not found", self.filename)))?;
+
+        let mut reader = ReaderBuilder::new()
+            .has_headers(true)
+            .from_reader(content.as_bytes());
+
+        let mut records = reader.deserialize();
+        if let Some(result) = records.next() {
+            let record: U = result
+                .map_err(|e| DataSetError::other(format!("CSV deserialization error: {}", e)))?;
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/vantage-dataset/examples/mocks/mod.rs
+++ b/vantage-dataset/examples/mocks/mod.rs
@@ -1,0 +1,4 @@
+#![allow(dead_code)]
+
+pub mod csv_mock;
+pub mod queue_mock;

--- a/vantage-dataset/examples/mocks/queue_mock.rs
+++ b/vantage-dataset/examples/mocks/queue_mock.rs
@@ -1,0 +1,90 @@
+// examples/queue_mock.rs
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use vantage_dataset::dataset::{DataSetError, InsertableDataSet, Result};
+
+/// MockQueue collects all messages from all topics
+#[derive(Debug, Clone)]
+pub struct MockQueue {
+    // topic_name -> Vec<messages>
+    topics: Arc<Mutex<HashMap<String, Vec<serde_json::Value>>>>,
+}
+
+impl MockQueue {
+    pub fn init() -> Self {
+        Self {
+            topics: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn message_count(&self, topic_name: &str) -> usize {
+        self.topics
+            .lock()
+            .unwrap()
+            .get(topic_name)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+
+    pub fn get_messages(&self, topic_name: &str) -> Vec<serde_json::Value> {
+        self.topics
+            .lock()
+            .unwrap()
+            .get(topic_name)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn get_all_messages(&self) -> HashMap<String, Vec<serde_json::Value>> {
+        self.topics.lock().unwrap().clone()
+    }
+
+    pub(crate) fn push_message(&self, topic_name: &str, message: serde_json::Value) {
+        let mut topics = self.topics.lock().unwrap();
+        topics
+            .entry(topic_name.to_string())
+            .or_insert_with(Vec::new)
+            .push(message);
+    }
+}
+
+/// Topic represents a typed topic in the queue
+pub struct Topic<E> {
+    queue: MockQueue,
+    topic_name: String,
+    _phantom: std::marker::PhantomData<E>,
+}
+
+impl<E> Topic<E>
+where
+    E: Serialize + Send,
+{
+    pub fn new(queue: &MockQueue) -> Self {
+        // Use the type name as topic identifier
+        let topic_name = std::any::type_name::<E>()
+            .split("::")
+            .last()
+            .unwrap_or("unknown");
+        Self {
+            queue: queue.clone(),
+            topic_name: topic_name.to_string(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<E> InsertableDataSet<E> for Topic<E>
+where
+    E: Serialize + Send + Sync,
+{
+    async fn insert(&self, record: E) -> Result<()> {
+        let value = serde_json::to_value(record)
+            .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+
+        self.queue.push_message(&self.topic_name, value);
+        Ok(())
+    }
+}

--- a/vantage-dataset/examples/queue.rs
+++ b/vantage-dataset/examples/queue.rs
@@ -1,0 +1,87 @@
+// examples/queue.rs
+
+mod mocks;
+use mocks::queue_mock::{MockQueue, Topic};
+
+use serde::{Deserialize, Serialize};
+use vantage_dataset::dataset::InsertableDataSet;
+
+// This is example implementation of a Queue with multiple topics
+// using vantage-dataset pattern. Queue integration is in mocks/, but
+// developer would only need to define types to operate with.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Signup {
+    email: String,
+    password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResetPassword {
+    email: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let queue = MockQueue::init();
+
+    // Developers can now use type safety, when inserting
+    // records into topics. You can also Box topic into
+    // Box<dyn Insertable>
+
+    let new_signup = Topic::<Signup>::new(&queue);
+    let reset_password = Topic::<ResetPassword>::new(&queue);
+
+    // Insert some messages into different topics
+    new_signup
+        .insert(Signup {
+            email: "john".to_string(),
+            password: "secret".to_string(),
+        })
+        .await?;
+
+    new_signup
+        .insert(Signup {
+            email: "jane".to_string(),
+            password: "password123".to_string(),
+        })
+        .await?;
+
+    reset_password
+        .insert(ResetPassword {
+            email: "john".to_string(),
+        })
+        .await?;
+
+    let _b: Box<dyn InsertableDataSet<ResetPassword>> = Box::new(reset_password);
+
+    // Show queue statistics
+    println!("Queue Statistics:");
+    println!("  Signup messages: {}", queue.message_count("Signup"));
+    println!(
+        "  Reset password messages: {}",
+        queue.message_count("ResetPassword")
+    );
+
+    // Show collected messages
+    println!("\nAll messages in queue:");
+    for (topic, messages) in queue.get_all_messages() {
+        println!("Topic '{}': {} messages", topic, messages.len());
+        for (i, message) in messages.iter().enumerate() {
+            println!("  {}: {}", i + 1, message);
+        }
+    }
+
+    // Show specific topic messages
+    println!("\nSignup topic messages:");
+    for message in queue.get_messages("Signup") {
+        println!("  {}", message);
+    }
+
+    println!("\nReset password topic messages:");
+    for message in queue.get_messages("ResetPassword") {
+        println!("  {}", message);
+    }
+
+    Ok(())
+}

--- a/vantage-dataset/src/dataset/error.rs
+++ b/vantage-dataset/src/dataset/error.rs
@@ -1,0 +1,31 @@
+// src/dataset/error.rs
+
+use thiserror::Error;
+
+/// Error type for dataset operations
+#[derive(Error, Debug)]
+pub enum DataSetError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("No data available")]
+    NoData,
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl DataSetError {
+    /// Create a generic error with a message
+    pub fn other<S: Into<String>>(msg: S) -> Self {
+        Self::Other(msg.into())
+    }
+
+    /// Create a "no data available" error
+    pub fn no_data() -> Self {
+        Self::NoData
+    }
+}
+
+/// Type alias for Result with DataSetError
+pub type Result<T> = std::result::Result<T, DataSetError>;

--- a/vantage-dataset/src/dataset/insertable.rs
+++ b/vantage-dataset/src/dataset/insertable.rs
@@ -1,0 +1,181 @@
+// src/dataset/insertable.rs
+
+use super::Result;
+use async_trait::async_trait;
+use serde::Serialize;
+
+#[async_trait]
+pub trait InsertableDataSet<T>
+where
+    T: Serialize + Send,
+{
+    /// Insert a record of the specified type
+    async fn insert(&self, record: T) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DataSetError;
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct LogEntry {
+        pub timestamp: u64,
+        pub message: String,
+    }
+
+    struct MockQueue {
+        items: std::sync::Mutex<Vec<serde_json::Value>>,
+    }
+
+    impl MockQueue {
+        fn new() -> Self {
+            Self {
+                items: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn len(&self) -> usize {
+            self.items.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl InsertableDataSet<LogEntry> for MockQueue {
+        async fn insert(&self, record: LogEntry) -> Result<()> {
+            let value = serde_json::to_value(record)
+                .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+
+            // Simulate adding to queue
+            self.items.lock().unwrap().push(value);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert_default_type() {
+        let queue = MockQueue::new();
+        let entry = LogEntry {
+            timestamp: 1234567890,
+            message: "Test log entry".to_string(),
+        };
+
+        let result = queue.insert(entry).await;
+        assert!(result.is_ok());
+        assert_eq!(queue.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_insert_as_generic_type() {
+        let _queue = MockQueue::new();
+
+        #[derive(Serialize)]
+        struct Event {
+            event_type: String,
+            data: String,
+        }
+
+        let _event = Event {
+            event_type: "user_action".to_string(),
+            data: "clicked_button".to_string(),
+        };
+
+        // This test is no longer valid since MockQueue only implements InsertableDataSet<LogEntry>
+        // In practice, you'd have separate implementations for different types
+    }
+
+    #[tokio::test]
+    async fn test_multiple_inserts() {
+        let queue = MockQueue::new();
+
+        // Insert using default type
+        let entry1 = LogEntry {
+            timestamp: 1000,
+            message: "First entry".to_string(),
+        };
+        queue.insert(entry1).await.unwrap();
+
+        // Insert another log entry
+        let entry2 = LogEntry {
+            timestamp: 2000,
+            message: "Second entry".to_string(),
+        };
+        queue.insert(entry2).await.unwrap();
+
+        assert_eq!(queue.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_serialization_error() {
+        let queue = MockQueue::new();
+
+        // Test serialization with a valid LogEntry
+        let entry = LogEntry {
+            timestamp: 123,
+            message: "Test entry".to_string(),
+        };
+        let result = queue.insert(entry).await;
+        assert!(result.is_ok());
+        assert_eq!(queue.len(), 1);
+    }
+
+    // Test that WritableDataSet implementations also work with InsertableDataSet
+    #[tokio::test]
+    async fn test_writable_as_insertable() {
+        use super::super::WritableDataSet;
+
+        struct MockWritable {
+            data: std::sync::Mutex<Vec<serde_json::Value>>,
+        }
+
+        impl MockWritable {
+            fn new() -> Self {
+                Self {
+                    data: std::sync::Mutex::new(Vec::new()),
+                }
+            }
+
+            fn len(&self) -> usize {
+                self.data.lock().unwrap().len()
+            }
+        }
+
+        #[async_trait]
+        impl InsertableDataSet<LogEntry> for MockWritable {
+            async fn insert(&self, record: LogEntry) -> Result<()> {
+                let value = serde_json::to_value(record)
+                    .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+                self.data.lock().unwrap().push(value);
+                Ok(())
+            }
+        }
+
+        #[async_trait]
+        impl WritableDataSet<LogEntry> for MockWritable {
+            async fn update<F>(&self, _callback: F) -> Result<()>
+            where
+                F: Fn(&mut LogEntry) + Send + Sync,
+            {
+                Ok(())
+            }
+
+            async fn delete(&self) -> Result<()> {
+                self.data.lock().unwrap().clear();
+                Ok(())
+            }
+        }
+
+        let writable = MockWritable::new();
+
+        // Test that we can use WritableDataSet as InsertableDataSet
+        let entry = LogEntry {
+            timestamp: 9999,
+            message: "From writable".to_string(),
+        };
+
+        let result = writable.insert(entry).await;
+        assert!(result.is_ok());
+        assert_eq!(writable.len(), 1);
+    }
+}

--- a/vantage-dataset/src/dataset/kv.rs
+++ b/vantage-dataset/src/dataset/kv.rs
@@ -1,0 +1,220 @@
+// src/dataset/indexable.rs
+
+use async_trait::async_trait;
+use serde::{Serialize, de::DeserializeOwned};
+
+#[async_trait]
+pub trait KvDataSet {
+    type Key: Send + Sync;
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Get a record by its key/identifier
+    async fn get_by_key<T>(&self, key: Self::Key) -> Result<Option<T>, Self::Error>
+    where
+        T: DeserializeOwned + Send;
+
+    /// Set/update a record with a specific key
+    async fn set_by_key<T>(&self, key: Self::Key, record: T) -> Result<(), Self::Error>
+    where
+        T: Serialize + Send;
+
+    /// Delete a record by its key
+    async fn delete_by_key(&self, key: Self::Key) -> Result<bool, Self::Error>;
+
+    /// Check if a key exists
+    async fn exists(&self, key: Self::Key) -> Result<bool, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DataSetError;
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct User {
+        pub id: u64,
+        pub name: String,
+    }
+
+    struct MockKeyValueStore {
+        data: std::sync::Mutex<HashMap<String, serde_json::Value>>,
+    }
+
+    impl MockKeyValueStore {
+        fn new() -> Self {
+            let mut initial_data = HashMap::new();
+            initial_data.insert(
+                "user:1".to_string(),
+                serde_json::json!({"id": 1, "name": "Alice"}),
+            );
+            initial_data.insert(
+                "user:2".to_string(),
+                serde_json::json!({"id": 2, "name": "Bob"}),
+            );
+
+            Self {
+                data: std::sync::Mutex::new(initial_data),
+            }
+        }
+
+        fn len(&self) -> usize {
+            self.data.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl KvDataSet for MockKeyValueStore {
+        type Key = String;
+        type Error = DataSetError;
+
+        async fn get_by_key<T>(&self, key: Self::Key) -> Result<Option<T>, Self::Error>
+        where
+            T: DeserializeOwned + Send,
+        {
+            let data = self.data.lock().unwrap();
+            match data.get(&key) {
+                Some(value) => {
+                    let record = serde_json::from_value(value.clone()).map_err(|e| {
+                        DataSetError::other(format!("Deserialization error: {}", e))
+                    })?;
+                    Ok(Some(record))
+                }
+                None => Ok(None),
+            }
+        }
+
+        async fn set_by_key<T>(&self, key: Self::Key, record: T) -> Result<(), Self::Error>
+        where
+            T: Serialize + Send,
+        {
+            let value = serde_json::to_value(record)
+                .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+            self.data.lock().unwrap().insert(key, value);
+            Ok(())
+        }
+
+        async fn delete_by_key(&self, key: Self::Key) -> Result<bool, Self::Error> {
+            Ok(self.data.lock().unwrap().remove(&key).is_some())
+        }
+
+        async fn exists(&self, key: Self::Key) -> Result<bool, Self::Error> {
+            Ok(self.data.lock().unwrap().contains_key(&key))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_by_key() {
+        let store = MockKeyValueStore::new();
+
+        // Get existing user
+        let user: Option<User> = store.get_by_key("user:1".to_string()).await.unwrap();
+        assert!(user.is_some());
+        let user = user.unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.name, "Alice");
+
+        // Get non-existent user
+        let missing: Option<User> = store.get_by_key("user:999".to_string()).await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_set_by_key() {
+        let store = MockKeyValueStore::new();
+        let initial_len = store.len();
+
+        let new_user = User {
+            id: 3,
+            name: "Charlie".to_string(),
+        };
+
+        // Set new user
+        let result = store.set_by_key("user:3".to_string(), new_user).await;
+        assert!(result.is_ok());
+        assert_eq!(store.len(), initial_len + 1);
+
+        // Verify it was stored correctly
+        let stored: Option<User> = store.get_by_key("user:3".to_string()).await.unwrap();
+        assert!(stored.is_some());
+        assert_eq!(stored.unwrap().name, "Charlie");
+    }
+
+    #[tokio::test]
+    async fn test_update_by_key() {
+        let store = MockKeyValueStore::new();
+
+        let updated_user = User {
+            id: 1,
+            name: "Alice Updated".to_string(),
+        };
+
+        // Update existing user
+        let result = store.set_by_key("user:1".to_string(), updated_user).await;
+        assert!(result.is_ok());
+
+        // Verify update
+        let user: Option<User> = store.get_by_key("user:1".to_string()).await.unwrap();
+        assert_eq!(user.unwrap().name, "Alice Updated");
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_key() {
+        let store = MockKeyValueStore::new();
+        let initial_len = store.len();
+
+        // Delete existing key
+        let deleted = store.delete_by_key("user:1".to_string()).await.unwrap();
+        assert!(deleted);
+        assert_eq!(store.len(), initial_len - 1);
+
+        // Try to delete non-existent key
+        let not_deleted = store.delete_by_key("user:999".to_string()).await.unwrap();
+        assert!(!not_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let store = MockKeyValueStore::new();
+
+        // Check existing key
+        let exists = store.exists("user:1".to_string()).await.unwrap();
+        assert!(exists);
+
+        // Check non-existent key
+        let not_exists = store.exists("user:999".to_string()).await.unwrap();
+        assert!(!not_exists);
+    }
+
+    #[tokio::test]
+    async fn test_generic_types() {
+        let store = MockKeyValueStore::new();
+
+        #[derive(Serialize, Deserialize)]
+        struct Settings {
+            theme: String,
+            notifications: bool,
+        }
+
+        let settings = Settings {
+            theme: "dark".to_string(),
+            notifications: true,
+        };
+
+        // Store and retrieve generic type
+        store
+            .set_by_key("settings:user1".to_string(), settings)
+            .await
+            .unwrap();
+        let retrieved: Option<Settings> = store
+            .get_by_key("settings:user1".to_string())
+            .await
+            .unwrap();
+
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.theme, "dark");
+        assert!(retrieved.notifications);
+    }
+}

--- a/vantage-dataset/src/dataset/mod.rs
+++ b/vantage-dataset/src/dataset/mod.rs
@@ -1,0 +1,32 @@
+//! Datasets are like a Vec<E>, but E are stored remotely and only fetched when needed.
+//!
+//! When we operate with DataSet we do not know how many rows are in a DataSet.
+//! An example dataset could contain all the Orders placed by a client.
+//!
+//! There are two main traits for Datasets:
+//!  - [`ReadableDataSet`]: allows to read rows
+//!  - [`WritableDataSet`]: allows to update or delete rows
+//!
+//! The included implementation for Datasets are:
+//!  - [`Table`]: a table is a dataset that stores data in a SQL table and implements both [`ReadableDataSet`] and [`WritableDataSet`].
+//!  - [`Query`]: a generic SELECT query that can fetch data and therefore implements [`ReadableDataSet`].
+//!
+//! [`Table`]: super::table::Table
+//! [`Query`]: super::query::Query
+mod error;
+pub use error::{DataSetError, Result};
+
+mod kv;
+pub use kv::KvDataSet;
+
+mod insertable;
+pub use insertable::InsertableDataSet;
+
+mod readable;
+pub use readable::ReadableDataSet;
+
+mod writable;
+pub use writable::WritableDataSet;
+
+// mod scalar;
+// pub use scalar::ScalarDataSet;

--- a/vantage-dataset/src/dataset/readable.rs
+++ b/vantage-dataset/src/dataset/readable.rs
@@ -1,0 +1,164 @@
+// src/dataset/readable.rs
+
+use super::Result;
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+
+#[async_trait]
+pub trait ReadableDataSet<E> {
+    async fn get(&self) -> Result<Vec<E>>;
+    async fn get_some(&self) -> Result<Option<E>>;
+
+    // Generic methods for any deserializable type
+    async fn get_as<T>(&self) -> Result<Vec<T>>
+    where
+        T: DeserializeOwned;
+
+    async fn get_some_as<T>(&self) -> Result<Option<T>>
+    where
+        T: DeserializeOwned;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::marker::PhantomData;
+
+    use super::super::DataSetError;
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct User {
+        pub id: u64,
+        pub name: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct VipUser {
+        pub id: u64,
+        pub name: String,
+        #[serde(default = "default_vip_level")]
+        pub vip_level: u8,
+    }
+
+    fn default_vip_level() -> u8 {
+        1
+    }
+
+    struct UserSet<T> {
+        data: Vec<serde_json::Value>,
+        _marker: std::marker::PhantomData<T>,
+    }
+
+    impl<T> UserSet<T> {
+        fn new() -> Self {
+            let data = vec![
+                serde_json::json!({
+                    "id": 1,
+                    "name": "Alice",
+                    "vip_level": 3
+                }),
+                serde_json::json!({
+                    "id": 2,
+                    "name": "Bob"
+                }),
+            ];
+            UserSet {
+                data,
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl<E: Sync + DeserializeOwned> ReadableDataSet<E> for UserSet<E> {
+        async fn get(&self) -> Result<Vec<E>> {
+            self.get_as().await
+        }
+
+        async fn get_some(&self) -> Result<Option<E>> {
+            self.get_some_as().await
+        }
+
+        async fn get_as<T>(&self) -> Result<Vec<T>>
+        where
+            T: DeserializeOwned,
+        {
+            self.data
+                .iter()
+                .map(|v| {
+                    serde_json::from_value(v.clone())
+                        .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))
+                })
+                .collect()
+        }
+
+        async fn get_some_as<T>(&self) -> Result<Option<T>>
+        where
+            T: DeserializeOwned,
+        {
+            let Some(value) = self.data.first() else {
+                return Ok(None);
+            };
+            serde_json::from_value(value.clone())
+                .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_user_type() {
+        let user_set = UserSet::<User>::new();
+
+        // Get as User type
+        let user = user_set.get_some().await.unwrap().unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.name, "Alice");
+
+        // Get all as User type
+        let users = user_set.get().await.unwrap();
+        assert_eq!(users.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_vip_user() {
+        let user_set = UserSet::<User>::new();
+
+        // Get as VipUser type
+        let vip_user: VipUser = user_set.get_some_as().await.unwrap().unwrap();
+        assert_eq!(vip_user.id, 1);
+        assert_eq!(vip_user.name, "Alice");
+        assert_eq!(vip_user.vip_level, 3);
+
+        // Get all as VipUser type
+        let vip_users: Vec<VipUser> = user_set.get_as().await.unwrap();
+        assert_eq!(vip_users.len(), 2);
+        assert_eq!(vip_users[1].vip_level, 1); // Uses default for Bob
+    }
+
+    #[tokio::test]
+    async fn test_get_json_value() {
+        let user_set = UserSet::new();
+
+        // Get as serde_json::Value using get_some
+        let value: serde_json::Value = user_set.get_some().await.unwrap().unwrap();
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["name"], "Alice");
+
+        // Get all as serde_json::Value
+        let values: Vec<serde_json::Value> = user_set.get().await.unwrap();
+        assert_eq!(values.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_partial_deserialization() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct PartialUser {
+            pub name: String,
+            // Ignoring id field
+        }
+
+        let user_set = UserSet::new();
+        let partial: PartialUser = user_set.get_some().await.unwrap().unwrap();
+        assert_eq!(partial.name, "Alice");
+    }
+}

--- a/vantage-dataset/src/dataset/writable.rs
+++ b/vantage-dataset/src/dataset/writable.rs
@@ -1,0 +1,107 @@
+// src/dataset/writable.rs
+
+use super::{InsertableDataSet, Result};
+use async_trait::async_trait;
+use serde::{Serialize, de::DeserializeOwned};
+
+#[async_trait]
+pub trait WritableDataSet<T>: InsertableDataSet<T>
+where
+    T: Serialize + DeserializeOwned + Send,
+{
+    /// Update records using a callback that modifies each record in place
+    async fn update<F>(&self, callback: F) -> Result<()>
+    where
+        F: Fn(&mut T) + Send + Sync;
+
+    /// Delete all records in the DataSet
+    async fn delete(&self) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::DataSetError;
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct User {
+        pub id: u64,
+        pub name: String,
+    }
+
+    struct MockDataSet {
+        data: std::sync::Mutex<Vec<serde_json::Value>>,
+    }
+
+    impl MockDataSet {
+        fn new() -> Self {
+            Self {
+                data: std::sync::Mutex::new(vec![
+                    serde_json::json!({"id": 1, "name": "Alice"}),
+                    serde_json::json!({"id": 2, "name": "Bob"}),
+                ]),
+            }
+        }
+
+        fn len(&self) -> usize {
+            self.data.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl InsertableDataSet<User> for MockDataSet {
+        async fn insert(&self, record: User) -> Result<()> {
+            let value = serde_json::to_value(record)
+                .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+            self.data.lock().unwrap().push(value);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl WritableDataSet<User> for MockDataSet {
+        async fn update<F>(&self, callback: F) -> Result<()>
+        where
+            F: Fn(&mut User) + Send + Sync,
+        {
+            let mut data = self.data.lock().unwrap();
+            for value in data.iter_mut() {
+                if let Ok(mut record) = serde_json::from_value::<User>(value.clone()) {
+                    callback(&mut record);
+                    *value = serde_json::to_value(record)
+                        .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+                }
+            }
+            Ok(())
+        }
+
+        async fn delete(&self) -> Result<()> {
+            self.data.lock().unwrap().clear();
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_user() {
+        let dataset = MockDataSet::new();
+
+        let result = dataset
+            .update(|user| {
+                user.name = format!("{} (Updated)", user.name);
+            })
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let dataset = MockDataSet::new();
+        assert!(dataset.len() > 0);
+
+        let result = dataset.delete().await;
+        assert!(result.is_ok());
+        assert_eq!(dataset.len(), 0);
+    }
+}

--- a/vantage-dataset/src/im/insertable.rs
+++ b/vantage-dataset/src/im/insertable.rs
@@ -1,0 +1,48 @@
+use async_trait::async_trait;
+use serde::{Serialize, de::DeserializeOwned};
+
+use crate::{
+    dataset::{DataSetError, InsertableDataSet, Result},
+    im::Table,
+};
+
+#[async_trait]
+impl<T> InsertableDataSet<T> for Table<T>
+where
+    T: Serialize + DeserializeOwned + Send + Sync,
+{
+    async fn insert(&self, record: T) -> Result<()> {
+        // Serialize record to JSON
+        let mut value = serde_json::to_value(record)
+            .map_err(|e| DataSetError::other(format!("Serialization error: {}", e)))?;
+
+        // Extract ID from record if present, otherwise generate random ID
+        let id = if let Some(record_id) = value.get("id") {
+            if record_id.is_null() {
+                self.generate_id()
+            } else if let Some(id_str) = record_id.as_str() {
+                id_str.to_string()
+            } else if let Some(id_num) = record_id.as_u64() {
+                id_num.to_string()
+            } else {
+                self.generate_id()
+            }
+        } else {
+            self.generate_id()
+        };
+
+        // Remove id from the stored record since it's in the key
+        if let serde_json::Value::Object(ref mut map) = value {
+            map.remove("id");
+        }
+
+        // Get current table and insert record
+        let mut table = self.data_source.get_or_create_table(&self.table_name);
+        table.insert(id, value);
+
+        // Update the table in data source
+        self.data_source.update_table(&self.table_name, table);
+
+        Ok(())
+    }
+}

--- a/vantage-dataset/src/im/mod.rs
+++ b/vantage-dataset/src/im/mod.rs
@@ -1,0 +1,218 @@
+// src/im/mod.rs
+
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+pub mod insertable;
+pub mod readable;
+pub mod table;
+pub use table::Table;
+
+/// ImDataSource stores tables in memory using IndexMap for ordered iteration
+#[derive(Debug, Clone)]
+pub struct ImDataSource {
+    // table_name -> IndexMap<id, serialized_record>
+    tables: Arc<Mutex<HashMap<String, IndexMap<String, serde_json::Value>>>>,
+}
+
+impl ImDataSource {
+    pub fn new() -> Self {
+        Self {
+            tables: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn get_or_create_table(&self, table_name: &str) -> IndexMap<String, serde_json::Value> {
+        let mut tables = self.tables.lock().unwrap();
+        tables
+            .entry(table_name.to_string())
+            .or_insert_with(IndexMap::new)
+            .clone()
+    }
+
+    fn update_table(&self, table_name: &str, table: IndexMap<String, serde_json::Value>) {
+        let mut tables = self.tables.lock().unwrap();
+        tables.insert(table_name.to_string(), table);
+    }
+}
+
+impl Default for ImDataSource {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        dataset::{InsertableDataSet, ReadableDataSet},
+        im::table::Table,
+    };
+
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    struct User {
+        id: Option<String>,
+        name: String,
+        email: String,
+        age: u32,
+    }
+
+    #[tokio::test]
+    async fn test_insert_and_get() {
+        let data_source = ImDataSource::new();
+        let users = Table::<User>::new(&data_source, "users");
+
+        // Insert users
+        let user1 = User {
+            id: Some("user-1".to_string()),
+            name: "Alice".to_string(),
+            email: "alice@example.com".to_string(),
+            age: 30,
+        };
+        let user2 = User {
+            id: None, // This will get auto-generated ID
+            name: "Bob".to_string(),
+            email: "bob@example.com".to_string(),
+            age: 25,
+        };
+
+        users.insert(user1.clone()).await.unwrap();
+        users.insert(user2.clone()).await.unwrap();
+
+        // Get all users
+        let all_users: Vec<User> = users.get().await.unwrap();
+        assert_eq!(all_users.len(), 2);
+
+        // Order should be maintained (Alice first, Bob second)
+        assert_eq!(all_users[0].name, "Alice");
+        assert_eq!(all_users[0].id, Some("user-1".to_string()));
+        assert_eq!(all_users[1].name, "Bob");
+        assert!(all_users[1].id.is_some()); // Bob should have auto-generated ID
+    }
+
+    #[tokio::test]
+    async fn test_get_some() {
+        let data_source = ImDataSource::new();
+        let users = Table::<User>::new(&data_source, "users");
+
+        let user = User {
+            id: Some("charlie-123".to_string()),
+            name: "Charlie".to_string(),
+            email: "charlie@example.com".to_string(),
+            age: 35,
+        };
+
+        users.insert(user.clone()).await.unwrap();
+
+        // Get first user
+        let first_user: User = users.get_some().await.unwrap().unwrap();
+        assert_eq!(first_user.name, "Charlie");
+        assert_eq!(first_user.id, Some("charlie-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_empty_table() {
+        let data_source = ImDataSource::new();
+        let users = Table::<User>::new(&data_source, "empty_users");
+
+        // Get from empty table should return empty vec
+        let all_users: Vec<User> = users.get().await.unwrap();
+        assert_eq!(all_users.len(), 0);
+
+        // Get some from empty table should return error
+        let result = users.get_some().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_multiple_tables() {
+        let data_source = ImDataSource::new();
+        let users = Table::<User>::new(&data_source, "users");
+
+        #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+        struct Product {
+            id: Option<String>,
+            name: String,
+            price: f64,
+        }
+
+        let products = Table::<Product>::new(&data_source, "products");
+
+        // Insert into both tables
+        users
+            .insert(User {
+                id: None,
+                name: "Alice".to_string(),
+                email: "alice@example.com".to_string(),
+                age: 30,
+            })
+            .await
+            .unwrap();
+
+        products
+            .insert(Product {
+                id: Some("laptop-1".to_string()),
+                name: "Laptop".to_string(),
+                price: 999.99,
+            })
+            .await
+            .unwrap();
+
+        // Each table should have its own records
+        let all_users: Vec<User> = users.get().await.unwrap();
+        let all_products: Vec<Product> = products.get().await.unwrap();
+
+        assert_eq!(all_users.len(), 1);
+        assert_eq!(all_products.len(), 1);
+        assert_eq!(all_users[0].name, "Alice");
+        assert!(all_users[0].id.is_some()); // Auto-generated ID
+        assert_eq!(all_products[0].name, "Laptop");
+        assert_eq!(all_products[0].id, Some("laptop-1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_empty_string_id() {
+        let data_source = ImDataSource::new();
+        let users = Table::<User>::new(&data_source, "users");
+
+        // Insert user with empty string ID (should be preserved as valid ID)
+        let user = User {
+            id: Some("".to_string()),
+            name: "Empty ID User".to_string(),
+            email: "empty@example.com".to_string(),
+            age: 25,
+        };
+
+        users.insert(user).await.unwrap();
+
+        // Get the user back
+        let retrieved_user = users.get_some().await.unwrap().unwrap();
+        assert_eq!(retrieved_user.name, "Empty ID User");
+        assert_eq!(retrieved_user.id, Some("".to_string())); // Empty string should be preserved
+    }
+
+    #[tokio::test]
+    async fn test_import() -> Result<(), Box<dyn std::error::Error>> {
+        let data_source = ImDataSource::new();
+        let users1 = Table::<User>::new(&data_source, "users1");
+        let mut users2 = Table::<User>::new(&data_source, "users2");
+
+        // Insert user with empty string ID (should be preserved as valid ID)
+        let user = User {
+            id: None,
+            name: "Empty ID User".to_string(),
+            email: "empty@example.com".to_string(),
+            age: 25,
+        };
+
+        users1.insert(user).await.unwrap();
+        let expected_data = users1.get().await?;
+        users2.import(users1).await.unwrap();
+        assert_eq!(expected_data, users2.get().await?);
+        Ok(())
+    }
+}

--- a/vantage-dataset/src/im/readable.rs
+++ b/vantage-dataset/src/im/readable.rs
@@ -1,0 +1,62 @@
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+
+use crate::{
+    dataset::{DataSetError, ReadableDataSet, Result},
+    im::Table,
+};
+
+#[async_trait]
+impl<T> ReadableDataSet<T> for Table<T>
+where
+    T: DeserializeOwned + Send + Sync,
+{
+    async fn get(&self) -> Result<Vec<T>> {
+        self.get_as().await
+    }
+    async fn get_some(&self) -> Result<Option<T>> {
+        self.get_some_as().await
+    }
+    async fn get_as<U>(&self) -> Result<Vec<U>>
+    where
+        U: DeserializeOwned,
+    {
+        let table = self.data_source.get_or_create_table(&self.table_name);
+        let mut records = Vec::new();
+
+        for (id, value) in table.iter() {
+            // Add the id field to the record for deserialization
+            let mut value_with_id = value.clone();
+            if let serde_json::Value::Object(ref mut map) = value_with_id {
+                map.insert("id".to_string(), serde_json::Value::String(id.clone()));
+            }
+
+            let record: U = serde_json::from_value(value_with_id)
+                .map_err(|e| DataSetError::other(format!("Deserialization error: {}", e)))?;
+            records.push(record);
+        }
+
+        Ok(records)
+    }
+
+    async fn get_some_as<U>(&self) -> Result<Option<U>>
+    where
+        U: DeserializeOwned,
+    {
+        let table = self.data_source.get_or_create_table(&self.table_name);
+
+        if let Some((id, value)) = table.iter().next() {
+            // Add the id field to the record for deserialization
+            let mut value_with_id = value.clone();
+            if let serde_json::Value::Object(ref mut map) = value_with_id {
+                map.insert("id".to_string(), serde_json::Value::String(id.clone()));
+            }
+
+            let record: U = serde_json::from_value(value_with_id)
+                .map_err(|e| DataSetError::other(format!("Deserialization error: {}", e)))?;
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/vantage-dataset/src/im/table.rs
+++ b/vantage-dataset/src/im/table.rs
@@ -1,0 +1,66 @@
+use serde::{Serialize, de::DeserializeOwned};
+use uuid::Uuid;
+
+use crate::{
+    dataset::{DataSetError, ReadableDataSet, Result},
+    im::ImDataSource,
+};
+
+/// Table represents a typed table in the ImDataSource
+pub struct Table<T> {
+    pub(super) data_source: ImDataSource,
+    pub(super) table_name: String,
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T> Table<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    pub fn new(data_source: &ImDataSource, table_name: &str) -> Self {
+        Self {
+            data_source: data_source.clone(),
+            table_name: table_name.to_string(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    pub fn generate_id(&self) -> String {
+        Uuid::new_v4().to_string()
+    }
+
+    pub async fn import(&mut self, ds: impl ReadableDataSet<T>) -> Result<()> {
+        let mut table = self.data_source.get_or_create_table(&self.table_name);
+        table.clear();
+
+        for i in ds.get().await?.into_iter() {
+            let mut value = serde_json::to_value(i)
+                .map_err(|e| DataSetError::Other(format!("Serialization error: {}", e)))?;
+
+            // Extract ID from record if present, otherwise generate random ID
+            let id = if let Some(record_id) = value.get("id") {
+                if record_id.is_null() {
+                    self.generate_id()
+                } else if let Some(id_str) = record_id.as_str() {
+                    id_str.to_string()
+                } else if let Some(id_num) = record_id.as_u64() {
+                    id_num.to_string()
+                } else {
+                    self.generate_id()
+                }
+            } else {
+                self.generate_id()
+            };
+
+            // Remove id from the stored record since it's in the key
+            if let serde_json::Value::Object(ref mut map) = value {
+                map.remove("id");
+            }
+
+            table.insert(id, value);
+        }
+
+        self.data_source.update_table(&self.table_name, table);
+        Ok(())
+    }
+}

--- a/vantage-dataset/src/lib.rs
+++ b/vantage-dataset/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod dataset;
+pub mod im;


### PR DESCRIPTION
a new `vantage-dataset` crate which introduces protocol for generic datasets. This adds 3 main traits:
 - ReadableDataSet
 - WritableDataSet
 - InsertableDataSet

Each of the above is associated with an entity record and can be interacted with in either typed (get()) or untyped (get_as()) way. 

Also vantage-dataset introduces `im` , IndexMap which implemetns insertable and readable and can be used as a cache. More changes will be coming after.  