### PR TITLE
diorama: optimistic write path

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.6.3 — unreleased
 
+- Optimistic writes. `Dio::write_optimistic(op)` (and the `patch_optimistic`
+  shorthand) stage a write in the cache and announce it (`WritePending`) before
+  the write-through runs, so a form edit shows instantly as
+  `RowStatus::PendingWrite`. On success it settles to `Fresh` (`RecordChanged`);
+  on failure the cache pre-image is restored and the row flips to
+  `RowStatus::WriteFailed` (`WriteReverted`) — the view reverts rather than
+  keeping a value that didn't save. The edit reflects across every bound scenery
+  via the existing `RecordChanged` fan-out. Two new bus events (`WritePending`,
+  `WriteReverted`) are handled by both `RecordScenery` and `TableScenery`; the
+  previously-unused `RowStatus::PendingWrite` / `WriteFailed` now have producers.
 - Soft-refresh sort for augmented (two-pass) grids. Changing a two-pass
   scenery's sort (or search) now rebuilds the ordered index for the new variant
   and **restarts the detail pass for the visible window** — augmentation resumes

--- a/vantage-diorama/README_ui.md
+++ b/vantage-diorama/README_ui.md
@@ -586,6 +586,41 @@ Bus publishes `RecordRemoved { id }`; the Scenery's reload finds nothing in
 cache and flips to `RecordStatus::NotFound`. Your render branch handles it
 (close the sheet, show a banner, whatever).
 
