### PR TITLE
add rest api vista driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,14 +4046,16 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
+ "ciborium",
  "indexmap",
  "reqwest",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tokio",
  "urlencoding",
  "vantage-cli-util",
@@ -4062,6 +4064,7 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "vantage-vista",
 ]
 
 [[package]]

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.1.4 — 2026-05-11
+
+Vista support behind the `vista` feature, so generic UIs that consume
+[`Vista`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/struct.Vista.html)
+can drive a REST endpoint the same way they drive SQLite or Mongo.
+
+```rust
+use vantage_api_client::RestApi;
+use vantage_vista::VistaFactory;
+
+let api = RestApi::builder("https://jsonplaceholder.typicode.com")
+    .response_shape(vantage_api_client::ResponseShape::BareArray)
+    .build();
+
+// Wrap a typed table.
+let typed = Table::<RestApi, EmptyEntity>::new("users", api.clone()).with_id_column("id");
+let vista = api.vista_factory().from_table(typed)?;
+
+// Or build it from YAML.
+let yaml = include_str!("users.vista.yaml");
+let vista = api.vista_factory().from_yaml(yaml)?;
+```
+
+- `RestApi::vista_factory()` returns a [`RestApiVistaFactory`](https://docs.rs/vantage-api-client/0.1.4/vantage_api_client/vista/struct.RestApiVistaFactory.html). The factory exposes `from_table<E>(Table<RestApi, E>) -> Result<Vista>` for the typed path and inherits `from_yaml(&str)` from [`VistaFactory`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.VistaFactory.html) for the schema path.
+- Read-only — `can_count: true`, `paginate_kind: PaginateKind::Offset`, every write capability `false`. Writes fall through to the default `TableShell` impl, which produces an `Unsupported` error consistent with the existing `TableSource` impl on `RestApi`.
+- YAML extras: per-table `api: { endpoint }` (path segment override when it differs from the spec name) and per-column `api: { field }` (JSON field alias). Base URL, auth header, response shape, and pagination convention stay on the factory's `RestApi` since they're per-deployment.
+- JSON ↔ CBOR translation at the row boundary via a `ciborium::Value::serialized` round-trip — same lossy edges (NaN, binary-as-string) you'd hit anywhere else and a no-op for vanilla REST traffic.
+- `add_eq_condition(field, CborValue)` translates back to a `serde_json::Value` and pushes via the existing `eq_condition` helper, so the condition lands in the URL the same way hand-built ones do — `?field=value`, multiple conditions AND together.
+
 ## 0.1.3 — 2026-05-09
 
 Opt-in [`RestApiBuilder::no_pagination()`](https://docs.rs/vantage-api-client/0.1.3/vantage_api_client/struct.RestApiBuilder.html#method.no_pagination) for APIs that don't paginate. ([#230](https://github.com/romaninsh/vantage/pull/230))

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,13 +1,18 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST API backends"
 
+[features]
+default = []
+vista = ["dep:vantage-vista", "dep:ciborium"]
+
 [dependencies]
 async-trait = "0.1"
+ciborium = { version = "0.2", features = ["std"], optional = true }
 indexmap = { version = "2", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -18,10 +23,13 @@ vantage-dataset = { version = "0.4.1", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.4", path = "../vantage-expressions" }
 vantage-table = { version = "0.4.2", path = "../vantage-table" }
 vantage-types = { version = "0.4", path = "../vantage-types", features = ["serde"] }
+vantage-vista = { version = "0.4.4", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
 tokio = { version = "1.48", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
+serde_yaml_ng = "0.10"
 urlencoding = "2.1"
 vantage-cli-util = { path = "../vantage-cli-util" }
+vantage-vista = { version = "0.4.4", path = "../vantage-vista" }

--- a/vantage-api-client/src/lib.rs
+++ b/vantage-api-client/src/lib.rs
@@ -1,7 +1,11 @@
 mod api;
 mod operation;
 mod table_source;
+#[cfg(feature = "vista")]
+pub mod vista;
 
 pub use api::{PaginationParams, ResponseShape, RestApi, RestApiBuilder};
 pub(crate) use operation::condition_to_query_param;
 pub use operation::eq_condition;
+#[cfg(feature = "vista")]
+pub use vista::{RestApiTableShell, RestApiVistaFactory};

--- a/vantage-api-client/src/vista/factory.rs
+++ b/vantage-api-client/src/vista/factory.rs
@@ -1,0 +1,252 @@
+//! `RestApiVistaFactory` — typed-table and YAML entry points, plus the
+//! `VistaFactory` trait impl. Read-only today (matching `RestApi`'s current
+//! `TableSource` impl), so the factory advertises only `can_count` and
+//! offset pagination.
+
+use serde_json::Value as JsonValue;
+use vantage_core::{Result, error};
+use vantage_table::column::core::Column as TableColumn;
+use vantage_table::column::flags::ColumnFlag;
+use vantage_table::table::Table;
+use vantage_table::traits::column_like::ColumnLike;
+use vantage_types::{EmptyEntity, Entity};
+use vantage_vista::{
+    Column as VistaColumn, NoExtras, PaginateKind, Vista, VistaCapabilities, VistaFactory,
+    VistaMetadata, flags as vista_flags,
+};
+
+use crate::RestApi;
+use crate::vista::source::RestApiTableShell;
+use crate::vista::spec::{RestApiColumnExtras, RestApiTableExtras, RestApiVistaSpec};
+
+pub struct RestApiVistaFactory {
+    api: RestApi,
+}
+
+impl RestApiVistaFactory {
+    pub fn new(api: RestApi) -> Self {
+        Self { api }
+    }
+
+    /// Wrap a typed table as a Vista. Column metadata is harvested from the
+    /// table; reads go through `Table`'s reading path.
+    pub fn from_table<E>(&self, table: Table<RestApi, E>) -> Result<Vista>
+    where
+        E: Entity<JsonValue> + 'static,
+    {
+        let metadata = metadata_from_table(&table);
+        let name = table.table_name().to_string();
+        let any_table = table.into_entity::<EmptyEntity>();
+
+        let source = RestApiTableShell::new(any_table, default_capabilities());
+        Ok(Vista::new(name, Box::new(source), metadata))
+    }
+
+    /// Build a `Table<RestApi, EmptyEntity>` from a spec. The endpoint path
+    /// comes from `api.endpoint` (or the spec name); per-column `api.field`
+    /// becomes the column alias so the JSON read path knows which field to
+    /// pull from each row.
+    pub fn table_from_spec(&self, spec: &RestApiVistaSpec) -> Result<Table<RestApi, EmptyEntity>> {
+        let endpoint = spec
+            .driver
+            .api
+            .as_ref()
+            .and_then(|m| m.endpoint.clone())
+            .unwrap_or_else(|| spec.name.clone());
+
+        let mut table = Table::<RestApi, EmptyEntity>::new(endpoint, self.api.clone());
+
+        for (name, col_spec) in &spec.columns {
+            table.add_column(build_column(name, col_spec)?);
+            if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
+                table.add_title_field(name);
+            }
+        }
+
+        let id_column = resolve_id_column(spec);
+        if !table.columns().contains_key(&id_column) {
+            return Err(error!(
+                "id column not present in spec.columns",
+                id = id_column
+            ));
+        }
+        table.set_id_field(&id_column);
+
+        Ok(table)
+    }
+}
+
+impl VistaFactory for RestApiVistaFactory {
+    type TableExtras = RestApiTableExtras;
+    type ColumnExtras = RestApiColumnExtras;
+    type ReferenceExtras = NoExtras;
+
+    fn build_from_spec(&self, spec: RestApiVistaSpec) -> Result<Vista> {
+        let vista_name = spec.name.clone();
+        let table = self.table_from_spec(&spec)?;
+        let mut vista = self.from_table(table)?;
+        vista.set_name(vista_name);
+        Ok(vista)
+    }
+}
+
+fn default_capabilities() -> VistaCapabilities {
+    VistaCapabilities {
+        can_count: true,
+        paginate_kind: PaginateKind::Offset,
+        ..VistaCapabilities::default()
+    }
+}
+
+pub(crate) fn resolve_id_column(spec: &RestApiVistaSpec) -> String {
+    if let Some(id) = &spec.id_column {
+        return id.clone();
+    }
+    for (name, col_spec) in &spec.columns {
+        if col_spec.flags.iter().any(|f| f == vista_flags::ID) {
+            return name.clone();
+        }
+    }
+    "id".to_string()
+}
+
+pub(crate) fn build_column(
+    name: &str,
+    col_spec: &vantage_vista::ColumnSpec<RestApiColumnExtras>,
+) -> Result<TableColumn<JsonValue>> {
+    let ty = col_spec.col_type.as_deref().unwrap_or("string");
+    let alias = col_spec
+        .driver
+        .api
+        .as_ref()
+        .and_then(|b| b.field.clone())
+        .filter(|s| s != name);
+    let hidden = col_spec.flags.iter().any(|f| f == vista_flags::HIDDEN);
+
+    let mut col = column_for_type(name, ty)?;
+    if let Some(alias) = alias {
+        col = col.with_alias(alias);
+    }
+    if hidden {
+        col = col.with_flag(ColumnFlag::Hidden);
+    }
+    Ok(col)
+}
+
+/// YAML type alias → typed `Column` (then erased to `Column<serde_json::Value>`).
+/// `json` covers arbitrary nested values — common in REST payloads.
+pub(crate) fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<JsonValue>> {
+    let col: TableColumn<JsonValue> = match ty {
+        "int" | "integer" | "i64" | "i32" => {
+            TableColumn::from_column(TableColumn::<i64>::new(name))
+        }
+        "float" | "double" | "f64" | "f32" => {
+            TableColumn::from_column(TableColumn::<f64>::new(name))
+        }
+        "bool" | "boolean" => TableColumn::from_column(TableColumn::<bool>::new(name)),
+        "string" | "text" | "str" => TableColumn::from_column(TableColumn::<String>::new(name)),
+        "json" => TableColumn::from_column(TableColumn::<JsonValue>::new(name)),
+        other => {
+            return Err(error!(
+                "Unknown YAML column type",
+                column = name,
+                ty = other.to_string()
+            ));
+        }
+    };
+    Ok(col)
+}
+
+pub(crate) fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
+where
+    T: vantage_table::traits::table_source::TableSource,
+    E: Entity<T::Value>,
+    T::Column<T::AnyType>: ColumnLike<T::AnyType>,
+{
+    let mut metadata = VistaMetadata::new();
+    for (name, col) in table.columns() {
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        if col.flags().contains(&ColumnFlag::Hidden) {
+            vc = vc.with_flag(vista_flags::HIDDEN);
+        }
+        metadata = metadata.with_column(vc);
+    }
+    if let Some(id_field) = table.id_field() {
+        metadata = metadata.with_id_column(id_field.name().to_string());
+    }
+    for title in table.title_fields() {
+        if let Some(col) = metadata.columns.get_mut(title) {
+            col.flags.push(vista_flags::TITLE.to_string());
+        }
+    }
+    metadata
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vantage_vista::ColumnSpec;
+
+    #[test]
+    fn build_column_uses_api_field_as_alias() {
+        let mut col_spec = ColumnSpec::<RestApiColumnExtras>::new().with_type("string");
+        col_spec.driver.api = Some(crate::vista::spec::RestApiColumnBlock {
+            field: Some("name".into()),
+        });
+        let col = build_column("full_name", &col_spec).unwrap();
+        assert_eq!(col.name(), "full_name");
+        assert_eq!(col.alias(), Some("name"));
+    }
+
+    #[test]
+    fn build_column_no_alias_when_field_matches_name() {
+        let mut col_spec = ColumnSpec::<RestApiColumnExtras>::new().with_type("string");
+        col_spec.driver.api = Some(crate::vista::spec::RestApiColumnBlock {
+            field: Some("name".into()),
+        });
+        let col = build_column("name", &col_spec).unwrap();
+        assert_eq!(col.alias(), None);
+    }
+
+    #[test]
+    fn resolve_id_column_prefers_explicit() {
+        let yaml = r#"
+name: users
+id_column: uuid
+columns:
+  uuid: { type: string }
+  email: { type: string, flags: [id] }
+"#;
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(resolve_id_column(&spec), "uuid");
+    }
+
+    #[test]
+    fn resolve_id_column_falls_back_to_flag() {
+        let yaml = r#"
+name: users
+columns:
+  email: { type: string, flags: [id] }
+  name: { type: string }
+"#;
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(resolve_id_column(&spec), "email");
+    }
+
+    #[test]
+    fn resolve_id_column_defaults_to_id() {
+        let yaml = r#"
+name: users
+columns:
+  name: { type: string }
+"#;
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(resolve_id_column(&spec), "id");
+    }
+
+    #[test]
+    fn column_for_type_rejects_unknown_alias() {
+        let err = column_for_type("foo", "blob").unwrap_err();
+        assert!(err.to_string().contains("Unknown YAML column type"));
+    }
+}

--- a/vantage-api-client/src/vista/mod.rs
+++ b/vantage-api-client/src/vista/mod.rs
@@ -1,0 +1,34 @@
+//! Vista bridge for the REST API backend.
+//!
+//! Construct a `Vista` from a typed `Table<RestApi, E>` via
+//! `RestApi::vista_factory()`, or from a YAML spec via
+//! `RestApiVistaFactory::from_yaml`. The YAML path builds a
+//! `Table<RestApi, EmptyEntity>` first and then routes through `from_table`
+//! — one construction path, one reading path.
+//!
+//! REST responses are `serde_json::Value`; vista's wire type is
+//! `ciborium::Value`. The shell translates each row at the boundary via a
+//! serde round-trip (`ciborium::Value::serialized` / `serde_json::to_value`).
+//! Conditions translate the other direction: `(field, CborValue)` → JSON
+//! value → `eq_condition`, which `RestApi::fetch_records` folds into the
+//! request URL query string.
+
+pub mod factory;
+pub mod source;
+pub mod spec;
+
+pub use factory::RestApiVistaFactory;
+pub use source::RestApiTableShell;
+pub use spec::{
+    RestApiColumnBlock, RestApiColumnExtras, RestApiTableBlock, RestApiTableExtras,
+    RestApiVistaSpec,
+};
+
+use crate::RestApi;
+
+impl RestApi {
+    /// Return a Vista factory bound to this REST API.
+    pub fn vista_factory(&self) -> RestApiVistaFactory {
+        RestApiVistaFactory::new(self.clone())
+    }
+}

--- a/vantage-api-client/src/vista/source.rs
+++ b/vantage-api-client/src/vista/source.rs
@@ -1,0 +1,109 @@
+//! `RestApiTableShell` — owns the typed `Table<RestApi, EmptyEntity>` and
+//! exposes it through the `TableShell` boundary.
+//!
+//! REST responses are JSON; vista's wire type is CBOR. Translation is a
+//! serde round-trip: `ciborium::Value::serialized` one way,
+//! `serde_json::to_value` the other. Same bytes that pass through
+//! `serde_json::Value` round-trip cleanly; the only lossy edges are NaN
+//! and binary-as-string, neither of which appears in vanilla REST traffic.
+//!
+//! `add_eq_condition` translates the CBOR value back to JSON and uses
+//! `eq_condition` (already present in the crate) to push an eq condition
+//! onto the wrapped table — `RestApi::fetch_records` then folds it into
+//! the URL query string the same way it does for hand-built conditions.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use serde_json::Value as JsonValue;
+use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{TableShell, Vista, VistaCapabilities};
+
+use crate::RestApi;
+use crate::eq_condition;
+
+pub struct RestApiTableShell {
+    pub(crate) table: Table<RestApi, EmptyEntity>,
+    pub(crate) capabilities: VistaCapabilities,
+}
+
+impl RestApiTableShell {
+    pub(crate) fn new(
+        table: Table<RestApi, EmptyEntity>,
+        capabilities: VistaCapabilities,
+    ) -> Self {
+        Self {
+            table,
+            capabilities,
+        }
+    }
+}
+
+fn json_to_cbor(v: JsonValue) -> CborValue {
+    CborValue::serialized(&v).unwrap_or(CborValue::Null)
+}
+
+fn cbor_to_json(v: CborValue) -> JsonValue {
+    serde_json::to_value(v).unwrap_or(JsonValue::Null)
+}
+
+fn json_record_to_cbor(record: Record<JsonValue>) -> Record<CborValue> {
+    record.into_iter().map(|(k, v)| (k, json_to_cbor(v))).collect()
+}
+
+#[async_trait]
+impl TableShell for RestApiTableShell {
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        let raw = self.table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, json_record_to_cbor(record)))
+            .collect())
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        Ok(self.table.get_value(id).await?.map(json_record_to_cbor))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        Ok(self
+            .table
+            .get_some_value()
+            .await?
+            .map(|(id, record)| (id, json_record_to_cbor(record))))
+    }
+
+    async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
+        Ok(self.table.list_values().await?.len() as i64)
+    }
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        if !self.table.columns().contains_key(field) {
+            return Err(error!("Unknown column for eq condition", field = field));
+        }
+        let json = cbor_to_json(value.clone());
+        self.table.add_condition(eq_condition(field, json));
+        Ok(())
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "rest-api"
+    }
+}

