### PR TITLE
diorama: deduplicating scenery registry (sharing, refcount, cancellation)

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 0.6.3 — unreleased
 
+- Deduplicating scenery registry. Opening a `TableScenery` for a
+  `(conditions, sort, search)` that is already live now returns the **same**
+  shared `Arc` — one reactor, one cache window, one in-flight fetch — instead of
+  standing up a parallel copy, so many widgets over the same query (a grid plus
+  its dropdowns, a row shown twice) cost one scenery. Lifecycle is refcounted:
+  when the last handle drops, the scenery's tasks are aborted, cancelling any
+  outstanding chunk load or two-pass detail hydration — a closing grid stops
+  pulling — and the registry entry is evicted. New `Dio::live_table_scenery_count()`
+  exposes the registry (seed for the diagnostics surface).
 - Scriptable test source. `MockShell` gained live, by-ref dataset mutation
   (`set_record` / `set_field` / `remove_record` / `clear_records`) so a test or
   example can edit the upstream mid-run and have the next read/refresh observe

--- a/vantage-diorama/README_ui.md
+++ b/vantage-diorama/README_ui.md
@@ -61,6 +61,38 @@ let counter = dio.value_scenery()
     .await?;
 ```
 
+## Sharing and lifecycle
+
+Opening a `TableScenery` is **cheap and deduplicated**. Two widgets that ask for
+the same `(conditions, sort, search)` get back the *same* `Arc` — one reactor,
+one cache window, one in-flight fetch — not two parallel copies:
+
+```rust
+let grid     = dio.table_scenery().sort("price", SortDir::Asc).open().await?;
+let elsewhere = dio.table_scenery().sort("price", SortDir::Asc).open().await?;
+// `grid` and `elsewhere` are the same object; edits and loads are shared.
+debug_assert!(std::sync::Arc::ptr_eq(&grid, &elsewhere));
+```
+
+This is why you don't budget for sceneries: a form with eight dropdowns over the
+same lookup table, or the same record shown in a grid row and a detail sheet,
+costs one scenery, not eight.
+
+Lifecycle is **refcounted**. The handle is the refcount; when the last clone
+drops, the scenery's background tasks are aborted. Because the viewport task
+owns every in-flight fetch inline, **a closing grid stops pulling** — outstanding
+chunk loads (and two-pass detail hydration) are cancelled rather than running to
+completion against a view nobody is watching. There is nothing to call: just drop
+the handle (clear the field, close the tab) and the work unwinds.
+
+```rust
+// One open window onto the registry — useful in tests and the diagnostics panel.
+assert_eq!(dio.live_table_scenery_count(), 1); // grid + elsewhere share one
+drop(grid);
+drop(elsewhere);
+assert_eq!(dio.live_table_scenery_count(), 0); // released → evicted, no leak
+```
+
 ## The pull-on-render contract
 
 GPUI's `TableDelegate` polls the delegate on every render frame. The relevant

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -16,7 +16,9 @@ use vantage_vista::Vista;
 use crate::lens::{CacheTable, Lens};
 use crate::ops::{ChangeEvent, WriteOp};
 use crate::scenery::record::spawn_record_scenery;
-use crate::scenery::{RecordScenery, RecordStatus, TableSceneryBuilder, ValueSceneryBuilder};
+use crate::scenery::{
+    RecordScenery, RecordStatus, TableScenery, TableSceneryBuilder, ValueSceneryBuilder,
+};
 
 use ciborium::Value as CborValue;
 use vantage_types::Record;
@@ -70,6 +72,15 @@ pub(crate) struct DioInner {
     pub(crate) query_indexes: std::sync::Mutex<
         std::collections::HashMap<String, Arc<crate::dio::query_index::QueryIndex>>,
     >,
+    /// Deduplicating registry of live table sceneries, keyed by
+    /// `(shape, conditions, sort, search)`. Holds `Weak` handles so it
+    /// never keeps a scenery alive: opening the same query twice returns
+    /// the one shared `Arc` (one reactor, one cache window, one in-flight
+    /// `JoinSet`), and the entry self-heals once the last widget releases
+    /// it. This is what makes "scenery must be cheap" true and what lets a
+    /// closing grid stop pulling — see [`TableSceneryImpl`]'s drop guard.
+    pub(crate) table_sceneries:
+        std::sync::Mutex<std::collections::HashMap<String, std::sync::Weak<dyn TableScenery>>>,
 }
 
 impl DioInner {
@@ -82,6 +93,33 @@ impl DioInner {
             .entry(key.to_string())
             .or_insert_with(|| Arc::new(crate::dio::query_index::QueryIndex::new()))
             .clone()
+    }
+
+    /// Return the live shared table scenery for `key`, or `None` if none is
+    /// open (or the last handle was just released — a dead `Weak`).
+    pub(crate) fn lookup_table_scenery(&self, key: &str) -> Option<Arc<dyn TableScenery>> {
+        self.table_sceneries
+            .lock()
+            .unwrap()
+            .get(key)
+            .and_then(std::sync::Weak::upgrade)
+    }
+
+    /// Publish a freshly-built scenery under `key`. If a concurrent open won
+    /// the race for the same key, returns that shared scenery instead and lets
+    /// `built` drop — its guard aborts the now-redundant tasks. Otherwise
+    /// inserts a `Weak` to `built` and hands it back.
+    pub(crate) fn register_table_scenery(
+        &self,
+        key: String,
+        built: Arc<dyn TableScenery>,
+    ) -> Arc<dyn TableScenery> {
+        let mut guard = self.table_sceneries.lock().unwrap();
+        if let Some(existing) = guard.get(&key).and_then(std::sync::Weak::upgrade) {
+            return existing;
+        }
+        guard.insert(key, Arc::downgrade(&built));
+        built
     }
 }
 
@@ -126,6 +164,19 @@ impl Dio {
     /// reactive view.
     pub fn table_scenery(&self) -> TableSceneryBuilder {
         TableSceneryBuilder::new(self.inner.clone())
+    }
+
+    /// Number of distinct table sceneries currently held open on this Dio.
+    ///
+    /// Prunes dead registry entries as a side effect, so the count reflects
+    /// only sceneries with at least one live handle. Two widgets sharing one
+    /// deduplicated `(conditions, sort, search)` count as **one**; once every
+    /// handle is released the count drops back, proving no leak. A read-only
+    /// window onto the dedup registry — the seed for the diagnostics surface.
+    pub fn live_table_scenery_count(&self) -> usize {
+        let mut guard = self.inner.table_sceneries.lock().unwrap();
+        guard.retain(|_, weak| weak.strong_count() > 0);
+        guard.len()
     }
 
     /// Open a reactive view onto a single record by id. Reads the

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -38,6 +38,7 @@ impl Lens {
             write_worker: Mutex::new(None),
             hot_tier: Arc::new(HotTier::new()),
             query_indexes: std::sync::Mutex::new(std::collections::HashMap::new()),
+            table_sceneries: std::sync::Mutex::new(std::collections::HashMap::new()),
         });
         let dio = Dio { inner };
 

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -11,7 +11,7 @@ use crate::dio::{Dio, DioInner, Generation};
 use super::loader::{enqueue_viewport, viewport_loop};
 use super::reactor::reload_loop;
 use super::state::TableSceneryState;
-use super::{SortDir, TableScenery, TableSceneryImpl, ViewportRequest};
+use super::{SceneryGuard, SortDir, TableScenery, TableSceneryImpl, ViewportRequest};
 
 /// Builder produced by [`Dio::table_scenery`](crate::Dio::table_scenery).
 pub struct TableSceneryBuilder {
@@ -88,6 +88,27 @@ impl TableSceneryBuilder {
             initial_range,
         } = self;
 
+        // Dedup key over (shape, conditions, sort, search). A live scenery
+        // for the same query is shared — one reactor, one cache window, one
+        // in-flight JoinSet — instead of standing up a parallel copy.
+        let key = {
+            let vista_sort = sort.as_ref().map(|(col, dir)| {
+                let dir = match dir {
+                    SortDir::Asc => vantage_vista::SortDirection::Ascending,
+                    SortDir::Desc => vantage_vista::SortDirection::Descending,
+                };
+                (col.as_str(), dir)
+            });
+            format!(
+                "table\u{1}{}\u{1}{}",
+                dio.master.index_key(&conditions, vista_sort),
+                search.as_deref().unwrap_or(""),
+            )
+        };
+        if let Some(existing) = dio.lookup_table_scenery(&key) {
+            return Ok(existing);
+        }
+
         let (gen_tx, _gen_rx) = watch::channel(Generation::default());
         let (viewport_tx, viewport_rx) = mpsc::unbounded_channel();
 
@@ -161,17 +182,21 @@ impl TableSceneryBuilder {
             state.bump_generation();
         }
 
-        // 3. Spawn reactor.
+        // 3. Spawn reactor. Handle retained by the scenery's drop guard so a
+        //    released scenery stops reacting (and frees its state) instead of
+        //    living for the Dio's whole lifetime.
         let bus_rx = dio.event_bus.subscribe();
         let reactor_state = state.clone();
-        dio.lens.runtime.spawn(async move {
+        let reactor_handle = dio.lens.runtime.spawn(async move {
             reload_loop(reactor_state, bus_rx).await;
         });
 
-        // 4. Spawn viewport-debounce loop.
+        // 4. Spawn viewport-debounce loop. This task owns every in-flight
+        //    fetch inline, so aborting it on drop cancels outstanding loads —
+        //    a closing grid stops pulling.
         let viewport_state = state.clone();
         let debounce = dio.lens.defaults.viewport_debounce;
-        dio.lens.runtime.spawn(async move {
+        let viewport_handle = dio.lens.runtime.spawn(async move {
             viewport_loop(viewport_state, viewport_rx, debounce).await;
         });
 
@@ -194,6 +219,16 @@ impl TableSceneryBuilder {
             );
         }
 
-        Ok(Arc::new(TableSceneryImpl { inner: state }) as Arc<dyn TableScenery>)
+        let scenery: Arc<dyn TableScenery> = Arc::new(TableSceneryImpl {
+            inner: state,
+            _guard: SceneryGuard {
+                tasks: vec![reactor_handle, viewport_handle],
+            },
+        });
+
+        // Publish to the dedup registry. If a concurrent open won the race for
+        // this key, `register_table_scenery` returns the winner and our
+        // `scenery` drops here — its guard aborts the redundant tasks.
+        Ok(dio.register_table_scenery(key, scenery))
     }
 }

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -79,6 +79,30 @@ pub trait TableScenery: Send + Sync {
 
 pub(crate) struct TableSceneryImpl {
     pub(crate) inner: Arc<TableSceneryState>,
+    /// Aborts the reactor + viewport tasks when the last handle to this
+    /// scenery is released. The viewport task owns every in-flight fetch
+    /// inline (single-pass chunk loads *and* two-pass detail hydration both
+    /// run inside it), so aborting it cancels outstanding requests — a
+    /// closing grid stops pulling. Dropping `inner` alone wouldn't suffice:
+    /// the tasks hold their own `Arc<TableSceneryState>`, so without this
+    /// guard a released scenery would linger for the Dio's whole lifetime.
+    _guard: SceneryGuard,
+}
+
+/// Owns the scenery's background tasks and aborts them on drop. Deliberately
+/// holds nothing else: registry eviction is lazy (`Weak::upgrade` + prune),
+/// so a scenery that loses a concurrent-open race can drop safely without
+/// touching the winner's registry entry.
+struct SceneryGuard {
+    tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for SceneryGuard {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
 }
 
 impl TableScenery for TableSceneryImpl {

--- a/vantage-diorama/tests/bdd_support/steps/mod.rs
+++ b/vantage-diorama/tests/bdd_support/steps/mod.rs
@@ -7,6 +7,7 @@ pub mod event_path;
 pub mod lifecycle;
 pub mod multi_dio;
 pub mod refresh;
+pub mod registry;
 pub mod skeleton;
 pub mod source;
 pub mod table_v2;

--- a/vantage-diorama/tests/bdd_support/steps/registry.rs
+++ b/vantage-diorama/tests/bdd_support/steps/registry.rs
@@ -1,0 +1,62 @@
+//! Step 2 — scenery dedup registry, refcount, and structural cancellation.
+//!
+//! Opening the same `(conditions, sort, search)` twice hands back one shared
+//! scenery (one reactor, one in-flight fetch). Releasing every handle aborts
+//! the background tasks — a closing grid stops pulling — and the registry
+//! entry self-heals.
+
+use std::sync::Arc;
+
+use cucumber::{then, when};
+use vantage_diorama::DioEvent;
+
+use crate::bdd_support::world::DioramaWorld;
+
+#[when("the table scenery is opened again")]
+async fn open_again(w: &mut DioramaWorld) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let scenery = dio
+        .table_scenery()
+        .open()
+        .await
+        .expect("re-open table scenery");
+    w.scenery2 = Some(scenery);
+    w.settle().await;
+}
+
+#[then("the two table sceneries are the same object")]
+async fn same_object(w: &mut DioramaWorld) {
+    let a = w.scenery.as_ref().expect("first scenery not opened");
+    let b = w.scenery2.as_ref().expect("second scenery not opened");
+    assert!(
+        Arc::ptr_eq(a, b),
+        "expected the two opens to share one scenery (dedup), got distinct objects"
+    );
+}
+
+#[then(regex = r"^the dio has (\d+) live table scener(?:y|ies)$")]
+async fn live_count(w: &mut DioramaWorld, expected: usize) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let got = dio.live_table_scenery_count();
+    assert_eq!(got, expected, "live table scenery count: want {expected}, got {got}");
+}
+
+#[when("the table scenery handles are released")]
+async fn release_handles(w: &mut DioramaWorld) {
+    w.scenery = None;
+    w.scenery2 = None;
+    // Let the drop guard's task aborts propagate.
+    w.settle().await;
+}
+
+#[then("the event log contains no RangeLoaded")]
+async fn no_range_loaded(w: &mut DioramaWorld) {
+    let events = w.snapshot_events().await;
+    let found = events
+        .iter()
+        .any(|e| matches!(e, DioEvent::RangeLoaded { .. }));
+    assert!(
+        !found,
+        "expected no RangeLoaded (load should have been cancelled), got: {events:?}"
+    );
+}

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -119,6 +119,9 @@ pub struct DioramaWorld {
     /// Opened by the `the table scenery is opened` step; subsequent
     /// generation assertions read from `scenery.subscribe()`.
     pub scenery: Option<Arc<dyn TableScenery>>,
+    /// A second handle to a table scenery, for dedup/refcount scenarios —
+    /// opening the same query again should hand back the *same* object.
+    pub scenery2: Option<Arc<dyn TableScenery>>,
     /// Multi-dio scenarios: a single Lens producing several Dios bound
     /// to different masters, each claiming its own cache table.
     pub named_masters: std::collections::HashMap<String, Vista>,
@@ -161,6 +164,7 @@ impl DioramaWorld {
             worker_handle: None,
             pending_dio: None,
             scenery: None,
+            scenery2: None,
             named_masters: std::collections::HashMap::new(),
             named_dios: std::collections::HashMap::new(),
             source: None,

--- a/vantage-diorama/tests/features/scenery_registry.feature
+++ b/vantage-diorama/tests/features/scenery_registry.feature
@@ -1,0 +1,48 @@
+Feature: Scenery dedup registry — sharing, refcount, cancellation
+
+  Step 2 — a UI widget binds to a Scenery; many widgets over the same
+  `(conditions, sort, search)` must share ONE scenery (one reactor, one cache
+  window, one in-flight fetch) so opening is cheap. Releasing every handle
+  aborts the background tasks — a closing grid stops pulling — and the registry
+  entry self-heals, so nothing leaks.
+
+  Scenario: opening the same query twice shares one scenery
+    Given a master with 1000 rows
+    And a lens with on_start that copies the first 100 rows to cache
+    And a total_provider that records calls and returns the master count
+    And an on_load_chunk callback that pulls the requested range from master
+    When the dio is created
+    And the table scenery is opened
+    And the table scenery is opened again
+    Then the two table sceneries are the same object
+    And total_provider has been called 1 time
+    And the dio has 1 live table scenery
+
+  Scenario: releasing every handle evicts the scenery — no leak
+    Given a master with 1000 rows
+    And a lens with on_start that copies the first 100 rows to cache
+    And a total_provider that returns the master count
+    And an on_load_chunk callback that pulls the requested range from master
+    When the dio is created
+    And the table scenery is opened
+    And the table scenery is opened again
+    Then the dio has 1 live table scenery
+    When the table scenery handles are released
+    Then the dio has 0 live table sceneries
+
+  Scenario: a closing grid cancels its in-flight fetch
+    Given a master with 1000 rows
+    And a lens with on_start that copies the first 100 rows to cache
+    And a total_provider that returns the master count
+    And an on_load_chunk callback that pulls the requested range from master
+    And the source has a read latency of 500 milliseconds
+    When the dio is created
+    And the table scenery is opened
+    And the table scenery viewport is set to 500..600
+    And 100 milliseconds pass
+    Then on_load_chunk has been called 1 time with range 500..600
+    And the table scenery row at index 550 is None
+    When the table scenery handles are released
+    And 1000 milliseconds pass
+    Then the event log contains no RangeLoaded
+    And the dio has 0 live table sceneries


### PR DESCRIPTION
Step 2 of taking the Scenery layer a level higher. **Stacked on #309** (base `diorama-scriptable-source`) so the diff is Step 2 only.

## What's in here
- **Dedup registry** on `DioInner` keyed by `(shape, conditions, sort, search)`. `table_scenery().open()` fast-paths on a live key and returns the **same** shared `Arc` — one reactor, one cache window, one in-flight fetch. Race-safe publish (loser drops, its guard aborts redundant tasks).
- **Refcounted lifecycle + structural cancellation**: `TableSceneryImpl` owns a drop guard holding the reactor + viewport task handles; last handle drop aborts them. The viewport task runs every fetch inline (single-pass chunk *and* two-pass detail), so abort cancels in-flight requests — **a closing grid stops pulling**. Fixes the prior leak where tasks held strong state for the Dio's whole lifetime.
- **`Dio::live_table_scenery_count()`** — read-only window onto the registry (seed for Step 9 diagnostics).
- BDD `scenery_registry.feature` (3 scenarios), `README_ui.md` "Sharing and lifecycle", CHANGELOG.

## Why
Makes "scenery must be cheap" true (many widgets over one query = one scenery) and "stop pulling when the grid closes" automatic. No behaviour change for existing single-open call sites.

## Verification
`cargo test -p vantage-diorama` → 63/63 BDD + all non-BDD green; clippy clean. Cancellation proof: 500ms source latency, load starts, handles released, +1000ms passes and `RangeLoaded` never fires → cancelled, not slow; live count returns to 0.