### PR TITLE
add with_* methods into selectable trait.

### DIFF
--- a/vantage-expressions/src/protocol/selectable.rs
+++ b/vantage-expressions/src/protocol/selectable.rs
@@ -24,4 +24,53 @@ pub trait Selectable: Send + Sync + Debug + Into<OwnedExpression> {
     fn is_distinct(&self) -> bool;
     fn get_limit(&self) -> Option<i64>;
     fn get_skip(&self) -> Option<i64>;
+
+    // Default implementations for builder-style methods
+    fn with_source(mut self, source: impl Into<Expr>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::set_source(&mut self, source, None);
+        self
+    }
+
+    fn with_source_as(mut self, source: impl Into<Expr>, alias: impl Into<String>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::set_source(&mut self, source, Some(alias.into()));
+        self
+    }
+
+    fn with_condition(mut self, condition: OwnedExpression) -> Self
+    where
+        Self: Sized,
+    {
+        Self::add_where_condition(&mut self, condition);
+        self
+    }
+
+    fn with_order(mut self, field_or_expr: impl Into<Expr>, ascending: bool) -> Self
+    where
+        Self: Sized,
+    {
+        Self::add_order_by(&mut self, field_or_expr, ascending);
+        self
+    }
+
+    fn with_field(mut self, field: impl Into<String>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::add_field(&mut self, field);
+        self
+    }
+
+    fn with_expression(mut self, expression: OwnedExpression, alias: Option<String>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::add_expression(&mut self, expression, alias);
+        self
+    }
 }

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -148,25 +148,6 @@ impl SurrealSelect {
         self.from = targets;
         self
     }
-
-    pub fn with_source(mut self, source: impl Into<Expr>) -> Self {
-        self.set_source(source, None);
-        self
-    }
-    pub fn with_source_as(mut self, source: impl Into<Expr>, alias: impl Into<String>) -> Self {
-        self.set_source(source, Some(alias.into()));
-        self
-    }
-
-    pub fn with_condition(mut self, condition: OwnedExpression) -> Self {
-        self.add_where_condition(condition);
-        self
-    }
-
-    pub fn with_order(mut self, field_or_expr: impl Into<Expr>, ascending: bool) -> Self {
-        self.add_order_by(field_or_expr, ascending);
-        self
-    }
 }
 
 impl<T: QueryResult> SurrealSelect<T> {
@@ -174,14 +155,7 @@ impl<T: QueryResult> SurrealSelect<T> {
         self.fields = vec![];
         self
     }
-    pub fn with_field(mut self, field: impl Into<String>) -> Self {
-        Selectable::add_field(&mut self, field);
-        self
-    }
-    pub fn with_expression(mut self, expression: OwnedExpression, alias: Option<String>) -> Self {
-        Selectable::add_expression(&mut self, expression, alias);
-        self
-    }
+
     pub fn with_value(mut self) -> Self {
         self.single_value = true;
         self

--- a/vantage-table/src/columns.rs
+++ b/vantage-table/src/columns.rs
@@ -1,0 +1,49 @@
+use indexmap::IndexMap;
+use vantage_expressions::{DataSource, OwnedExpression};
+
+use super::{Entity, Table};
+
+/// Represents a table column with optional alias
+#[derive(Debug, Clone)]
+pub struct Column {
+    name: String,
+    alias: Option<String>,
+}
+
+impl Column {
+    /// Create a new column with the given name
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            alias: None,
+        }
+    }
+
+    /// Set an alias for this column
+    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
+        self.alias = Some(alias.into());
+        self
+    }
+
+    /// Get the column name
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the column alias if set
+    pub fn alias(&self) -> Option<&str> {
+        self.alias.as_deref()
+    }
+}
+
+impl<T: DataSource<OwnedExpression>, E: Entity> Table<T, E> {
+    /// Add a column to the table
+    pub fn add_column(&mut self, column: Column) {
+        self.columns.insert(column.name().to_string(), column);
+    }
+
+    /// Get all columns
+    pub fn columns(&self) -> &IndexMap<String, Column> {
+        &self.columns
+    }
+}

--- a/vantage-table/src/conditions.rs
+++ b/vantage-table/src/conditions.rs
@@ -1,0 +1,15 @@
+use vantage_expressions::{DataSource, OwnedExpression};
+
+use super::{Entity, Table};
+
+impl<T: DataSource<OwnedExpression>, E: Entity> Table<T, E> {
+    /// Add a condition to limit what records the table represents
+    pub fn add_condition(&mut self, condition: OwnedExpression) {
+        self.conditions.push(condition);
+    }
+
+    /// Get all conditions
+    pub fn conditions(&self) -> &[OwnedExpression] {
+        &self.conditions
+    }
+}

--- a/vantage-table/src/lib.rs
+++ b/vantage-table/src/lib.rs
@@ -31,10 +31,14 @@ use indexmap::IndexMap;
 use std::marker::PhantomData;
 use vantage_expressions::{OwnedExpression, protocol::selectable::Selectable};
 
+pub mod columns;
+pub mod conditions;
 pub mod readable;
 
 /// Re-export DataSource from vantage-expressions for convenience
 pub use vantage_expressions::protocol::datasource::DataSource;
+
+pub use crate::columns::Column;
 
 /// Trait for entities that can be associated with tables
 pub trait Entity {
@@ -44,39 +48,6 @@ pub trait Entity {
 /// Empty entity type for tables without a specific entity
 pub struct EmptyEntity;
 impl Entity for EmptyEntity {}
-
-/// Represents a table column with optional alias
-#[derive(Debug, Clone)]
-pub struct Column {
-    name: String,
-    alias: Option<String>,
-}
-
-impl Column {
-    /// Create a new column with the given name
-    pub fn new(name: impl Into<String>) -> Self {
-        Self {
-            name: name.into(),
-            alias: None,
-        }
-    }
-
-    /// Set an alias for this column
-    pub fn with_alias(mut self, alias: impl Into<String>) -> Self {
-        self.alias = Some(alias.into());
-        self
-    }
-
-    /// Get the column name
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    /// Get the column alias if set
-    pub fn alias(&self) -> Option<&str> {
-        self.alias.as_deref()
-    }
-}
 
 /// A table abstraction defined over a datasource and entity
 #[derive(Debug)]
@@ -125,30 +96,9 @@ impl<T: DataSource<OwnedExpression>, E: Entity> Table<T, E> {
             conditions: self.conditions,
         }
     }
-
-    /// Add a column to the table
-    pub fn add_column(&mut self, column: Column) {
-        self.columns.insert(column.name().to_string(), column);
-    }
-
-    /// Add a condition to limit what records the table represents
-    pub fn add_condition(&mut self, condition: OwnedExpression) {
-        self.conditions.push(condition);
-    }
-
     /// Get the table name
     pub fn table_name(&self) -> &str {
         &self.table_name
-    }
-
-    /// Get all columns
-    pub fn columns(&self) -> &IndexMap<String, Column> {
-        &self.columns
-    }
-
-    /// Get all conditions
-    pub fn conditions(&self) -> &[OwnedExpression] {
-        &self.conditions
     }
 
     /// Get the underlying data source


### PR DESCRIPTION
```
let select = SelectQuery()
   .with_field("foo");
 ```
 
 this usage pattern is now defined in a trait, so you don't have to implement it, unless you want additonal functionality.