### PR TITLE
vantage-sql: fetch_window + not_in/not_in_list operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -5,6 +5,9 @@
 - SQLite Vista now implements `fetch_window` (advertised via `can_fetch_window`), serving an
   arbitrary `[offset, offset + limit)` row window through `Pagination::window`. Previously only
   page-indexed `fetch_page` was available, so random-access window fetches were refused.
+- Regression test `vista_get_ref_preserves_with_expression_columns` covers `vantage-table` 0.6.4's
+  fix for computed columns surviving `get_ref` entity erasure — a typed child with a
+  `with_expression` now keeps that column when reached through a parent vista's `get_ref`.
 
 ## 0.6.0 — unreleased
 

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- SQLite Vista now implements `fetch_window` (advertised via `can_fetch_window`), serving an
+  arbitrary `[offset, offset + limit)` row window through `Pagination::window`. Previously only
+  page-indexed `fetch_page` was available, so random-access window fetches were refused.
+
 ## 0.6.0 — unreleased
 
 - Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## 0.6.1 — unreleased
+## 0.6.2
+
+### Added
+
+- `SqliteOperation`, `PostgresOperation` and `MysqlOperation` gained `not_in` and `not_in_list`,
+  mirroring the existing `in_` / `in_list` pair.
+
+## 0.6.1
 
 - SQLite Vista now implements `fetch_window` (advertised via `can_fetch_window`), serving an
   arbitrary `[offset, offset + limit)` row window through `Pagination::window`. Previously only
@@ -9,7 +16,7 @@
   fix for computed columns surviving `get_ref` entity erasure — a typed child with a
   `with_expression` now keeps that column when reached through a parent vista's `get_ref`.
 
-## 0.6.0 — unreleased
+## 0.6.2 — 2026-06-21
 
 - Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.
 
@@ -18,17 +25,17 @@
 ### Changed
 
 - `register_engine!` is split so its registrations live in a reusable
-  `__register_engine_onto(&mut Engine)`; the macro and `__create_engine` call it. Prepares the
-  SQL backend for the conventional Rhai-scripted reference traversal added in
-  `vantage-vista` 0.5.4. No behavior change for existing engine call sites.
+  `__register_engine_onto(&mut Engine)`; the macro and `__create_engine` call it. Prepares the SQL
+  backend for the conventional Rhai-scripted reference traversal added in `vantage-vista` 0.5.4. No
+  behavior change for existing engine call sites.
 
 ## 0.5.8 — 2026-06-06
 
 ### Changed
 
-- Tracks the `vantage-vista` thin refactor (0.5.3): dropped the obsolete `with_foreign`
-  vista integration test now that cross-persistence traversal lives in
-  `vantage-vista-factory`. No functional change to the SQL backends.
+- Tracks the `vantage-vista` thin refactor (0.5.3): dropped the obsolete `with_foreign` vista
+  integration test now that cross-persistence traversal lives in `vantage-vista-factory`. No
+  functional change to the SQL backends.
 
 ## 0.5.7 — 2026-06-02
 
@@ -36,8 +43,8 @@
 
 - Tables can be sourced from a sub-`SELECT` via `vantage-table`'s new `SelectSource`
   (`type Source = SelectSource<SqliteSelect>`), rendering `FROM (<select>) AS <alias>`.
-- SQLite vista specs accept a `sqlite.rhai:` block: a Rhai script that builds the vista's
-  source `SELECT` instead of pointing at a physical table. The resulting vista is read-only
+- SQLite vista specs accept a `sqlite.rhai:` block: a Rhai script that builds the vista's source
+  `SELECT` instead of pointing at a physical table. The resulting vista is read-only
   (insert/update/delete capabilities are cleared). Requires the `rhai` feature.
 
 ## 0.5.6 — 2026-06-01

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/condition.rs
+++ b/vantage-sql/src/condition.rs
@@ -268,6 +268,40 @@ macro_rules! define_sql_operation {
                 $condition::from_typed(expr)
             }
 
