### PR TITLE
diorama: soft-refresh sort fix for two-pass grids

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.6.3 — unreleased
 
+- Soft-refresh sort for augmented (two-pass) grids. Changing a two-pass
+  scenery's sort (or search) now rebuilds the ordered index for the new variant
+  and **restarts the detail pass for the visible window** — augmentation resumes
+  without the user scrolling. Previously `set_sort` dropped two-pass sceneries
+  onto the single-pass reseed path, which never re-listed the variant nor
+  re-issued the viewport, so hydration silently stalled. The reorder re-seeds
+  from cache in one atomic swap (the grid never blanks), a previously-seen sort
+  reorders with no refetch, and a scenery that mutates its own sort/search in
+  place leaves the dedup registry (it's no longer the shareable canonical view
+  for the original query).
 - Deduplicating scenery registry. Opening a `TableScenery` for a
   `(conditions, sort, search)` that is already live now returns the **same**
   shared `Arc` — one reactor, one cache window, one in-flight fetch — instead of

--- a/vantage-diorama/README_ui.md
+++ b/vantage-diorama/README_ui.md
@@ -486,6 +486,15 @@ largest workloads where even chunked windowing is overkill.
 the Scenery's reload task wakes, re-filters/sorts the cached row set,
 publishes a new generation. The widget re-renders.
 
+**Sort on an augmented (two-pass) grid is soft-refresh.** Changing the sort
+re-points the scenery at the new variant's ordered index and re-seeds the
+visible rows from cache **immediately** — the grid never blanks — then restarts
+the detail pass for the visible window in the background, so augmentation
+resumes without the user having to scroll. A sort you've used before reorders
+straight from cache with no refetch; a brand-new sort lists its first page once.
+(Mutating the sort/search in place takes the scenery out of the dedup registry —
+it's now a bespoke view, not the shareable canonical one for the original query.)
+
 What's **not** happening yet: push-down to master or to the cache backend.
 The filter runs in-memory across the loaded `Vec<Arc<EnrichedRecord>>`.
 For 100k rows × a handful of text columns, that's milliseconds. For

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -151,7 +151,8 @@ impl TableSceneryBuilder {
             load_in_flight: Mutex::new(None),
             master_capabilities,
             two_pass,
-            index,
+            index: RwLock::new(index),
+            registry_key: Mutex::new(Some(key.clone())),
             detail_in_flight: Mutex::new(std::collections::HashSet::new()),
             list_in_flight: Mutex::new(false),
         });
