### PR TITLE
diorama: scriptable test source (latency, faults, live mutation)

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.6.3 — unreleased
 
+- Scriptable test source. `MockShell` gained live, by-ref dataset mutation
+  (`set_record` / `set_field` / `remove_record` / `clear_records`) so a test or
+  example can edit the upstream mid-run and have the next read/refresh observe
+  it. The BDD harness builds on this with virtual-time latency and counted
+  fault injection (`tests/features/source_control.feature`), giving the diorama
+  machinery a deterministic stand-in for a slow/failing/mutating transport —
+  no network required. Foundation for the upcoming async-native transport.
 - Non-blanking refresh for chunk-loaded (paged/lazy) table sceneries. A refresh now
   re-fetches the last viewport in place — fresh rows overwrite the cached slots, and a
   failed refetch leaves the existing rows untouched — instead of clearing the cache and

--- a/vantage-diorama/README_datasource.md
+++ b/vantage-diorama/README_datasource.md
@@ -269,6 +269,47 @@ If reads work, writes round-trip, and the Lens's `on_start` /`on_refresh` /
 test matrix (composition with other drivers, capability propagation, error
 surfaces) lives in `vantage-diorama/tests/`.
 
+### Scripting a fake source (latency, faults, live mutation)
+
+You rarely want a real network in a behavioural test — it's slow and
+non-deterministic. `MockShell` is the in-memory `TableShell` Diorama's own BDD
+suite drives, and it doubles as a **scriptable source**: its store is
+`Arc`-shared, so a clone taken before you box it into a `Vista` stays a live
+handle you can mutate mid-test to simulate an upstream that changed between
+reads.
+
+```rust
+use ciborium::Value as CborValue;
+use vantage_vista::{Vista, mocks::MockShell};
+
+// Seed, then keep a handle to the live store.
+let source = MockShell::new()
+    .with_metadata(my_metadata())
+    .with_record("42", record(&[("title", CborValue::Text("before".into()))]));
+let control = source.clone();                  // shares the same rows
+let master = Vista::new("items", Box::new(source));
+
+let dio = lens.make_dio(master).await?;
+let scenery = dio.table_scenery().open().await?;
+// ... first read sees "before" ...
+
+// Simulate the upstream changing, then reconcile:
+control.set_field("42", "title", CborValue::Text("after".into()));
+dio.refresh().await?;                           // re-fetches in place
+// ... the next read sees "after", and the grid never blanked ...
+
+control.remove_record("42");                    // row vanishes upstream
+control.set_record("99", record(&[/* … */]));   // a new row appears
+control.clear_records();                         // empty upstream
+```
+
+For **latency** and **injected failures** under deterministic virtual time, the
+BDD harness wraps the source's reads in a gate driven by `tokio::time::pause()`
+— see `tests/features/source_control.feature` and the `the source has a read
+latency of N milliseconds` / `the source fails the next N reads` steps. That
+same harness is the stand-in for the real transport: the machinery is exercised
+against slow/failing/mutating sources without a socket in sight.
+
 ## A small worked example
 
 A REST API for a product catalog. Pagination via `?page=N`. No native search.