+            /// `field NOT IN (values_expression)`
+            fn not_in(&self, values: impl $crate::vantage_expressions::Expressive<T>) -> $condition
+            where
+                Self: Sized,
+            {
+                $crate::condition::build_sql_binary::<T, $any_type, $condition>(
+                    self,
+                    values,
+                    "{} NOT IN ({})",
+                )
+            }
+
+            /// `field NOT IN (a, b, c)` from a slice of scalar values
+            fn not_in_list<V: Into<T> + Clone>(&self, values: &[V]) -> $condition
+            where
+                Self: Sized,
+                T: Clone,
+            {
+                use $crate::vantage_expressions::Expression;
+                use $crate::vantage_expressions::traits::expressive::ExpressiveEnum;
+                let params: Vec<Expression<T>> = values
+                    .iter()
+                    .map(|v| Expression::new("{}", vec![ExpressiveEnum::Scalar(v.clone().into())]))
+                    .collect();
+                let expr: Expression<T> = Expression::new(
+                    "{} NOT IN ({})",
+                    vec![
+                        ExpressiveEnum::Nested(self.expr()),
+                        ExpressiveEnum::Nested(Expression::from_vec(params, ", ")),
+                    ],
+                );
+                $condition::from_typed(expr)
+            }
+
             /// `CAST(expr AS type_name)`
             fn cast(&self, type_name: &str) -> $condition
             where

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -74,6 +74,7 @@ impl SqliteVistaFactory {
                 can_search: true,
                 can_set_page_size: true,
                 can_fetch_page: true,
+                can_fetch_window: true,
                 can_fetch_next: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -277,6 +277,24 @@ where
             .collect())
     }
 
