### PR TITLE
Table::with_condition() and Table::count()

### DIFF
--- a/vantage-expressions/src/protocol/selectable.rs
+++ b/vantage-expressions/src/protocol/selectable.rs
@@ -73,4 +73,12 @@ pub trait Selectable: Send + Sync + Debug + Into<Expression> {
         Self::add_expression(&mut self, expression, alias);
         self
     }
+
+    fn with_limit(mut self, limit: Option<i64>, skip: Option<i64>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::set_limit(&mut self, limit, skip);
+        self
+    }
 }

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod protocol;
 pub mod select;
 
-use vantage_expressions::{IntoExpressive, Expression, expr};
+use vantage_expressions::{Expression, IntoExpressive, expr};
 
 pub use select::Select;
 

--- a/vantage-sql/src/select/mod.rs
+++ b/vantage-sql/src/select/mod.rs
@@ -195,10 +195,7 @@ impl Select {
                     }
                 })
                 .collect();
-            expr!(
-                "WITH {} ",
-                Expression::from_vec(with_expressions, ", ")
-            )
+            expr!("WITH {} ", Expression::from_vec(with_expressions, ", "))
         }
     }
 
@@ -211,10 +208,7 @@ impl Select {
                 .iter()
                 .map(|source| source.clone().into())
                 .collect();
-            expr!(
-                " FROM {}",
-                Expression::from_vec(from_expressions, ", ")
-            )
+            expr!(" FROM {}", Expression::from_vec(from_expressions, ", "))
         }
     }
 

--- a/vantage-surrealdb/src/associated_query.rs
+++ b/vantage-surrealdb/src/associated_query.rs
@@ -1,11 +1,13 @@
 use serde_json::Value;
 use std::marker::PhantomData;
-use vantage_expressions::AssociatedQueryable;
+use std::ops::Deref;
 use vantage_expressions::protocol::result::{self, QueryResult};
 use vantage_expressions::util::error::{Error, Result};
+use vantage_expressions::{AssociatedQueryable, Expression, Selectable};
 use vantage_table::Entity;
 
 use crate::select::SurrealSelect;
+use crate::surreal_return::SurrealReturn;
 use crate::{SurrealDB, protocol::SurrealQueriable};
 
 /// SurrealDB-specific trait for associated queries that can be executed