@@ -170,7 +171,7 @@ impl TableSceneryBuilder {
             // first list page. The detail pass stays dormant until a viewport
             // is set, so opening yields `Incomplete` rows with zero detail
             // calls.
-            let index_empty = state.index.as_ref().map(|i| i.is_empty()).unwrap_or(true);
+            let index_empty = state.index().map(|i| i.is_empty()).unwrap_or(true);
             if index_empty {
                 super::two_pass::run_list_page(state.clone()).await;
             } else {

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -107,7 +107,7 @@ impl Drop for SceneryGuard {
 
 impl TableScenery for TableSceneryImpl {
     fn row_count(&self) -> usize {
-        if let Some(index) = self.inner.index.as_ref() {
+        if let Some(index) = self.inner.index() {
             return index.len();
         }
         if let Some(t) = *self.inner.total.read().unwrap() {
@@ -119,7 +119,7 @@ impl TableScenery for TableSceneryImpl {
     fn has_more(&self) -> bool {
         // Two-pass / sequential no-total: more pages exist until the list pass
         // sees a short or empty page.
-        if let Some(index) = self.inner.index.as_ref() {
+        if let Some(index) = self.inner.index() {
             return !index.is_complete();
         }
         let total = *self.inner.total.read().unwrap();
@@ -133,7 +133,7 @@ impl TableScenery for TableSceneryImpl {
     fn estimated_total(&self) -> Option<usize> {
         // Two-pass: the running index length is the best estimate; it grows as
         // pages load and freezes once the list pass completes.
-        if let Some(index) = self.inner.index.as_ref() {
+        if let Some(index) = self.inner.index() {
             return Some(index.len());
         }
         let stored = *self.inner.total.read().unwrap();
@@ -204,11 +204,13 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn set_search(&self, query: Option<String>) {
+        self.inner.deregister();
         *self.inner.search.write().unwrap() = query;
         self.inner.reload_notify.notify_one();
     }
 
     fn set_sort(&self, column: Option<String>, dir: SortDir) {
+        self.inner.deregister();
         *self.inner.sort.write().unwrap() = column.map(|c| (c, dir));
         self.inner.reload_notify.notify_one();
     }

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -24,8 +24,16 @@ pub(crate) async fn reload_loop(
         }
 
         tokio::select! {
+            // `set_sort` / `set_search` ping `reload_notify`. A two-pass
+            // scenery must rebuild its ordered index and restart hydration
+            // (single-pass `reseed_from_cache` re-sorts in memory and is
+            // enough on its own).
             _ = state.reload_notify.notified() => {
-                reseed(&state).await;
+                if state.two_pass {
+                    super::two_pass::resort(state.clone()).await;
+                } else {
+                    reseed(&state).await;
+                }
             }
             recv = bus.recv() => {
                 match recv {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -69,7 +69,14 @@ pub(crate) struct TableSceneryState {
     pub(crate) two_pass: bool,
     /// The shared per-query ordered index for this scenery's conditions/sort,
     /// keyed by [`Vista::index_key`](vantage_vista::Vista::index_key). `None` in single-pass mode.
-    pub(crate) index: Option<Arc<crate::dio::query_index::QueryIndex>>,
+    /// Swappable: a `set_sort` / `set_search` re-points it at the index for the
+    /// new variant (see [`resort`](super::two_pass::resort)).
+    pub(crate) index: RwLock<Option<Arc<crate::dio::query_index::QueryIndex>>>,
+    /// This scenery's key in the Dio's dedup registry, captured at open. Cleared
+    /// (and the registry entry removed) the first time the handle mutates its own
+    /// query in place — a bespoke, resorted scenery is no longer the shareable
+    /// canonical one, so a later open under the old key must not get it back.
+    pub(crate) registry_key: Mutex<Option<String>>,
     /// Ids whose detail fetch is currently dispatched — guards against
     /// re-hydrating the same row while a fetch is in flight.
     pub(crate) detail_in_flight: Mutex<std::collections::HashSet<String>>,
@@ -86,6 +93,27 @@ impl TableSceneryState {
 
     pub(crate) fn current_generation(&self) -> u64 {
         self.generation.load(Ordering::SeqCst)
+    }
+
+    /// Current two-pass index (cloned `Arc`), or `None` in single-pass mode.
+    pub(crate) fn index(&self) -> Option<Arc<crate::dio::query_index::QueryIndex>> {
+        self.index.read().unwrap().clone()
+    }
+
+    /// Re-point the two-pass index at a different query variant's ordered index.
+    pub(crate) fn set_index(&self, index: Option<Arc<crate::dio::query_index::QueryIndex>>) {
+        *self.index.write().unwrap() = index;
+    }
+
+    /// Drop this scenery's dedup-registry entry the first time it mutates its
+    /// own query (sort/search) in place. Idempotent: the key is taken once.
+    pub(crate) fn deregister(&self) {
+        let Some(key) = self.registry_key.lock().unwrap().take() else {
+            return;
+        };
+        if let Some(dio) = self.dio_weak.upgrade() {
+            dio.table_sceneries.lock().unwrap().remove(&key);
+        }
     }
 
     /// Replace the sparse map from a freshly-listed cache snapshot.

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -71,7 +71,7 @@ pub(crate) async fn seed_from_index(state: &Arc<TableSceneryState>) {
     let Some(dio_inner) = state.dio_weak.upgrade() else {
         return;
     };
-    let Some(index) = state.index.as_ref() else {
+    let Some(index) = state.index() else {
         return;
     };
     let ids = index.ids();
@@ -88,7 +88,7 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     let Some(dio_inner) = state.dio_weak.upgrade() else {
         return;
     };
-    let Some(index) = state.index.clone() else {
+    let Some(index) = state.index() else {
         return;
     };
     let Some(cb) = dio_inner.lens.callbacks.on_list_page.as_ref() else {
@@ -156,6 +156,77 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     }
 }
 
+/// Soft-refresh a two-pass scenery after its `(conditions, sort)` changed.
+///
+/// Re-points the scenery at the ordered index for the new variant, presents
+/// that order from cache **immediately** (responsive — the grid never blanks),
+/// and re-issues the last viewport so the detail pass hydrates the
+/// newly-visible rows in the background (eventually precise). Without this, a
+/// sort change left the stale index in place and never restarted hydration —
+/// augmentation appeared to "stop" until the user happened to scroll.
+pub(crate) async fn resort(state: Arc<TableSceneryState>) {
+    let Some(dio_inner) = state.dio_weak.upgrade() else {
+        return;
+    };
+
+    // 1. Re-point at the index for the new (conditions, sort) variant. Reusing
+    //    a variant opened earlier finds its index already built.
+    let conditions = state.conditions.read().unwrap().clone();
+    let sort = state.sort.read().unwrap().clone();
+    let vista_sort = sort.as_ref().map(|(col, dir)| {
+        let dir = match dir {
+            SortDir::Asc => SortDirection::Ascending,
+            SortDir::Desc => SortDirection::Descending,
+        };
+        (col.as_str(), dir)
+    });
+    let key = dio_inner.master.index_key(&conditions, vista_sort);
+    let new_index = dio_inner.query_index(&key);
+    state.set_index(Some(new_index.clone()));
+
+    // 2. A sort variant we've never listed needs one list page to learn its
+    //    order. A variant we've seen before reorders straight from cache — no
+    //    fetch, no blank.
+    if new_index.is_empty() {
+        run_list_page(state.clone()).await;
+    }
+
+    // 3. Rebuild the sparse map from the index in one atomic swap, so the new
+    //    order replaces the old in a single write — the grid never blanks to an
+    //    empty map mid-reorder. Each row shows `Fresh`/`Incomplete` per its
+    //    cached status.
+    let ids = new_index.ids();
+    let mut rows = std::collections::BTreeMap::new();
+    let mut id_to_idx = std::collections::HashMap::new();
+    for (i, id) in ids.iter().enumerate() {
+        let Some((rec, status)) = dio_inner
+            .cache
+            .get_value_with_status(id)
+            .await
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+        let enriched = match status {
+            CacheStatus::Complete => EnrichedRecord::fresh(rec),
+            CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
+        };
+        rows.insert(i, Arc::new(enriched));
+        id_to_idx.insert(id.clone(), i);
+    }
+    *state.rows.write().unwrap() = rows;
+    *state.id_to_idx.write().unwrap() = id_to_idx;
+    // Old in-flight detail claims belonged to the previous order — drop them so
+    // the restarted detail pass isn't blocked by stale single-flight guards.
+    state.detail_in_flight.lock().unwrap().clear();
+    state.bump_generation();
+
+    // 4. Restart the detail pass for the last viewport so augmentation resumes
+    //    without waiting for the user to scroll.
+    state.refresh_loaded_viewport();
+}
+
 /// Run the detail pass for `range`: for each indexed id in the range that is
 /// not already `Complete` (and not in flight), fetch its detail, merge it into
 /// the cache as `Complete`, and flip the row to `Fresh`. Skips ids already
@@ -165,7 +236,7 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     let Some(dio_inner) = state.dio_weak.upgrade() else {
         return;
     };
-    let Some(index) = state.index.clone() else {
+    let Some(index) = state.index() else {
         return;
     };
     let Some(cb) = dio_inner.lens.callbacks.on_load_detail.as_ref() else {

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -19,7 +19,7 @@ use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_cmd::{Cmd, CmdSpec, eq};
 use vantage_dataset::prelude::ReadableValueSet;
-use vantage_diorama::{Dio, Lens, RowStatus, TableScenery};
+use vantage_diorama::{Dio, Lens, RowStatus, SortDir, TableScenery};
 use vantage_table::pagination::Pagination;
 use vantage_table::table::Table;
 use vantage_types::EmptyEntity;
@@ -235,6 +235,73 @@ async fn detail_pass_hydrates_visible_rows_once_in_order() {
     eventually("debounce settles", || true).await;
     tokio::time::sleep(Duration::from_millis(20)).await;
     assert_eq!(count_with_prefix(&log, "detail"), 2, "no re-hydration");
+}
+
+/// Regression (soft-refresh sort): changing the sort **restarts the detail
+/// pass for the visible window without a scroll**. Before the fix, `set_sort`
+/// dropped a two-pass scenery onto the single-pass reseed path, which never
+/// rebuilt the ordered index nor re-issued the viewport — so augmentation
+/// silently stopped until the user happened to scroll.
+#[tokio::test]
+async fn sort_change_restarts_augmentation_without_scrolling() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+    eventually("initial hydration", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&scenery, 1), Some(RowStatus::Fresh))
+    })
+    .await;
+    let list_before = count_with_prefix(&log, "list");
+
+    // Change the sort in place — NO new set_viewport. The machinery must rebuild
+    // the ordered index for the new variant (one list page) and restart the
+    // detail pass on its own. Before the fix, set_sort fell to the single-pass
+    // reseed-from-cache path: it never listed the new variant nor re-issued the
+    // viewport, so `list` stayed flat and augmentation was dead.
+    scenery.set_sort(Some("branch".to_string()), SortDir::Asc);
+
+    eventually("new sort variant is listed", || {
+        count_with_prefix(&log, "list") > list_before
+            && matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+
+    assert!(
+        count_with_prefix(&log, "list") > list_before,
+        "a sort change must list the new variant, not silently reseed from cache"
+    );
+    // Soft-refresh: the visible row never blanks to None, and its augmented
+    // (detail) columns survive the reorder because the cache is keyed by id.
+    assert!(scenery.row(0).is_some(), "row 0 stays present across the resort");
+    assert_eq!(detail_of(&scenery, 0).as_deref(), Some("full-r0"));
+
+    // Reverting to a variant already listed reorders straight from cache — its
+    // index exists and its rows are `Complete`, so neither a list nor a detail
+    // call is issued, and the grid never blanks.
+    let list_after_sort = count_with_prefix(&log, "list");
+    let detail_after_sort = count_with_prefix(&log, "detail");
+    scenery.set_sort(None, SortDir::Asc);
+    eventually("revert reseeds from cache", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(
+        count_with_prefix(&log, "list"),
+        list_after_sort,
+        "reverting to a seen variant must not re-list it"
+    );
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        detail_after_sort,
+        "reverting must not re-fetch already-complete details"
+    );
+    assert!(scenery.row(0).is_some(), "row 0 never blanks on revert");
 }
 
 /// Sequential, no-total paging: each `request_load_more` fetches the next list


### PR DESCRIPTION
Step 3 of taking the Scenery layer a level higher. **Stacked on #310** (base `diorama-scenery-registry`) so the diff is Step 3 only.

## The bug
"Grids stop augmenting if I change sort order." In two-pass mode, `set_sort`/`set_search` pinged `reload_notify`, and the reactor ran the **single-pass** `reseed_from_cache()` — which never rebuilt the ordered `QueryIndex` for the new variant nor re-issued the viewport. Augmentation silently stalled until the user scrolled.

## The fix
- New `two_pass::resort()`: re-points the scenery at the new `(conditions, sort)` variant's index, re-seeds the visible rows from cache in **one atomic swap (never blanks)**, and re-issues the last viewport so the detail pass restarts on its own.
- Reactor's `reload_notify` path routes two-pass sceneries to `resort` (single-pass keeps the in-memory reseed).
- `index` made swappable (`RwLock`): a seen sort reorders with **no refetch**; a brand-new sort lists its first page once.
- Registry consistency: a scenery that mutates its own sort/search **de-registers** from the Step 2 dedup pool, so a stale key can't return a wrong-sorted scenery.

## Verification
`cargo test -p vantage-diorama`: full suite green (63 BDD + 8 two-pass incl. new `sort_change_restarts_augmentation_without_scrolling`); clippy clean. Rigor check: temporarily reverting the reactor branch makes the new test **fail** ('new sort variant is listed' not met) — it genuinely catches the bug — then restored.