+### Editing — optimistic writes
+
+A form saves through `dio.write_optimistic(op)` (or the `dio.patch_optimistic(id,
+partial)` shorthand). The value is staged in the cache and shown **immediately**
+— the row's `EnrichedRecord.status` flips to `RowStatus::PendingWrite` — while
+the write-through runs in the background. On success it settles to `Fresh`; on
+failure the cache pre-image is restored and the row flips to
+`RowStatus::WriteFailed { error }`, so the form reverts rather than lying about a
+value that didn't save.
+
+```rust
+// On the form's save button:
+let edited = self.form.changed_fields();          // Record<CborValue> of edits
+let dio = self.dio.clone();
+let id = self.id.clone();
+cx.spawn(async move {
+    // Returns Err after a successful rollback — surface it if you like, but the
+    // scenery already flipped the row to WriteFailed for the UI to render.
+    let _ = dio.patch_optimistic(id, edited).await;
+});
+```
+
+Because every view reads the one cache row, the edit reflects across **every**
+bound scenery at once — the grid row, a second detail sheet, a KPI badge — via
+the same `RecordChanged` fan-out, with no extra wiring. Render the row's
+`status` to show a "saving…" affordance and an error badge:
+
+```rust
+match record.status {
+    RowStatus::PendingWrite      => spinner("saving…"),
+    RowStatus::WriteFailed { .. } => error_badge("couldn't save — reverted"),
+    _                            => normal_cell(record),
+}
+```
+
 ## `ValueScenery` — counters and badges
 
 ```rust

--- a/vantage-diorama/src/dio/event_bus.rs
+++ b/vantage-diorama/src/dio/event_bus.rs
@@ -25,6 +25,23 @@ pub enum DioEvent {
         error: String,
     },
 
+    /// An optimistic write was just staged in the cache: the new value is
+    /// already visible, but the write-through hasn't confirmed yet. Sceneries
+    /// flip the row for `id` to [`PendingWrite`](crate::RowStatus::PendingWrite).
+    WritePending {
+        id: String,
+    },
+
+    /// An optimistic write failed and its cache pre-image was restored. The
+    /// value has reverted; sceneries surface the error by flipping the row for
+    /// `id` to [`WriteFailed`](crate::RowStatus::WriteFailed). Distinct from
+    /// [`WriteFailed`](Self::WriteFailed), the fire-and-forget facade-queue
+    /// failure that does not touch the cache.
+    WriteReverted {
+        id: String,
+        error: String,
+    },
+
     /// Emitted by `TableScenery` once a `set_viewport` / `request_load_more`
     /// has cleared its debounce window and committed a viewport. Always
     /// fires; a viewport entirely inside the cached range still emits this

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -1,6 +1,7 @@
 pub mod event_bus;
 pub mod hot_tier;
 pub mod impls;
+mod optimistic;
 pub(crate) mod query_index;
 pub mod refresh;
 pub mod shell;

--- a/vantage-diorama/src/dio/optimistic.rs
+++ b/vantage-diorama/src/dio/optimistic.rs
@@ -1,0 +1,108 @@
+//! Optimistic write path — stage a write in the cache and notify views
+//! *before* the write-through confirms, then either commit or roll back.
+//!
+//! This is what makes form edits feel instant: the new value is visible the
+//! moment the user hits save (rows flip to
+//! [`PendingWrite`](crate::RowStatus::PendingWrite)), the actual write runs in
+//! the background, and on failure the cache pre-image is restored and the row
+//! flips to [`WriteFailed`](crate::RowStatus::WriteFailed). Because every view
+//! reads the one cache row, the edit reflects across every bound scenery at
+//! once.
+//!
+//! Contract: in this path the cache is **framework-managed**. The `on_write`
+//! callback should be master-authoritative (write upstream); it may also touch
+//! the cache, but the optimistic stage and the rollback are what views observe.
+
+use vantage_core::Result;
+use vantage_types::Record;
+
+use ciborium::Value as CborValue;
+
+use crate::dio::{Dio, DioEvent, DioInner};
+use crate::ops::WriteOp;
+
+impl Dio {
+    /// Apply `op` optimistically: stage it in the cache, publish
+    /// [`WritePending`](DioEvent::WritePending) so views show the new value as
+    /// `PendingWrite`, run the write-through, then either confirm (publish
+    /// [`RecordChanged`](DioEvent::RecordChanged), rows settle to `Fresh`) or
+    /// restore the cache pre-image and publish
+    /// [`WriteReverted`](DioEvent::WriteReverted) (rows revert and show
+    /// `WriteFailed`).
+    ///
+    /// Returns `Ok(())` once committed, or the write-through's error after a
+    /// successful rollback. `DeleteAll` has no single-row pre-image to stage,
+    /// so it runs straight through the write-through with no optimism.
+    pub async fn write_optimistic(&self, op: WriteOp) -> Result<()> {
+        let Some(id) = op.id().map(str::to_string) else {
+            return crate::dio::worker::run_write_through(self, op).await;
+        };
+
+        // 1. Snapshot the pre-image so a failed write can roll back exactly.
+        let pre = self.inner.cache.get_value(&id).await?;
+
+        // 2. Stage the optimistic value and announce it — views update now.
+        apply_to_cache(&self.inner, &op, pre.as_ref()).await?;
+        let _ = self
+            .inner
+            .event_bus
+            .send(DioEvent::WritePending { id: id.clone() });
+
+        // 3. Run the real write-through.
+        match crate::dio::worker::run_write_through(self, op).await {
+            Ok(()) => {
+                let _ = self.inner.event_bus.send(DioEvent::RecordChanged { id });
+                Ok(())
+            }
+            Err(err) => {
+                // 4. Roll the cache back to the pre-image and surface the error.
+                match &pre {
+                    Some(prev) => self.inner.cache.insert_value(&id, prev).await?,
+                    None => self.inner.cache.delete_value(&id).await?,
+                }
+                let _ = self.inner.event_bus.send(DioEvent::WriteReverted {
+                    id,
+                    error: err.to_string(),
+                });
+                Err(err)
+            }
+        }
+    }
+
+    /// Convenience for the common form-edit case: merge `partial` into the row
+    /// at `id` optimistically.
+    pub async fn patch_optimistic(
+        &self,
+        id: impl Into<String>,
+        partial: Record<CborValue>,
+    ) -> Result<()> {
+        self.write_optimistic(WriteOp::Patch {
+            id: id.into(),
+            partial,
+        })
+        .await
+    }
+}
+
+/// Write the op's optimistic result into the cache. `Patch` merges onto the
+/// pre-image so untouched columns survive (the cache stores whole rows).
+async fn apply_to_cache(
+    inner: &DioInner,
+    op: &WriteOp,
+    pre: Option<&Record<CborValue>>,
+) -> Result<()> {
+    match op {
+        WriteOp::Insert { id, record } | WriteOp::Replace { id, record } => {
+            inner.cache.insert_value(id, record).await
+        }
+        WriteOp::Patch { id, partial } => {
+            let mut merged = pre.cloned().unwrap_or_default();
+            for (k, v) in partial {
+                merged.insert(k.clone(), v.clone());
+            }
+            inner.cache.insert_value(id, &merged).await
+        }
+        WriteOp::Delete { id } => inner.cache.delete_value(id).await,
+        WriteOp::DeleteAll => Ok(()),
+    }
+}

--- a/vantage-diorama/src/dio/worker.rs
+++ b/vantage-diorama/src/dio/worker.rs
@@ -28,7 +28,7 @@ pub(crate) async fn write_worker_loop(inner: Weak<DioInner>, mut rx: mpsc::Recei
         };
         let dio = Dio { inner: strong };
         let id_for_event = op.id().map(str::to_string);
-        let outcome = dispatch(&dio, op).await;
+        let outcome = run_write_through(&dio, op).await;
         if let Err(err) = outcome {
             tracing::error!(error = %err, "Dio write op failed");
             let _ = dio.inner.event_bus.send(DioEvent::WriteFailed {
@@ -39,7 +39,11 @@ pub(crate) async fn write_worker_loop(inner: Weak<DioInner>, mut rx: mpsc::Recei
     }
 }
 
-async fn dispatch(dio: &Dio, op: WriteOp) -> Result<()> {
+/// Run a write through the lens's `on_write` callback, or the default
+/// write-to-master path when none is registered. Shared by the fire-and-forget
+/// queue worker and the optimistic write path
+/// ([`Dio::write_optimistic`](crate::Dio::write_optimistic)).
+pub(crate) async fn run_write_through(dio: &Dio, op: WriteOp) -> Result<()> {
     if let Some(cb) = dio.inner.lens.callbacks.on_write.as_ref() {
         cb(dio, op).await
     } else {

--- a/vantage-diorama/src/scenery/enriched_record.rs
+++ b/vantage-diorama/src/scenery/enriched_record.rs
@@ -40,6 +40,28 @@ impl EnrichedRecord {
         }
     }
 
+    /// Wrap a row carrying an **optimistically-staged** write — the new value
+    /// is shown immediately while the write-through is in flight.
+    pub fn pending_write(record: Record<CborValue>) -> Self {
+        Self {
+            record,
+            status: RowStatus::PendingWrite,
+            dirty_fields: None,
+            fetched_at: Some(SystemTime::now()),
+        }
+    }
+
+    /// Wrap a row whose optimistic write failed and was rolled back: `record`
+    /// is the restored pre-image, `status` carries the error for the UI.
+    pub fn write_failed(record: Record<CborValue>, error: String) -> Self {
+        Self {
+            record,
+            status: RowStatus::WriteFailed { error },
+            dirty_fields: None,
+            fetched_at: Some(SystemTime::now()),
+        }
+    }
+
     /// Mark a row whose detail pass failed. Keeps the partial (list-pass)
     /// `record` so the row stays visible, but records the error so the UI can
     /// surface it. Carries over the previous `fetched_at`.

--- a/vantage-diorama/src/scenery/record.rs
+++ b/vantage-diorama/src/scenery/record.rs
@@ -96,6 +96,34 @@ impl RecordSceneryState {
         self.bump_generation();
     }
 
+    /// Show the optimistically-staged value while the write is in flight.
+    async fn set_pending_write(&self) {
+        let Some(dio_inner) = self.dio_weak.upgrade() else {
+            return;
+        };
+        if let Ok(Some(rec)) = dio_inner.cache.get_value(&self.id).await {
+            *self.record.write().unwrap() = Some(Arc::new(EnrichedRecord::pending_write(rec)));
+            self.bump_generation();
+        }
+    }
+
+    /// The optimistic write was rolled back: re-read the restored pre-image and
+    /// flag the failure so the form can surface it.
+    async fn set_write_failed(&self, error: String) {
+        let Some(dio_inner) = self.dio_weak.upgrade() else {
+            return;
+        };
+        match dio_inner.cache.get_value(&self.id).await {
+            Ok(Some(rec)) => {
+                *self.record.write().unwrap() =
+                    Some(Arc::new(EnrichedRecord::write_failed(rec, error)));
+            }
+            // Pre-image was absent (a failed insert): drop the row.
+            _ => *self.record.write().unwrap() = None,
+        }
+        self.bump_generation();
+    }
+
     fn bump_generation(&self) {
         let next = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
         // `send_replace` (not `send`) — the stored value must reflect the
@@ -124,6 +152,12 @@ async fn reload_loop(state: Arc<RecordSceneryState>, mut bus: broadcast::Receive
                 if let Err(e) = state.reload().await {
                     tracing::error!(error = %e, "RecordScenery reload failed");
                 }
+            }
+            Ok(DioEvent::WritePending { id }) if id == state.id => {
+                state.set_pending_write().await;
+            }
+            Ok(DioEvent::WriteReverted { id, error }) if id == state.id => {
+                state.set_write_failed(error).await;
             }
             Ok(_) => {}
             Err(broadcast::error::RecvError::Lagged(_)) => {

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -52,6 +52,17 @@ pub(crate) async fn reload_loop(
                     | Ok(DioEvent::Invalidated) => {
                         refresh(&state).await;
                     }
+                    // Optimistic-write affordance: stamp just the affected row
+                    // rather than reseeding the whole map. On success the
+                    // trailing `RecordChanged` settles it back to `Fresh`.
+                    Ok(DioEvent::WritePending { id }) => {
+                        state.mark_row(&id, crate::scenery::RowStatus::PendingWrite).await;
+                    }
+                    Ok(DioEvent::WriteReverted { id, error }) => {
+                        state
+                            .mark_row(&id, crate::scenery::RowStatus::WriteFailed { error })
+                            .await;
+                    }
                     Ok(DioEvent::WriteFailed { .. })
                     | Ok(DioEvent::ViewportChanged { .. })
                     | Ok(DioEvent::RangeLoaded { .. })

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -10,7 +10,7 @@ use vantage_vista::VistaCapabilities;
 
 use crate::dio::{DioInner, Generation};
 use crate::lens::SceneryChunkTarget;
-use crate::scenery::enriched_record::EnrichedRecord;
+use crate::scenery::enriched_record::{EnrichedRecord, RowStatus};
 
 use super::helpers::{cbor_cmp, matches_conditions, matches_search};
 use super::{SortDir, ViewportRequest};
@@ -175,6 +175,30 @@ impl TableSceneryState {
             .insert(idx, Arc::new(EnrichedRecord::fresh(rec)));
         self.bump_generation();
         Ok(())
+    }
+
+    /// Stamp the slot for `id` with `status`, re-reading its current cache
+    /// value (the optimistic-write affordance — `PendingWrite` while a write is
+    /// in flight, `WriteFailed` after a rollback). No-op if the row isn't in
+    /// this scenery's window. Bumps generation so bound widgets repaint.
+    pub(crate) async fn mark_row(&self, id: &str, status: RowStatus) {
+        let Some(dio_inner) = self.dio_weak.upgrade() else {
+            return;
+        };
+        let Some(idx) = self.id_to_idx.read().unwrap().get(id).copied() else {
+            return;
+        };
+        let Ok(Some(rec)) = dio_inner.cache.get_value(id).await else {
+            return;
+        };
+        let enriched = EnrichedRecord {
+            record: rec,
+            status,
+            dirty_fields: None,
+            fetched_at: Some(std::time::SystemTime::now()),
+        };
+        self.rows.write().unwrap().insert(idx, Arc::new(enriched));
+        self.bump_generation();
     }
 
     /// True if every index in `range` is loaded.

--- a/vantage-diorama/tests/bdd_support/steps/write_path.rs
+++ b/vantage-diorama/tests/bdd_support/steps/write_path.rs
@@ -5,6 +5,7 @@
 use ciborium::Value as CborValue;
 use cucumber::{gherkin::Step, given, then, when};
 use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
+use vantage_diorama::WriteOp;
 use vantage_types::Record;
 
 use crate::bdd_support::{
@@ -104,6 +105,17 @@ async fn patch_via_facade(w: &mut DioramaWorld, step: &Step) {
             .await
             .expect("facade patch enqueue");
     }
+    w.settle().await;
+}
+
+#[when(regex = r#"^I optimistically patch "([^"]+)" with (\w+) "([^"]+)"$"#)]
+async fn optimistic_patch(w: &mut DioramaWorld, id: String, field: String, value: String) {
+    let dio = w.dio.as_ref().expect("dio not created");
+    let mut partial: Record<CborValue> = Record::new();
+    partial.insert(field, CborValue::Text(value));
+    // Drives the whole optimistic flow (stage → write-through → commit/rollback).
+    // A rollback returns Err; the scenario asserts the reverted state, so swallow it.
+    let _ = dio.write_optimistic(WriteOp::Patch { id, partial }).await;
     w.settle().await;
 }
 

--- a/vantage-diorama/tests/features/optimistic_write.feature
+++ b/vantage-diorama/tests/features/optimistic_write.feature
@@ -1,0 +1,32 @@
+Feature: Optimistic writes
+
+  Step 4 — `dio.write_optimistic(op)` stages the new value in the cache and
+  announces it (`WritePending`) before the write-through runs, so a form edit is
+  visible instantly. On success the value is confirmed (`RecordChanged`); on
+  failure the cache pre-image is restored and the error surfaced
+  (`WriteReverted`) — the view reverts, never stuck on a value that didn't save.
+
+  Scenario: an optimistic write commits — staged, then confirmed
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that records calls
+    When the dio is created
+    And I optimistically patch "a" with title "alpha"
+    And I wait for 2 events
+    Then the cache record "a" has title "alpha"
+    And on_write has been called 1 time
+    And the event log matches snapshot "optimistic_commit"
+
+  Scenario: an optimistic write rolls back on failure — value reverts
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And an on_write callback that always errors
+    When the dio is created
+    And I optimistically patch "a" with title "alpha"
+    And I wait for 2 events
+    Then the cache record "a" has title "one"
+    And the event log matches snapshot "optimistic_rollback"

--- a/vantage-diorama/tests/record_scenery.rs
+++ b/vantage-diorama/tests/record_scenery.rs
@@ -178,6 +178,161 @@ async fn record_scenery_with_skips_cache_lookup() -> Result<()> {
     Ok(())
 }
 
+// ---- optimistic writes ------------------------------------------------------
+
+use tokio::sync::Notify;
+use vantage_diorama::RowStatus;
+
+fn partial_name(name: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("name".to_string(), cbor_text(name));
+    r
+}
+
+/// Lens whose `on_write` blocks on `gate` until released, so a test can observe
+/// the `PendingWrite` window before the write-through completes.
+async fn build_lens_gated_write(cache_path: std::path::PathBuf, gate: Arc<Notify>) -> Arc<Lens> {
+    Arc::new(
+        Lens::new()
+            .cache_at(cache_path)
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .on_write(move |_dio, _op| {
+                let gate = gate.clone();
+                async move {
+                    gate.notified().await;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    )
+}
+
+/// Lens whose `on_write` always errors — drives the rollback path.
+async fn build_lens_erroring_write(cache_path: std::path::PathBuf) -> Arc<Lens> {
+    Arc::new(
+        Lens::new()
+            .cache_at(cache_path)
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .on_write(|_dio, _op| async move { Err(vantage_core::error!("upstream rejected")) })
+            .build()
+            .expect("build lens"),
+    )
+}
+
+/// An optimistic write shows the new value as `PendingWrite` immediately, then
+/// settles to `Fresh` once the write-through confirms.
+#[tokio::test]
+async fn optimistic_patch_shows_pending_then_fresh() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let gate = Arc::new(Notify::new());
+    let lens = build_lens_gated_write(tmp.path().join("cache.redb"), gate.clone()).await;
+    let dio = lens.make_dio(seeded_master()).await?;
+
+    let scenery = dio.record_scenery("a").await?;
+    let mut gen_rx = scenery.subscribe();
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+
+    // Run the write on a task — it stages the value + emits WritePending, then
+    // blocks in on_write until we release the gate.
+    let dio2 = dio.clone();
+    let handle =
+        tokio::spawn(async move { dio2.patch_optimistic("a", partial_name("edited")).await });
+
+    wait_for_gen(&mut gen_rx, g0).await;
+    let r = scenery.record().expect("record present");
+    assert_eq!(r.record.get("name"), Some(&cbor_text("edited")), "value staged");
+    assert_eq!(r.record.get("price"), Some(&CborValue::Integer(30.into())), "patch merges");
+    assert!(matches!(r.status, RowStatus::PendingWrite), "got {:?}", r.status);
+
+    // Release the write-through → confirms → Fresh.
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    gate.notify_one();
+    handle.await.unwrap().expect("write commits");
+    wait_for_gen(&mut gen_rx, g1).await;
+
+    let r = scenery.record().expect("record present");
+    assert_eq!(r.record.get("name"), Some(&cbor_text("edited")));
+    assert!(matches!(r.status, RowStatus::Fresh), "got {:?}", r.status);
+    Ok(())
+}
+
+/// A failed optimistic write rolls the value back to the pre-image and flags the
+/// row `WriteFailed`.
+#[tokio::test]
+async fn optimistic_patch_rolls_back_to_write_failed() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = build_lens_erroring_write(tmp.path().join("cache.redb")).await;
+    let dio = lens.make_dio(seeded_master()).await?;
+
+    let scenery = dio.record_scenery("a").await?;
+
+    let outcome = dio.patch_optimistic("a", partial_name("edited")).await;
+    assert!(outcome.is_err(), "a rejecting write-through must surface the error");
+
+    // The reactor processes WritePending then WriteReverted; wait for the row to
+    // settle on the failure.
+    let mut failed = false;
+    for _ in 0..200 {
+        if let Some(r) = scenery.record()
+            && matches!(r.status, RowStatus::WriteFailed { .. })
+        {
+            assert_eq!(
+                r.record.get("name"),
+                Some(&cbor_text("alpha")),
+                "value reverted to the pre-image"
+            );
+            failed = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert!(failed, "row never reached WriteFailed");
+    Ok(())
+}
+
+/// An edit reflects across every open view of the record — two independent
+/// `RecordScenery`s for the same id both update from the one cache row.
+#[tokio::test]
+async fn optimistic_edit_reflects_in_a_second_record_scenery() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = build_lens(tmp.path().join("cache.redb")).await?;
+    let dio = lens.make_dio(seeded_master()).await?;
+
+    let s1 = dio.record_scenery("a").await?;
+    let s2 = dio.record_scenery("a").await?;
+
+    // No on_write → default write-through to master; commits.
+    dio.patch_optimistic("a", partial_name("shared")).await?;
+
+    for (label, s) in [("s1", &s1), ("s2", &s2)] {
+        let mut seen = false;
+        for _ in 0..200 {
+            if let Some(r) = s.record()
+                && r.record.get("name") == Some(&cbor_text("shared"))
+            {
+                seen = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(seen, "{label} never observed the shared edit");
+    }
+    Ok(())
+}
+
 #[tokio::test]
 async fn scenery_outlives_dio_handle_drop() -> Result<()> {
     let tmp = TempDir::new().unwrap();

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_commit.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_commit.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+expression: events
+---
+- "WritePending { id: \"a\" }"
+- "RecordChanged { id: \"a\" }"

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_rollback.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_rollback.snap
@@ -1,0 +1,6 @@
+---
+source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+expression: events
+---
+- "WritePending { id: \"a\" }"
+- "WriteReverted { id: \"a\", error: \"on_write rejected\" }"


### PR DESCRIPTION
Step 4 of taking the Scenery layer a level higher. **Stacked on #311.**

## What's in here
- `Dio::write_optimistic(op)` + `patch_optimistic(id, partial)`: snapshot cache pre-image → stage value → `WritePending` → write-through → success `RecordChanged` (settles `Fresh`) / failure restore pre-image + `WriteReverted` (row `WriteFailed`). Write-through dispatch extracted (`worker::run_write_through`) and shared with the queue worker.
- Two new bus events (`WritePending`, `WriteReverted`) handled by **both** `RecordScenery` and `TableScenery` (`mark_row` stamps just the affected slot). `RowStatus::PendingWrite`/`WriteFailed` now have producers.
- Cross-view consistency via the existing `RecordChanged` fan-out — one cache row, every bound scenery updates.

## Verification
`cargo test -p vantage-diorama`: full suite green (65 BDD incl. 2 optimistic scenarios with golden traces; 10 record_scenery incl. 3 new). Clippy clean. A gated test deterministically proves the PendingWrite→Fresh window; the rollback test proves value-revert + WriteFailed; the cross-view test proves two sceneries for one id both update.

No behaviour change to the existing facade write queue (optimistic is a distinct entry point).