### PR TITLE
fix rest query join and diorama refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4589,7 +4589,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4759,7 +4759,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.2 — unreleased
+
+- REST: fix URL construction when a table path already carries a query string
+  (e.g. `launches/?mode=detailed`). Pagination and condition params now join with
+  `&` instead of emitting a second `?`, which the server rejected (HTTP 500).
+
 ## 0.6.1 — unreleased
 
 - REST lazy-load: `RestApiBuilder::total_key`/`debug`, `RestApi::fetch_window_records`/`fetch_total`,

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.1"
+version = "0.6.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -376,11 +376,8 @@ impl RestApi {
                 (consumed, Vec::new())
             };
 
-        let url = format!(
-            "{}{}",
-            endpoint,
-            self.build_query_string(window, &conds, &query_consumed)
-        );
+        let query = self.build_query_string(window, &conds, &query_consumed);
+        let url = join_query(&endpoint, &query);
 
         let mut request = self.client.get(&url);
         if let Some(ref auth) = self.auth_header {
@@ -483,6 +480,17 @@ impl RestApi {
 
 fn urlencode(s: &str) -> String {
     urlencoding::encode(s).into_owned()
+}
+
+/// Append a `build_query_string` result (always opening with `?`, or empty)
+/// to an endpoint URL. The table path may itself carry a query string (e.g.
+/// `launches/?mode=detailed`), in which case the appended params must join
+/// with `&` — otherwise the URL gets two `?` and the API rejects it.
+fn join_query(endpoint: &str, query: &str) -> String {
+    match query.strip_prefix('?') {
+        Some(rest) if endpoint.contains('?') => format!("{endpoint}&{rest}"),
+        _ => format!("{endpoint}{query}"),
+    }
 }
 
 /// Walk an `Expression`'s parameter tree and force any `Deferred`
@@ -686,5 +694,61 @@ mod tests {
     fn no_pagination_suppresses_window_params() {
         let api = RestApi::builder("http://x").no_pagination().build();
         assert_eq!(qs(&api, Some((20, 10))), "");
+    }
+
+    #[test]
+    fn query_string_joins_plain_endpoint_with_question_mark() {
+        assert_eq!(
+            join_query("http://x/launches/", "?_page=1&_limit=10"),
+            "http://x/launches/?_page=1&_limit=10"
+        );
+    }
+
+    #[test]
+    fn query_string_joins_templated_endpoint_with_ampersand() {
+        // Endpoint already carries `?mode=detailed`; pagination must append
+        // with `&`, not a second `?`.
+        assert_eq!(
+            join_query("http://x/launches/?mode=detailed", "?offset=0&limit=1"),
+            "http://x/launches/?mode=detailed&offset=0&limit=1"
+        );
+    }
+
+    #[test]
+    fn empty_query_string_leaves_endpoint_untouched() {
+        assert_eq!(
+            join_query("http://x/launches/?mode=detailed", ""),
+            "http://x/launches/?mode=detailed"
+        );
+    }
+
+    /// Live regression for the double-`?` bug: a real fetch against the
+    /// Launch Library 2 dev API using a table path that already carries a
+    /// query string (`launches/?mode=detailed`). Before the `join_query`
+    /// fix the request URL was `…/launches/?mode=detailed?offset=0&limit=1`
+    /// and the server answered 500. Network-gated, so `#[ignore]`d:
+    /// `cargo test -p vantage-api-client -- --ignored query_string`.
+    #[tokio::test]
+    #[ignore = "hits the live Launch Library 2 dev API"]
+    async fn live_templated_table_path_fetches_rows() {
+        let api = RestApi::builder("https://lldev.thespacedevs.com/2.3.0")
+            .pagination_params(PaginationParams::skip_limit("offset", "limit"))
+            .response_shape(ResponseShape::Wrapped {
+                array_key: "results".into(),
+            })
+            .total_key("count")
+            .build();
+
+        let total = api
+            .fetch_total("launches/?mode=detailed", [])
+            .await
+            .expect("fetch_total");
+        assert!(total.is_some_and(|n| n > 0), "expected a positive count");
+
+        let rows = api
+            .fetch_window_records("launches/?mode=detailed", Some("id"), 0, 3, [])
+            .await
+            .expect("fetch_window_records");
+        assert_eq!(rows.len(), 3, "expected the requested 3-row window");
     }
 }

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.3 — unreleased
+
+- Non-blanking refresh for chunk-loaded (paged/lazy) table sceneries. A refresh now
+  re-fetches the last viewport in place — fresh rows overwrite the cached slots, and a
+  failed refetch leaves the existing rows untouched — instead of clearing the cache and
+  waiting for a refill. Previously any refill lag or error (e.g. a slow/`504` page) left
+  the visible rows blank while their count survived.
+
 ## 0.6.2 — unreleased
 
 Generic augmentation: wire a **second** Vista into a `Dio` to enrich each master row,

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -120,6 +120,7 @@ impl TableSceneryBuilder {
             rows: RwLock::new(Default::default()),
             id_to_idx: RwLock::new(HashMap::new()),
             total: RwLock::new(None),
+            last_viewport: RwLock::new(None),
             page_size,
             generation: AtomicU64::new(0),
             generation_tx: gen_tx,

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -157,6 +157,10 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         return;
     };
 
+    // Remember the window the grid last asked for so a refresh can re-fetch
+    // exactly it in place (see `TableSceneryState::refresh_loaded_viewport`).
+    *state.last_viewport.write().unwrap() = Some(visible.clone());
+
     let _ = dio_inner.event_bus.send(DioEvent::ViewportChanged {
         range: visible.clone(),
     });

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -25,43 +25,58 @@ pub(crate) async fn reload_loop(
 
         tokio::select! {
             _ = state.reload_notify.notified() => {
-                if let Err(e) = state.reseed_from_cache().await {
-                    tracing::error!(error = %e, "TableScenery reseed failed");
-                } else {
-                    state.bump_generation();
-                }
+                reseed(&state).await;
             }
             recv = bus.recv() => {
                 match recv {
+                    // `Refreshing` is the leading edge of `dio.refresh()`; the
+                    // refetch happens on the trailing `Invalidated`. Reseeding
+                    // here would only re-show the current cache, so a
+                    // chunk-loaded scenery ignores it.
+                    Ok(DioEvent::Refreshing) => {
+                        if !state.is_chunk_loaded() {
+                            reseed(&state).await;
+                        }
+                    }
                     Ok(DioEvent::RecordChanged { .. })
                     | Ok(DioEvent::RecordInserted { .. })
                     | Ok(DioEvent::RecordRemoved { .. })
-                    | Ok(DioEvent::Invalidated)
-                    | Ok(DioEvent::Refreshing) => {
-                        // v2 starts with full reseed — preserves the cache as
-                        // the source of truth for index assignments. Targeted
-                        // single-row updates (preserving chunk-loaded indices)
-                        // land in a follow-up iteration.
-                        if let Err(e) = state.reseed_from_cache().await {
-                            tracing::error!(error = %e, "TableScenery reseed failed");
-                        } else {
-                            state.bump_generation();
-                        }
+                    | Ok(DioEvent::Invalidated) => {
+                        refresh(&state).await;
                     }
                     Ok(DioEvent::WriteFailed { .. })
                     | Ok(DioEvent::ViewportChanged { .. })
                     | Ok(DioEvent::RangeLoaded { .. })
                     | Ok(DioEvent::LoadFailed { .. }) => {}
                     Err(broadcast::error::RecvError::Lagged(_)) => {
-                        if let Err(e) = state.reseed_from_cache().await {
-                            tracing::error!(error = %e, "TableScenery reseed failed");
-                        } else {
-                            state.bump_generation();
-                        }
+                        refresh(&state).await;
                     }
                     Err(broadcast::error::RecvError::Closed) => return,
                 }
             }
         }
+    }
+}
+
+/// Whole-set refresh. A chunk-loaded (paged/lazy) scenery re-fetches its
+/// last viewport in place — `force_load` overwrites each slot as fresh rows
+/// land and a failed refetch keeps the existing rows, so the grid never
+/// blanks. Other sceneries reseed the sparse map from the cache (which their
+/// `on_refresh` has already restaged).
+async fn refresh(state: &Arc<TableSceneryState>) {
+    if state.is_chunk_loaded() {
+        state.refresh_loaded_viewport();
+    } else {
+        reseed(state).await;
+    }
+}
+
+/// Rebuild the sparse map from a fresh cache snapshot, bumping generation on
+/// success. Preserves the cache as the source of truth for index assignments.
+async fn reseed(state: &Arc<TableSceneryState>) {
+    if let Err(e) = state.reseed_from_cache().await {
+        tracing::error!(error = %e, "TableScenery reseed failed");
+    } else {
+        state.bump_generation();
     }
 }

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -30,6 +30,12 @@ pub(crate) struct TableSceneryState {
     pub(crate) id_to_idx: RwLock<HashMap<String, usize>>,
     pub(crate) total: RwLock<Option<usize>>,
 
+    /// The most recent viewport range handed to the loader. A refresh on a
+    /// chunk-loaded scenery re-fetches exactly this range in place (see
+    /// [`refresh_loaded_viewport`](Self::refresh_loaded_viewport)). `None`
+    /// until the first viewport is set.
+    pub(crate) last_viewport: RwLock<Option<Range<usize>>>,
+
     pub(crate) page_size: usize,
 
     pub(crate) generation: AtomicU64,
@@ -147,6 +153,39 @@ impl TableSceneryState {
     pub(crate) fn range_fully_cached(&self, range: &Range<usize>) -> bool {
         let rows = self.rows.read().unwrap();
         range.clone().all(|i| rows.contains_key(&i))
+    }
+
+    /// True for a single-pass, chunk-loaded scenery (paged/lazy via
+    /// `on_load_chunk`). This is the variant whose refresh re-fetches the
+    /// visible window in place instead of reseeding from cache — reseeding
+    /// would only re-show whatever happens to be cached (and shows nothing
+    /// if the cache was just cleared).
+    pub(crate) fn is_chunk_loaded(&self) -> bool {
+        if self.two_pass {
+            return false;
+        }
+        self.dio_weak
+            .upgrade()
+            .map(|d| d.lens.callbacks.on_load_chunk.is_some())
+            .unwrap_or(false)
+    }
+
+    /// Re-fetch the last viewport in place so a refresh updates the visible
+    /// rows without blanking them: `force_load` overwrites each slot as the
+    /// fresh rows land, and a failed refetch leaves the existing rows
+    /// untouched (the loader never clears on error). No-op until a viewport
+    /// has been set.
+    pub(crate) fn refresh_loaded_viewport(&self) {
+        let range = self.last_viewport.read().unwrap().clone();
+        if let Some(range) = range {
+            super::loader::enqueue_viewport(
+                self,
+                ViewportRequest {
+                    range,
+                    force_load: true,
+                },
+            );
+        }
     }
 
     /// Largest cached index, +1 — the natural start for the next

--- a/vantage-diorama/tests/refresh.rs
+++ b/vantage-diorama/tests/refresh.rs
@@ -1,0 +1,162 @@
+//! Non-blanking refresh for chunk-loaded (paged/lazy) sceneries.
+//!
+//! A refresh re-fetches the last viewport in place: fresh rows overwrite the
+//! cached slots, and a *failed* refetch leaves the existing rows untouched —
+//! the grid never goes blank. Contrast with the old behaviour, where refresh
+//! cleared the cache and waited for a refill (any lag or error blanked the
+//! visible rows while their count survived).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Generation, Lens, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn rec(v: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r
+}
+
+fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get("v") {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+/// A master is required to build a Dio; this scenery loads from `backend`
+/// via `on_load_chunk`, not the master, so a bare MockShell suffices.
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("v", "String"))
+        .with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+/// Paged lens with NO `on_refresh` — refresh flows through the scenery's
+/// in-place viewport refetch, the path under test.
+fn paged_lens(
+    cache: std::path::PathBuf,
+    backend: Backend,
+    fail_next: Arc<AtomicBool>,
+) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            let fail = fail_next.clone();
+            async move {
+                if fail.swap(false, Ordering::SeqCst) {
+                    return Err(vantage_core::error!("simulated chunk failure"));
+                }
+                let rows = b.lock().unwrap().clone();
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+#[tokio::test]
+async fn refresh_updates_visible_rows_in_place() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("v1")),
+        ("b".into(), rec("v1")),
+    ]));
+    let fail_next = Arc::new(AtomicBool::new(false));
+    let lens = paged_lens(tmp.path().join("c.redb"), backend.clone(), fail_next);
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..2);
+    wait_for_gen(&mut gen_rx, g0).await;
+    assert_eq!(value(&scenery, 0).as_deref(), Some("v1"));
+
+    // Source changes underneath us; refresh must reflect it in place.
+    backend.lock().unwrap()[0].1 = rec("v2");
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g1).await;
+
+    assert_eq!(
+        value(&scenery, 0).as_deref(),
+        Some("v2"),
+        "refresh updates in place"
+    );
+    assert_eq!(scenery.row_count(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn failed_refresh_keeps_rows_instead_of_blanking() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let backend: Backend = Arc::new(Mutex::new(vec![("a".into(), rec("v1"))]));
+    let fail_next = Arc::new(AtomicBool::new(false));
+    let lens = paged_lens(
+        tmp.path().join("c.redb"),
+        backend.clone(),
+        fail_next.clone(),
+    );
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..1);
+    wait_for_gen(&mut gen_rx, g0).await;
+    assert_eq!(value(&scenery, 0).as_deref(), Some("v1"));
+
+    // The next chunk fetch will fail (e.g. a 504). The refresh must NOT
+    // clear the row — the old value has to survive.
+    backend.lock().unwrap()[0].1 = rec("v2");
+    fail_next.store(true, Ordering::SeqCst);
+    dio.refresh().await?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert_eq!(
+        value(&scenery, 0).as_deref(),
+        Some("v1"),
+        "a failed refresh must keep the previous value, not blank it"
+    );
+    assert!(
+        scenery.row(0).is_some(),
+        "row must not be cleared on a failed refresh"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Two small unrelated bug fixes bundled together.

**vantage-api-client** — REST URLs were getting a double `?` when a table path already carried a query string. `launches/?mode=detailed` became `…/launches/?mode=detailed?offset=0&limit=1`, which the server 500'd. New `join_query(endpoint, query)` checks for an existing `?` and joins with `&` when present. Covered by three unit tests plus a network-gated regression against Launch Library 2.

**vantage-diorama** — `dio.refresh()` on a chunk-loaded scenery used to wipe the cache and wait for a refill, so a slow or 504'd page left visible rows blank while `row_count()` still reported the old number. Refresh now re-fetches the last viewport in place via `force_load`; fresh rows overwrite each cached slot as they land, and a failed refetch leaves the existing rows untouched (the loader never clears on error).

Mechanism in short:

- `TableSceneryState` gains `last_viewport: RwLock<Option<Range<usize>>>`, recorded by the loader on every chunk fire.
- `is_chunk_loaded()` routes single-pass paged/lazy sceneries through the in-place path; two-pass / non-chunked ones still reseed from cache, unchanged.
- `refresh_loaded_viewport()` re-enqueues the last range with `force_load: true`.
- Reactor splits `Refreshing`/`Invalidated`: chunk-loaded → in-place; others → reseed.

New `vantage-diorama/tests/refresh.rs` covers both the in-place update and the failed-refetch-keeps-rows case.