@@ -46,6 +48,106 @@ impl<Q: SurrealQueriable, R> SurrealAssociated<Q, R> {
 impl<T: QueryResult, R> SurrealAssociated<SurrealSelect<T>, R> {
     pub fn preview(&self) -> String {
         self.query.preview()
+    }
+}
+
+impl<Q: SurrealQueriable, R> Deref for SurrealAssociated<Q, R> {
+    type Target = Q;
+
+    fn deref(&self) -> &Self::Target {
+        &self.query
+    }
+}
+
+impl<Q: SurrealQueriable + Selectable, R: Send + Sync> Selectable for SurrealAssociated<Q, R> {
+    fn set_source(&mut self, source: impl Into<vantage_expressions::Expr>, alias: Option<String>) {
+        self.query.set_source(source, alias)
+    }
+
+    fn add_field(&mut self, field: impl Into<String>) {
+        self.query.add_field(field)
+    }
+
+    fn add_expression(
+        &mut self,
+        expression: vantage_expressions::Expression,
+        alias: Option<String>,
+    ) {
+        self.query.add_expression(expression, alias)
+    }
+
+    fn add_where_condition(&mut self, condition: vantage_expressions::Expression) {
+        self.query.add_where_condition(condition)
+    }
+
+    fn set_distinct(&mut self, distinct: bool) {
+        self.query.set_distinct(distinct)
+    }
+
+    fn add_order_by(
+        &mut self,
+        field_or_expr: impl Into<vantage_expressions::Expr>,
+        ascending: bool,
+    ) {
+        self.query.add_order_by(field_or_expr, ascending)
+    }
+
+    fn add_group_by(&mut self, expression: vantage_expressions::Expression) {
+        self.query.add_group_by(expression)
+    }
+
+    fn set_limit(&mut self, limit: Option<i64>, skip: Option<i64>) {
+        self.query.set_limit(limit, skip)
+    }
+
+    fn clear_fields(&mut self) {
+        self.query.clear_fields()
+    }
+
+    fn clear_where_conditions(&mut self) {
+        self.query.clear_where_conditions()
+    }
+
+    fn clear_order_by(&mut self) {
+        self.query.clear_order_by()
+    }
+
+    fn clear_group_by(&mut self) {
+        self.query.clear_group_by()
+    }
+
+    fn has_fields(&self) -> bool {
+        self.query.has_fields()
+    }
+
+    fn has_where_conditions(&self) -> bool {
+        self.query.has_where_conditions()
+    }
+
+    fn has_order_by(&self) -> bool {
+        self.query.has_order_by()
+    }
+
+    fn has_group_by(&self) -> bool {
+        self.query.has_group_by()
+    }
+
+    fn is_distinct(&self) -> bool {
+        self.query.is_distinct()
+    }
+
+    fn get_limit(&self) -> Option<i64> {
+        self.query.get_limit()
+    }
+
+    fn get_skip(&self) -> Option<i64> {
+        self.query.get_skip()
+    }
+}
+
+impl<Q: SurrealQueriable + Into<Expression>, R> Into<Expression> for SurrealAssociated<Q, R> {
+    fn into(self) -> Expression {
+        self.query.into()
     }
 }
 
@@ -134,6 +236,50 @@ impl AssociatedQueryable<Value> for SurrealAssociated<SurrealSelect<result::Sing
 
 #[async_trait::async_trait]
 impl SurrealAssociatedQueryable<Value> for SurrealAssociated<SurrealSelect<result::Single>, Value> {
+    async fn get_as_value(&self) -> Result<Value> {
+        let raw_result = self.query.get(&self.datasource).await;
+        Ok(raw_result)
+    }
+}
+
+// Implementation for SurrealReturn - returns Value
+#[async_trait::async_trait]
+impl AssociatedQueryable<Value> for SurrealAssociated<SurrealReturn, Value> {
+    async fn get(&self) -> Result<Value> {
+        let raw_result = self.query.get(&self.datasource).await;
+        Ok(raw_result)
+    }
+}
+
+#[async_trait::async_trait]
+impl SurrealAssociatedQueryable<Value> for SurrealAssociated<SurrealReturn, Value> {
+    async fn get_as_value(&self) -> Result<Value> {
+        let raw_result = self.query.get(&self.datasource).await;
+        Ok(raw_result)
+    }
+}
+
+// Implementation for SurrealReturn - returns i64 (for count queries)
+#[async_trait::async_trait]
+impl AssociatedQueryable<i64> for SurrealAssociated<SurrealReturn, i64> {
+    async fn get(&self) -> Result<i64> {
+        let raw_result = self.query.get(&self.datasource).await;
+        // SurrealDB count returns [number], so extract the first element
+        if let Value::Array(ref arr) = raw_result {
+            if let Some(Value::Number(num)) = arr.first() {
+                if let Some(count) = num.as_i64() {
+                    return Ok(count);
+                }
+            }
+        }
+        Err(Error::new(
+            "Failed to parse count result as i64".to_string(),
+        ))
+    }
+}
+
+#[async_trait::async_trait]
+impl SurrealAssociatedQueryable<i64> for SurrealAssociated<SurrealReturn, i64> {
     async fn get_as_value(&self) -> Result<Value> {
         let raw_result = self.query.get(&self.datasource).await;
         Ok(raw_result)

--- a/vantage-surrealdb/src/field_projection.rs
+++ b/vantage-surrealdb/src/field_projection.rs
@@ -118,11 +118,7 @@ impl FieldProjection {
     ///
     /// * `expression` - The expression to evaluate for this field
     /// * `alias` - The field name/alias in the resulting object
-    pub fn add_expression(
-        &mut self,
-        expression: impl Into<Expression>,
-        alias: impl Into<String>,
-    ) {
+    pub fn add_expression(&mut self, expression: impl Into<Expression>, alias: impl Into<String>) {
         self.fields
             .push(FieldProjectionField::new(alias, expression));
     }

--- a/vantage-surrealdb/src/identifier.rs
+++ b/vantage-surrealdb/src/identifier.rs
@@ -2,7 +2,7 @@
 //!
 //! doc wip
 
-use vantage_expressions::{IntoExpressive, Expression, expr};
+use vantage_expressions::{Expression, IntoExpressive, expr};
 
 use crate::operation::Expressive;
 

--- a/vantage-surrealdb/src/select/mod.rs
+++ b/vantage-surrealdb/src/select/mod.rs
@@ -405,7 +405,7 @@ impl SurrealSelect<result::Rows> {
         SurrealReturn::new(Sum::new(query.expr()).into()).into()
     }
     pub fn as_count(self) -> SurrealReturn {
-        let result = self.only_expression(expr!("*"));
+        let result = self.only_expression(expr!("id"));
         SurrealReturn::new(Fx::new("count", vec![result.expr()]).into()).into()
     }
     pub fn only_expression(self, expr: Expression) -> SurrealSelect<result::List> {

--- a/vantage-surrealdb/src/table_ext.rs
+++ b/vantage-surrealdb/src/table_ext.rs
@@ -1,7 +1,10 @@
 use vantage_expressions::{expr, protocol::selectable::Selectable};
 use vantage_table::{Entity, Table};
 
-use crate::{SurrealDB, associated_query::SurrealAssociated, select::SurrealSelect};
+use crate::{
+    SurrealDB, associated_query::SurrealAssociated, select::SurrealSelect,
+    surreal_return::SurrealReturn,
+};
 use vantage_expressions::protocol::result;
 
 /// Extension trait for Table<SurrealDB, E> providing SurrealDB-specific query methods
@@ -27,6 +30,9 @@ pub trait SurrealTableExt<E: Entity> {
 
     /// Execute a select query and return the results directly
     async fn surreal_get(&self) -> vantage_expressions::util::error::Result<Vec<E>>;
+
+    /// Create a count query that returns the number of rows
+    fn surreal_count(&self) -> SurrealAssociated<SurrealReturn, i64>;
 }
 
 #[async_trait::async_trait]
@@ -130,5 +136,10 @@ impl<E: Entity> SurrealTableExt<E> for Table<SurrealDB, E> {
     async fn surreal_get(&self) -> vantage_expressions::util::error::Result<Vec<E>> {
         use vantage_expressions::AssociatedQueryable;
         self.select_surreal().get().await
+    }
+
+    fn surreal_count(&self) -> SurrealAssociated<SurrealReturn, i64> {
+        let count_return = self.select_surreal().query.as_count();
+        SurrealAssociated::new(count_return, self.data_source().clone())
     }
 }

--- a/vantage-surrealdb/tests/select.rs
+++ b/vantage-surrealdb/tests/select.rs
@@ -422,7 +422,7 @@ fn test_aggregation_methods() {
 
     assert_eq!(
         count_query.preview(),
-        "RETURN count(SELECT VALUE * FROM products WHERE active = true)"
+        "RETURN count(SELECT VALUE id FROM products WHERE active = true)"
     );
 }
 

--- a/vantage-table/src/columns.rs
+++ b/vantage-table/src/columns.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
-use vantage_expressions::{DataSource, Expression};
+use std::ops::Index;
+use vantage_expressions::{DataSource, Expression, IntoExpressive, expr};
 
 use super::{Entity, Table};
 
@@ -34,6 +35,128 @@ impl Column {
     pub fn alias(&self) -> Option<&str> {
         self.alias.as_deref()
     }
+
+    /// Create an expression from this column name
+    pub fn expr(&self) -> Expression {
+        expr!(self.name.clone())
+    }
+}
+
+/// Operations trait for columns, providing comparison and other SQL operations
+pub trait ColumnOperations {
+    /// Equal to comparison
+    fn eq(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// Not equal to comparison
+    fn ne(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// Greater than comparison
+    fn gt(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// Less than comparison
+    fn lt(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// Greater than or equal comparison
+    fn gte(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// Less than or equal comparison
+    fn lte(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// IN operator for lists
+    fn in_list(&self, items: impl Into<IntoExpressive<Expression>>) -> Expression;
+
+    /// IS NULL check
+    fn is_null(&self) -> Expression;
+
+    /// IS NOT NULL check
+    fn is_not_null(&self) -> Expression;
+
+    /// LIKE pattern matching
+    fn like(&self, pattern: impl Into<IntoExpressive<Expression>>) -> Expression;
+}
+
+impl ColumnOperations for Column {
+    fn eq(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} = {}", self, other.into())
+    }
+
+    fn ne(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} != {}", self, other.into())
+    }
+
+    fn gt(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} > {}", self, other.into())
+    }
+
+    fn lt(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} < {}", self, other.into())
+    }
+
+    fn gte(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} >= {}", self, other.into())
+    }
+
+    fn lte(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} <= {}", self, other.into())
+    }
+
+    fn in_list(&self, items: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} IN ({})", self, items.into())
+    }
+
+    fn is_null(&self) -> Expression {
+        expr!("{} IS NULL", self)
+    }
+
+    fn is_not_null(&self) -> Expression {
+        expr!("{} IS NOT NULL", self)
+    }
+
+    fn like(&self, pattern: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} LIKE {}", self, pattern.into())
+    }
+}
+
+impl ColumnOperations for &Column {
+    fn eq(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} = {}", *self, other.into())
+    }
+
+    fn ne(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} != {}", *self, other.into())
+    }
+
+    fn gt(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} > {}", *self, other.into())
+    }
+
+    fn lt(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} < {}", *self, other.into())
+    }
+
+    fn gte(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} >= {}", *self, other.into())
+    }
+
+    fn lte(&self, other: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} <= {}", *self, other.into())
+    }
+
+    fn in_list(&self, items: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} IN ({})", *self, items.into())
+    }
+
+    fn is_null(&self) -> Expression {
+        expr!("{} IS NULL", *self)
+    }
+
+    fn is_not_null(&self) -> Expression {
+        expr!("{} IS NOT NULL", *self)
+    }
+
+    fn like(&self, pattern: impl Into<IntoExpressive<Expression>>) -> Expression {
+        expr!("{} LIKE {}", *self, pattern.into())
+    }
 }
 
 impl From<String> for Column {
@@ -62,5 +185,111 @@ impl<T: DataSource<Expression>, E: Entity> Table<T, E> {
     /// Get all columns
     pub fn columns(&self) -> &IndexMap<String, Column> {
         &self.columns
+    }
+}
+
+impl<T: DataSource<Expression>, E: Entity> Index<&str> for Table<T, E> {
+    type Output = Column;
+
+    fn index(&self, index: &str) -> &Self::Output {
+        &self.columns[index]
+    }
+}
+
+impl Into<IntoExpressive<Expression>> for Column {
+    fn into(self) -> IntoExpressive<Expression> {
+        IntoExpressive::nested(self.expr())
+    }
+}
+
+impl Into<IntoExpressive<Expression>> for &Column {
+    fn into(self) -> IntoExpressive<Expression> {
+        IntoExpressive::nested(self.expr())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vantage_expressions::{expr, mocks::StaticDataSource};
+
+    #[test]
+    fn test_column_in_expression() {
+        let datasource = StaticDataSource::new(serde_json::json!([]));
+        let table = Table::new("users", datasource)
+            .with_column("is_vip")
+            .with_column("name");
+
+        let expr = expr!("{} = true", &table["is_vip"]);
+        assert_eq!(expr.preview(), "is_vip = true");
+    }
+
+    #[test]
+    fn test_column_operations_with_table() {
+        let datasource = StaticDataSource::new(serde_json::json!([]));
+        let table = Table::new("users", datasource)
+            .with_column("age")
+            .with_column("name")
+            .with_column("is_vip");
+
+        // Test column operations through table access
+        let age_col = table.column("age").unwrap();
+        let expr = age_col.gt(18);
+        assert_eq!(expr.preview(), "age > 18");
+
+        let name_col = table.column("name").unwrap();
+        let expr = name_col.eq("John");
+        assert_eq!(expr.preview(), "name = \"John\"");
+
+        // Test building conditions - create expressions first, then move table
+        let age_condition = age_col.gte(21);
+        let name_condition = name_col.like("J%");
+
+        let table_with_conditions = table
+            .with_condition(age_condition)
+            .with_condition(name_condition);
+
+        assert_eq!(table_with_conditions.conditions.len(), 2);
+    }
+
+    #[test]
+    fn test_column_operations() {
+        let col = Column::new("age");
+
+        // Test eq
+        let expr = col.eq(25);
+        assert_eq!(expr.preview(), "age = 25");
+
+        // Test gt
+        let expr = col.gt(18);
+        assert_eq!(expr.preview(), "age > 18");
+
+        // Test lt
+        let expr = col.lt(65);
+        assert_eq!(expr.preview(), "age < 65");
+
+        // Test in_list
+        let expr = col.in_list(vec![1, 2, 3]);
+        assert_eq!(expr.preview(), "age IN ([1,2,3])");
+
+        // Test is_null
+        let expr = col.is_null();
+        assert_eq!(expr.preview(), "age IS NULL");
+
+        // Test like
+        let expr = col.like("John%");
+        assert_eq!(expr.preview(), "age LIKE \"John%\"");
+    }
+
+    #[test]
+    fn test_column_operations_reference() {
+        let col = Column::new("name");
+
+        // Test with reference
+        let expr = (&col).eq("John");
+        assert_eq!(expr.preview(), "name = \"John\"");
+
+        let expr = (&col).ne("Jane");
+        assert_eq!(expr.preview(), "name != \"Jane\"");
     }
 }

--- a/vantage-table/src/lib.rs
+++ b/vantage-table/src/lib.rs
@@ -38,7 +38,7 @@ pub mod readable;
 /// Re-export DataSource from vantage-expressions for convenience
 pub use vantage_expressions::protocol::datasource::DataSource;
 
-pub use crate::columns::Column;
+pub use crate::columns::{Column, ColumnOperations};
 
 /// Trait for entities that can be associated with tables
 pub trait Entity:
@@ -52,7 +52,7 @@ pub struct EmptyEntity;
 impl Entity for EmptyEntity {}
 
 /// A table abstraction defined over a datasource and entity
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Table<T, E>
 where
     T: DataSource<Expression>,
@@ -106,6 +106,17 @@ impl<T: DataSource<Expression>, E: Entity> Table<T, E> {
     /// Get the underlying data source
     pub fn data_source(&self) -> &T {
         &self.data_source
+    }
+
+    /// Add a condition using the builder pattern
+    pub fn with_condition(mut self, condition: Expression) -> Self {
+        self.add_condition(condition);
+        self
+    }
+
+    /// Get a reference to a column for operations
+    pub fn column(&self, name: &str) -> Option<&Column> {
+        self.columns.get(name)
     }
 
     /// Create a select query with table configuration applied


### PR DESCRIPTION
Vantage 0.3 now has columns! And it's super easy to reference them for operations:

```rust
    let paying_clients = set_of_clients
        .clone()
        .with_condition(set_of_clients["is_paying_client"].eq(true));
```

and this PR also adds count():

```rust
    let count_result = paying_clients.surreal_count().get().await?;
    // i64 !
```