+    async fn fetch_window(
+        &self,
+        _vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        // Clone the wrapped table so this call's window doesn't disturb the
+        // shell's own condition / order / search state.
+        let mut window_table = self.table.clone();
+        window_table.set_pagination(Some(Pagination::window(offset as i64, limit as i64)));
+
+        let raw = window_table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect())
+    }
+
     async fn fetch_next(
         &self,
         _vista: &Vista,

--- a/vantage-sql/tests/sqlite/6_vista.rs
+++ b/vantage-sql/tests/sqlite/6_vista.rs
@@ -317,6 +317,56 @@ async fn vista_get_ref_has_many_via_row() -> TestResult {
     Ok(())
 }
 
+/// Regression: `with_expression` columns must survive reference traversal.
+/// `get_ref` resolves the child through `get_ref_from_row`, which erases the
+/// entity to `EmptyEntity`. Before the fix, `Table::into_entity` dropped the
+/// expression closures, so computed aggregates vanished from nested / drilldown
+/// rows while still appearing on the top-level table — silently returning
+/// fewer columns than the parent vista.
+#[tokio::test]
+async fn vista_get_ref_preserves_with_expression_columns() -> TestResult {
+    #[entity(SqliteType)]
+    #[derive(Debug, Clone, PartialEq, Default)]
+    struct Order {
+        client_id: String,
+        total: i64,
+    }
+
+    let db = setup_clients_orders().await;
+
+    let db_for_child = db.clone();
+    let clients = Table::<SqliteDB, EmptyEntity>::new("client", db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_many("orders", "client_id", move |_| {
+            // A *typed* child (entity = Order, not EmptyEntity) carrying a
+            // computed expression — get_ref will erase it to EmptyEntity.
+            Table::<SqliteDB, Order>::new("orders", db_for_child.clone())
+                .with_id_column("id")
+                .with_column_of::<String>("client_id")
+                .with_column_of::<i64>("total")
+                .with_expression("total_with_tax", |_| sqlite_expr!("\"total\" * 2"))
+        });
+
+    let mut clients = db.vista_factory().from_table(clients)?;
+    let (_, alice) = clients
+        .with_id(CborValue::Text("alice".into()))?
+        .get_some_value()
+        .await?
+        .expect("alice exists");
+
+    let alice_orders = clients.get_ref("orders", &alice)?;
+    let rows = alice_orders.list_values().await?;
+    assert_eq!(rows.len(), 2, "alice has 2 orders");
+    let o1 = rows.get("o1").expect("order o1");
+    assert_eq!(
+        o1.get("total_with_tax"),
+        Some(&CborValue::Integer(20i64.into())),
+        "computed expression must survive get_ref entity erasure"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn vista_list_references_surfaces_cardinality() -> TestResult {
     let db = setup_clients_orders().await;

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.4 — unreleased
+
+- `Pagination::window(offset, limit)` for random-access `[offset, offset + limit)` windows whose
+  offset need not be a multiple of the page size (`skip()` returns the offset verbatim). Backs
+  `Vista::fetch_window` on offset/limit-addressable drivers.
+
 ## 0.6.3 — unreleased
 
 - Added `ColumnFlag::Label` — hints a column is better shown as a small status tag attached to the

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -5,6 +5,12 @@
 - `Pagination::window(offset, limit)` for random-access `[offset, offset + limit)` windows whose
   offset need not be a multiple of the page size (`skip()` returns the offset verbatim). Backs
   `Vista::fetch_window` on offset/limit-addressable drivers.
+- `with_expression` computed columns now survive `into_entity` (and therefore reference traversal
+  that erases the entity to `EmptyEntity`, such as `get_ref_from_row`). Previously `into_entity`
+  dropped all expressions, so computed aggregates were present on a top-level table but silently
+  missing from its nested/drilldown rows. `ExpressionFn` is now stored entity-erased; `with_expression`
+  adapts the caller's `Fn(&Table<T, E>)` into it. Fixes the `get_ref_from_row` doc claim that
+  expressions are preserved.
 
 ## 0.6.3 — unreleased
 

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/pagination.rs
+++ b/vantage-table/src/pagination.rs
@@ -5,6 +5,10 @@ use vantage_expressions::traits::selectable::Selectable;
 pub struct Pagination {
     page: i64,
     items_per_page: i64,
+    /// Explicit skip for a random-access `[offset, offset+limit)` window. When
+    /// set, `skip()` returns it verbatim instead of deriving it from `page` —
+    /// so the offset need not be a multiple of the page size.
+    offset: Option<i64>,
 }
 
 impl Pagination {
@@ -13,6 +17,18 @@ impl Pagination {
         Self {
             page: page.max(1),
             items_per_page: items_per_page.max(1),
+            offset: None,
+        }
+    }
+
+    /// Create pagination for an explicit `[offset, offset + limit)` window
+    /// (random access). Unlike [`new`](Self::new), the offset is independent of
+    /// the page size, so any absolute row range maps directly onto a query.
+    pub fn window(offset: i64, limit: i64) -> Self {
+        Self {
+            page: 1,
+            items_per_page: limit.max(1),
+            offset: Some(offset.max(0)),
         }
     }
 
@@ -51,7 +67,7 @@ impl Pagination {
 
     /// Calculate skip/offset value for queries
     pub fn skip(&self) -> i64 {
-        (self.page - 1) * self.items_per_page
+        self.offset.unwrap_or((self.page - 1) * self.items_per_page)
     }
 
     /// Apply pagination to a select query
@@ -68,6 +84,7 @@ impl Default for Pagination {
         Self {
             page: 1,
             items_per_page: 50,
+            offset: None,
         }
     }
 }

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 use vantage_expressions::Expression;
-use vantage_types::Entity;
+use vantage_types::{EmptyEntity, Entity};
 
 use crate::{
     pagination::Pagination, references::Reference, sorting::SortDirection,
@@ -11,8 +11,15 @@ use crate::{
 };
 
 /// Type alias for expression closures stored on Table.
-pub type ExpressionFn<T, E> =
-    Arc<dyn Fn(&Table<T, E>) -> Expression<<T as TableSource>::Value> + Send + Sync>;
+///
+/// Stored against the entity-erased `Table<T, EmptyEntity>` rather than the
+/// concrete `Table<T, E>` so the closures survive [`Table::into_entity`] — an
+/// expression only ever reads entity-agnostic table state (columns and
+/// relations by name, conditions, subqueries), never the entity's typed fields.
+/// [`Table::with_expression`] adapts the caller's `Fn(&Table<T, E>)` into this
+/// shape; see [`Table::as_entity_erased`] for the soundness of the cast.
+pub type ExpressionFn<T> =
+    Arc<dyn Fn(&Table<T, EmptyEntity>) -> Expression<<T as TableSource>::Value> + Send + Sync>;
 
 #[derive(Clone)]
 pub struct Table<T, E>
@@ -30,7 +37,7 @@ where
     pub(super) next_order_id: i64,
     pub(super) refs: Option<IndexMap<String, Arc<dyn Reference>>>,
     pub(super) contained: Vec<crate::references::ContainedRelation<T>>,
-    pub(super) expressions: IndexMap<String, ExpressionFn<T, E>>,
+    pub(super) expressions: IndexMap<String, ExpressionFn<T>>,
     pub(super) pagination: Option<Pagination>,
     pub(super) title_field: Option<String>,
     pub(super) title_fields: Vec<String>,
@@ -59,7 +66,11 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         }
     }
 
-    /// Convert this table to use a different entity type
+    /// Convert this table to use a different entity type.
+    ///
+    /// Computed expressions are carried over — they're stored entity-erased
+    /// (see [`ExpressionFn`]), so aggregates survive reference traversal that
+    /// erases the entity to `EmptyEntity` (e.g. `get_ref_from_row`).
     pub fn into_entity<E2: Entity<T::Value>>(self) -> Table<T, E2> {
         Table {
             data_source: self.data_source,
@@ -72,12 +83,24 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             next_order_id: self.next_order_id,
             refs: self.refs,
             contained: self.contained,
-            expressions: IndexMap::new(),
+            expressions: self.expressions,
             pagination: self.pagination,
             title_field: self.title_field,
             title_fields: self.title_fields,
             id_field: self.id_field,
         }
+    }
+
+    /// Borrow this table as its entity-erased form `Table<T, EmptyEntity>`.
+    ///
+    /// `E` appears in `Table` only as `PhantomData<E>` (a zero-sized field), so
+    /// `Table<T, E>` and `Table<T, EmptyEntity>` are layout-identical and this
+    /// reinterpret is sound. Used to feed `self` to the entity-erased
+    /// [`ExpressionFn`] closures at evaluation time.
+    pub(crate) fn as_entity_erased(&self) -> &Table<T, EmptyEntity> {
+        // SAFETY: identical layout (E is PhantomData only); lifetime is tied to
+        // `&self`, and the borrow is shared/read-only.
+        unsafe { &*(self as *const Table<T, E> as *const Table<T, EmptyEntity>) }
     }
 
     /// Snapshot the table's relations as Vista references (name, target type,

--- a/vantage-table/src/table/impls/columns.rs
+++ b/vantage-table/src/table/impls/columns.rs
@@ -132,7 +132,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         T::Column<T::AnyType>: vantage_expressions::Expressive<T::Value>,
     {
         if let Some(expr_fn) = self.expressions.get(name) {
-            Some(expr_fn(self))
+            Some(expr_fn(self.as_entity_erased()))
         } else {
             use vantage_expressions::Expressive;
             self.columns.get(name).map(|c| c.expr())

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -474,8 +474,9 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         let wrapped: crate::table::base::ExpressionFn<T> =
             Arc::new(move |erased: &Table<T, vantage_types::EmptyEntity>| {
                 // SAFETY: layout-identical (E is PhantomData only); shared borrow.
-                let typed: &Table<T, E> =
-                    unsafe { &*(erased as *const Table<T, vantage_types::EmptyEntity> as *const Table<T, E>) };
+                let typed: &Table<T, E> = unsafe {
+                    &*(erased as *const Table<T, vantage_types::EmptyEntity> as *const Table<T, E>)
+                };
                 expr_fn(typed)
             });
         self.expressions.insert(name.to_string(), wrapped);

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -463,8 +463,22 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         mut self,
         name: &str,
         expr_fn: impl Fn(&Table<T, E>) -> Expression<T::Value> + Send + Sync + 'static,
-    ) -> Self {
-        self.expressions.insert(name.to_string(), Arc::new(expr_fn));
+    ) -> Self
+    where
+        T: 'static,
+        E: 'static,
+    {
+        // Adapt the caller's `Fn(&Table<T, E>)` into the entity-erased
+        // `ExpressionFn<T>` we store, so it survives `into_entity`. The closure
+        // never touches entity-typed fields, only name-keyed table state.
+        let wrapped: crate::table::base::ExpressionFn<T> =
+            Arc::new(move |erased: &Table<T, vantage_types::EmptyEntity>| {
+                // SAFETY: layout-identical (E is PhantomData only); shared borrow.
+                let typed: &Table<T, E> =
+                    unsafe { &*(erased as *const Table<T, vantage_types::EmptyEntity> as *const Table<T, E>) };
+                expr_fn(typed)
+            });
+        self.expressions.insert(name.to_string(), wrapped);
         self
     }
 

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -51,7 +51,7 @@ where
         // Add all columns as fields (or expressions if defined)
         for column in self.columns.values() {
             if let Some(expr_fn) = self.expressions.get(column.name()) {
-                let expr = expr_fn(self);
+                let expr = expr_fn(self.as_entity_erased());
                 self.data_source.add_select_column(
                     &mut select,
                     expr_any!("({})", (expr)),
@@ -69,7 +69,7 @@ where
         // Add expressions that don't correspond to any column
         for (name, expr_fn) in &self.expressions {
             if !self.columns.contains_key(name) {
-                let expr = expr_fn(self);
+                let expr = expr_fn(self.as_entity_erased());
                 self.data_source.add_select_column(
                     &mut select,
                     expr_any!("({})", (expr)),


### PR DESCRIPTION
Two SQL improvements on top of main:

- **SQLite Vista fetch_window**: implements `fetch_window` (advertised via `can_fetch_window`), serving an arbitrary `[offset, offset + limit)` row window through `Pagination::window`.
- **Preserve with_expression columns** across `into_entity` / `get_ref` (vantage-table 0.6.4 fix, regression test included).
- **`not_in` / `not_in_list`** added to `SqliteOperation`, `PostgresOperation`, and `MysqlOperation` via the `define_sql_operation!` macro, mirroring the existing `in_` / `in_list` pair.

Bumps `vantage-sql` to 0.6.2.