--- a/vantage-diorama/tests/bdd_support/backend.rs
+++ b/vantage-diorama/tests/bdd_support/backend.rs
@@ -106,13 +106,20 @@ impl MasterRows {
     /// (CSV temp directory, SQLite in-memory connection).
     pub async fn build_master_for(&self, w: &mut DioramaWorld) -> Result<Vista> {
         match w.backend {
-            BackendKind::Mock => Ok(self.build_mock()),
+            BackendKind::Mock => {
+                let shell = self.build_mock();
+                // Retain a clone as the live, mutable dataset handle — its
+                // store is Arc-shared with the Vista we box below, so a
+                // scenario can edit rows mid-run via `w.source`.
+                w.source = Some(shell.clone());
+                Ok(Vista::new(self.name.clone(), Box::new(shell)))
+            }
             BackendKind::Csv => self.build_csv(w),
             BackendKind::Sqlite => self.build_sqlite(w).await,
         }
     }
 
-    fn build_mock(&self) -> Vista {
+    fn build_mock(&self) -> MockShell {
         let mut meta = VistaMetadata::new().with_id_column(&self.id_column);
         for col in &self.columns {
             let mut c = Column::new(col, "String");
@@ -145,7 +152,7 @@ impl MasterRows {
             }
             shell = shell.with_record(&row.id, rec);
         }
-        Vista::new(self.name.clone(), Box::new(shell))
+        shell
     }
 
     fn build_csv(&self, w: &mut DioramaWorld) -> Result<Vista> {

--- a/vantage-diorama/tests/bdd_support/spies.rs
+++ b/vantage-diorama/tests/bdd_support/spies.rs
@@ -25,4 +25,12 @@ pub struct Spies {
     /// invocation returns `Err` and clears the flag. Drives the
     /// `LoadFailed` scenarios without rebuilding the lens.
     pub on_load_chunk_error_once: Arc<AtomicBool>,
+    /// Virtual-time latency (ms) the scriptable source sleeps before each
+    /// gated read (currently `on_load_chunk`). `0` = none. Lets a scenario
+    /// model a slow upstream deterministically under the paused clock.
+    pub source_latency_ms: Arc<AtomicU64>,
+    /// Count of upcoming gated source reads to fail. Decremented on each
+    /// gated read — a self-clearing, countable fault, distinct from the
+    /// one-shot [`on_load_chunk_error_once`](Self::on_load_chunk_error_once).
+    pub source_fail_reads: Arc<AtomicU64>,
 }

--- a/vantage-diorama/tests/bdd_support/steps/mod.rs
+++ b/vantage-diorama/tests/bdd_support/steps/mod.rs
@@ -8,5 +8,6 @@ pub mod lifecycle;
 pub mod multi_dio;
 pub mod refresh;
 pub mod skeleton;
+pub mod source;
 pub mod table_v2;
 pub mod write_path;

--- a/vantage-diorama/tests/bdd_support/steps/source.rs
+++ b/vantage-diorama/tests/bdd_support/steps/source.rs
@@ -1,0 +1,58 @@
+//! Step 1 — scriptable-source controls.
+//!
+//! The "source" here is the Mock backend's shell, retained on the World as a
+//! live dataset handle (`w.source`). These steps let a scenario script a slow,
+//! failing, or mutating upstream deterministically under the paused clock —
+//! the in-test stand-in for the real transport the later phases build.
+
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use cucumber::{given, then, when};
+
+use crate::bdd_support::world::DioramaWorld;
+
+// ---- Givens: latency + faults ----------------------------------------------
+
+#[given(regex = r"^the source has a read latency of (\d+) milliseconds$")]
+async fn source_latency(w: &mut DioramaWorld, ms: u64) {
+    w.spies.source_latency_ms.store(ms, Ordering::SeqCst);
+}
+
+#[given(regex = r"^the source fails the next (\d+) reads?$")]
+async fn source_fail_reads(w: &mut DioramaWorld, n: u64) {
+    w.spies.source_fail_reads.store(n, Ordering::SeqCst);
+}
+
+// ---- Whens: live dataset mutation + ms time-travel -------------------------
+
+#[when(regex = r#"^the source record "([^"]+)" (\w+) becomes "([^"]+)"$"#)]
+async fn source_mutate(w: &mut DioramaWorld, id: String, field: String, value: String) {
+    let source = w
+        .source
+        .as_ref()
+        .expect("mock source not built (Mock backend only)");
+    source.set_field(&id, &field, CborValue::Text(value));
+}
+
+#[when(regex = r"^(\d+) milliseconds? pass(?:es)?$")]
+async fn millis_pass(w: &mut DioramaWorld, ms: u64) {
+    tokio::time::advance(Duration::from_millis(ms)).await;
+    w.settle().await;
+}
+
+// ---- Then: read a row's title ----------------------------------------------
+
+#[then(regex = r#"^the table scenery row at index (\d+) has title "([^"]+)"$"#)]
+async fn row_has_title(w: &mut DioramaWorld, idx: usize, title: String) {
+    let scenery = w.scenery.as_ref().expect("scenery not opened");
+    let row = scenery
+        .row(idx)
+        .unwrap_or_else(|| panic!("no row at index {idx}"));
+    let got = match row.record.get("title") {
+        Some(CborValue::Text(s)) => s.clone(),
+        other => panic!("row {idx} title not text: {other:?}"),
+    };
+    assert_eq!(got, title, "row {idx} title: want {title}, got {got}");
+}

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -123,6 +123,11 @@ pub struct DioramaWorld {
     /// to different masters, each claiming its own cache table.
     pub named_masters: std::collections::HashMap<String, Vista>,
     pub named_dios: std::collections::HashMap<String, Dio>,
+    /// The Mock backend's shell, retained as a live, mutable dataset
+    /// handle — its store is `Arc`-shared with the master Vista, so
+    /// `source.set_field(...)` mid-scenario is observed by the next read.
+    /// `None` for CSV/SQLite backends.
+    pub source: Option<vantage_vista::mocks::MockShell>,
 }
 
 impl std::fmt::Debug for DioramaWorld {
@@ -158,6 +163,7 @@ impl DioramaWorld {
             scenery: None,
             named_masters: std::collections::HashMap::new(),
             named_dios: std::collections::HashMap::new(),
+            source: None,
         }
     }
 
@@ -461,15 +467,30 @@ impl LensBuilderState {
                 let master_list_counter = spies.master_list_calls.clone();
                 let last_range = spies.last_load_chunk_range.clone();
                 let error_once = spies.on_load_chunk_error_once.clone();
+                let source_latency = spies.source_latency_ms.clone();
+                let source_fail_reads = spies.source_fail_reads.clone();
                 b = b.on_load_chunk(move |dio, range, sink| {
                     let counter = counter.clone();
                     let master_list_counter = master_list_counter.clone();
                     let last_range = last_range.clone();
                     let error_once = error_once.clone();
+                    let source_latency = source_latency.clone();
+                    let source_fail_reads = source_fail_reads.clone();
                     let dio = dio.clone();
                     async move {
                         counter.fetch_add(1, Ordering::SeqCst);
                         *last_range.lock().await = Some(range.clone());
+                        // Scriptable-source gate: virtual-time latency, then
+                        // a self-clearing counted fault. Both default to 0,
+                        // so an unscripted scenario is unaffected.
+                        let latency_ms = source_latency.load(Ordering::SeqCst);
+                        if latency_ms > 0 {
+                            tokio::time::sleep(Duration::from_millis(latency_ms)).await;
+                        }
+                        if source_fail_reads.load(Ordering::SeqCst) > 0 {
+                            source_fail_reads.fetch_sub(1, Ordering::SeqCst);
+                            return Err(vantage_core::error!("source read failed (injected)"));
+                        }
                         if error_once.swap(false, Ordering::SeqCst) {
                             return Err(vantage_core::error!("on_load_chunk rejected (one-shot)"));
                         }

--- a/vantage-diorama/tests/features/source_control.feature
+++ b/vantage-diorama/tests/features/source_control.feature
@@ -1,0 +1,52 @@
+Feature: Scriptable source — latency, counted faults, live mutation
+
+  Step 1 — the test harness can model a slow / failing / mutating upstream
+  deterministically under the paused clock (`tokio::time::advance`). The same
+  knobs are the in-test stand-in for the real transport later phases build, so
+  the diorama machinery is exercised against realistic source behaviour without
+  any network.
+
+  Scenario: a slow source still loads the viewport under virtual time
+    Given a master with 1000 rows
+    And a lens with on_start that copies the first 100 rows to cache
+    And a total_provider that returns the master count
+    And an on_load_chunk callback that pulls the requested range from master
+    And the source has a read latency of 200 milliseconds
+    When the dio is created
+    And the table scenery is opened
+    And the table scenery viewport is set to 500..600
+    And I wait for 2 events
+    Then on_load_chunk has been called 1 time with range 500..600
+    And the table scenery row at index 550 is Some
+    And the event log matches snapshot "source_latency_loaded"
+
+  Scenario: a counted source fault fails one load then recovers on refresh
+    Given a master with 1000 rows
+    And a lens with on_start that copies the first 100 rows to cache
+    And a total_provider that returns the master count
+    And an on_load_chunk callback that pulls the requested range from master
+    And the source fails the next 1 read
+    When the dio is created
+    And the table scenery is opened
+    And the table scenery viewport is set to 500..600
+    And I wait for 2 events
+    Then the event log contains LoadFailed { range: 500..600 }
+    And the table scenery row at index 550 is None
+    When dio.refresh is called
+    And I wait for 6 events
+    Then the table scenery row at index 550 is Some
+
+  Scenario: a mid-scenario source edit appears after refresh
+    Given a master with 1000 rows
+    And a lens with on_start that copies the first 100 rows to cache
+    And a total_provider that returns the master count
+    And an on_load_chunk callback that pulls the requested range from master
+    When the dio is created
+    And the table scenery is opened
+    And the table scenery viewport is set to 200..205
+    And I wait for 2 events
+    Then the table scenery row at index 200 has title "row-200"
+    When the source record "000200" title becomes "row-200-EDITED"
+    And dio.refresh is called
+    And I wait for 6 events
+    Then the table scenery row at index 200 has title "row-200-EDITED"

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@source_latency_loaded.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@source_latency_loaded.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+expression: events
+---
+- "ViewportChanged { range: 500..600 }"
+- "RangeLoaded { range: 500..600 }"

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -67,6 +67,38 @@ impl MockShell {
         self
     }
 
+    // ---- Live dataset mutation ---------------------------------------------
+    //
+    // The store is `Arc<Mutex<…>>`, so a clone of this shell taken *before*
+    // it is boxed into a `Vista` keeps a handle to the same rows. These
+    // by-ref helpers let a test or example mutate the dataset mid-run —
+    // simulating an upstream that changed between reads — and have the next
+    // `list`/`get`/refresh observe it. They are additive and opt-in; an
+    // untouched shell behaves exactly as before.
+
+    /// Insert or replace a record by id through the shared store.
+    pub fn set_record(&self, id: impl Into<String>, record: Record<CborValue>) {
+        self.data.lock().unwrap().insert(id.into(), record);
+    }
+
+    /// Overwrite a single field of an existing record (read-modify-write).
+    /// No-op if the record is absent.
+    pub fn set_field(&self, id: &str, field: &str, value: CborValue) {
+        if let Some(rec) = self.data.lock().unwrap().get_mut(id) {
+            rec.insert(field.to_string(), value);
+        }
+    }
+
+    /// Remove a record by id. No-op if absent.
+    pub fn remove_record(&self, id: &str) {
+        self.data.lock().unwrap().shift_remove(id);
+    }
+
+    /// Drop every record.
+    pub fn clear_records(&self) {
+        self.data.lock().unwrap().clear();
+    }
+
     fn matches_filters(&self, record: &Record<CborValue>) -> bool {
         self.filters
             .lock()


### PR DESCRIPTION
Step 1 of taking the Scenery layer a level higher: a deterministic stand-in for a slow/failing/mutating transport so the diorama machinery can be tested without a network.

## What's in here
- **vantage-vista `MockShell`** — live by-ref dataset mutation (`set_record` / `set_field` / `remove_record` / `clear_records`). Additive and opt-in; the Arc-shared store lets a clone taken before boxing into a `Vista` stay a live handle, so a test/example can edit the upstream mid-run.
- **diorama BDD harness** — virtual-time latency + counted-fault knobs on `Spies`, gated into the chunk-load callback under `tokio::time::pause()`; the Mock shell retained on the World as a live source; new steps for latency, fault injection, live mutation, and millisecond time-travel.
- **Smoke feature** `source_control.feature` (3 scenarios) + golden event-trace snapshot, proving responsive-first / eventually-precise loading.
- README_datasource.md + CHANGELOG.

## Why
This is the test seam the upcoming async-native transport slots into: the machinery is exercised against slow/failing/mutating sources with no socket. No behaviour change to shipping code (MockShell additions are opt-in).

## Verification
`cargo test -p vantage-diorama --test bdd` → 60/60 scenarios, 538/538 steps green; `vantage-vista` 33/33.