--- a/vantage-api-client/src/vista/source.rs
+++ b/vantage-api-client/src/vista/source.rs
@@ -31,10 +31,7 @@ pub struct RestApiTableShell {
 }
 
 impl RestApiTableShell {
-    pub(crate) fn new(
-        table: Table<RestApi, EmptyEntity>,
-        capabilities: VistaCapabilities,
-    ) -> Self {
+    pub(crate) fn new(table: Table<RestApi, EmptyEntity>, capabilities: VistaCapabilities) -> Self {
         Self {
             table,
             capabilities,
@@ -51,7 +48,10 @@ fn cbor_to_json(v: CborValue) -> JsonValue {
 }
 
 fn json_record_to_cbor(record: Record<JsonValue>) -> Record<CborValue> {
-    record.into_iter().map(|(k, v)| (k, json_to_cbor(v))).collect()
+    record
+        .into_iter()
+        .map(|(k, v)| (k, json_to_cbor(v)))
+        .collect()
 }
 
 #[async_trait]

--- a/vantage-api-client/src/vista/spec.rs
+++ b/vantage-api-client/src/vista/spec.rs
@@ -1,0 +1,129 @@
+//! YAML-facing types for the REST API Vista driver.
+//!
+//! `base_url`, auth header, response shape and pagination convention stay on
+//! the factory's `RestApi` — they're per-deployment, not per-table, and don't
+//! belong in checked-in YAML. The per-table block only carries the endpoint
+//! path when it differs from the spec name.
+
+use serde::{Deserialize, Serialize};
+use vantage_vista::{NoExtras, VistaSpec};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestApiTableExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api: Option<RestApiTableBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestApiTableBlock {
+    /// Endpoint path segment when it differs from the spec name. Joined to
+    /// the factory's `RestApi.base_url` — same shape `RestApi::endpoint_url`
+    /// would build for any other table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestApiColumnExtras {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api: Option<RestApiColumnBlock>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestApiColumnBlock {
+    /// JSON field name when it differs from the spec column name. Becomes the
+    /// column's alias so reads/writes target the underlying field while the
+    /// vista surfaces it under the spec name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
+pub type RestApiVistaSpec = VistaSpec<RestApiTableExtras, RestApiColumnExtras, NoExtras>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_parses_into_rest_api_vista_spec() {
+        let yaml = r#"
+name: comments
+columns:
+  id:
+    type: int
+    flags: [id]
+  postId:
+    type: int
+  body:
+    type: string
+    flags: [title]
+api:
+  endpoint: comments
+"#;
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(spec.name, "comments");
+        assert_eq!(spec.columns.len(), 3);
+        assert_eq!(
+            spec.driver
+                .api
+                .as_ref()
+                .and_then(|m| m.endpoint.as_deref()),
+            Some("comments")
+        );
+        assert_eq!(spec.columns["id"].col_type.as_deref(), Some("int"));
+        assert!(spec.columns["body"].flags.contains(&"title".to_string()));
+    }
+
+    #[test]
+    fn yaml_parses_column_field_alias() {
+        let yaml = r#"
+name: users
+columns:
+  id:
+    type: int
+    flags: [id]
+  full_name:
+    type: string
+    api:
+      field: name
+"#;
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert_eq!(
+            spec.columns["full_name"]
+                .driver
+                .api
+                .as_ref()
+                .and_then(|b| b.field.as_deref()),
+            Some("name")
+        );
+    }
+
+    #[test]
+    fn yaml_rejects_unknown_api_block_field() {
+        let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+api:
+  endpoint: users
+  bogus: 1
+"#;
+        let err = serde_yaml_ng::from_str::<RestApiVistaSpec>(yaml).unwrap_err();
+        assert!(err.to_string().contains("bogus") || err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn yaml_endpoint_defaults_to_spec_name_when_block_omitted() {
+        let yaml = r#"
+name: users
+columns:
+  id: { type: int, flags: [id] }
+"#;
+        let spec: RestApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        assert!(spec.driver.api.is_none());
+    }
+}

--- a/vantage-api-client/src/vista/spec.rs
+++ b/vantage-api-client/src/vista/spec.rs
@@ -68,10 +68,7 @@ api:
         assert_eq!(spec.name, "comments");
         assert_eq!(spec.columns.len(), 3);
         assert_eq!(
-            spec.driver
-                .api
-                .as_ref()
-                .and_then(|m| m.endpoint.as_deref()),
+            spec.driver.api.as_ref().and_then(|m| m.endpoint.as_deref()),
             Some("comments")
         );
         assert_eq!(spec.columns["id"].col_type.as_deref(), Some("int"));


### PR DESCRIPTION
REST API is the fifth driver to slot into `Vista`, joining csv / sqlite-postgres / mongo / surreal. Opt in with `features = ["vista"]`; non-vista users keep their existing dependency footprint.

```rust
let vista = api.vista_factory().from_table(users_table)?;
let rows = vista.list_values().await?;                          // CBOR records
vista.add_condition_eq("name", CborValue::Text("Biff".into()))?; // -> ?name=Biff
```

YAML loads through `from_yaml` with a per-table `api: { endpoint }` block (path segment override when it differs from the spec name) and per-column `api: { field }` (JSON field alias). Base URL, auth header, response shape, and pagination convention stay on the factory's `RestApi` — they're per-deployment, not per-table, and don't belong in checked-in YAML.

### Read-only, matching the underlying `TableSource`

`RestApi`'s `TableSource` impl is read-only today, and the shell mirrors that: `can_count: true`, `paginate_kind: Offset`, every write capability `false`. Writes fall through to the default [`TableShell`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html) impl, which produces an `Unsupported` error consistent with what `RestApi` already does — no new failure mode for callers.

### JSON ↔ CBOR at the row boundary

REST responses are `serde_json::Value`; vista's wire type is `ciborium::Value`. The shell translates each row at the boundary via a `ciborium::Value::serialized` round-trip — same lossy edges (NaN, binary-as-string) you'd hit anywhere else and a no-op for vanilla REST traffic. [`TableShell::add_eq_condition`](https://docs.rs/vantage-vista/0.4.4/vantage_vista/trait.TableShell.html#method.add_eq_condition) translates `(field, CborValue)` back to a `serde_json::Value` and pushes via the existing `eq_condition` helper, so the condition lands in the URL the same way hand-built ones do (`?field=value`, multiple conditions AND together).

### Versions

- `vantage-api-client` 0.1.3 → 0.1.4 (additive: new opt-in `vista` feature; default features unchanged)