### PR TITLE
diorama: titles_only() picker projection (dropdown/autocomplete)

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.6.3 — unreleased
 
+- `titles_only()` table-scenery projection — the dropdown / autocomplete shape.
+  A picker binds to the same `TableScenery` a grid does (visible band →
+  `set_viewport`, typeahead → `set_search`), projected to the title columns. On
+  an augmented (two-pass) lookup, `titles_only` **suppresses the detail pass**:
+  the picker serves the cheap list-pass rows and never pays for per-row
+  hydration, so a large lookup opens a picker as cheaply as it lists. A
+  `titles_only` picker keys distinctly in the dedup registry from a full grid
+  over the same query, so neither inherits the other's hydration.
 - Optimistic writes. `Dio::write_optimistic(op)` (and the `patch_optimistic`
   shorthand) stage a write in the cache and announce it (`WritePending`) before
   the write-through runs, so a form edit shows instantly as

--- a/vantage-diorama/README_ui.md
+++ b/vantage-diorama/README_ui.md
@@ -93,6 +93,33 @@ drop(elsewhere);
 assert_eq!(dio.live_table_scenery_count(), 0); // released → evicted, no leak
 ```
 
+## Dropdowns & autocomplete reuse the grid mechanic
+
+A dropdown (FK picker) and an autocomplete are the **same** `TableScenery` a grid
+binds to — just projected to the title columns. Open with `.titles_only()`:
+
+```rust
+// A country picker — id + title columns, lazily loaded, search-as-you-type.
+let countries = countries_dio.table_scenery().titles_only().open().await?;
+// DropdownField renders `countries.row(i)`'s title column and submits its id.
+// AutocompleteField additionally forwards keystrokes:
+//   countries.set_search((!q.is_empty()).then(|| q));
+// and its visible band:
+//   countries.set_viewport(visible);
+```
+
+Everything you already know about grids applies: the visible band drives loading
+via `set_viewport`, typeahead drives `set_search`, and the dedup registry means a
+form with eight pickers over the same lookup table costs **one** scenery, not
+eight (see *Sharing and lifecycle*).
+
+The one difference `.titles_only()` makes is on an **augmented (two-pass)**
+lookup: it suppresses the detail pass. The picker serves the cheap list-pass
+rows (id + title) and never pays for per-row hydration, so a 10,000-row lookup
+opens a picker as cheaply as it lists. A `titles_only` picker and a full grid
+over the same query are deliberately distinct sceneries — the grid hydrates, the
+picker doesn't — so neither drags cost onto the other.
+
 ## The pull-on-render contract
 
 GPUI's `TableDelegate` polls the delegate on every render frame. The relevant

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -22,6 +22,7 @@ pub struct TableSceneryBuilder {
     pub(crate) page_size: usize,
     pub(crate) eager: bool,
     pub(crate) initial_range: Option<std::ops::Range<usize>>,
+    pub(crate) titles_only: bool,
 }
 
 impl TableSceneryBuilder {
@@ -34,6 +35,7 @@ impl TableSceneryBuilder {
             page_size: 100,
             eager: false,
             initial_range: None,
+            titles_only: false,
         }
     }
 
@@ -73,6 +75,19 @@ impl TableSceneryBuilder {
         self
     }
 
+    /// Project to the cheap title columns only — the dropdown / autocomplete
+    /// shape. On an **augmented (two-pass)** table this suppresses the detail
+    /// pass entirely: the scenery serves the list-pass rows (id + title columns)
+    /// and never pays for per-row hydration, so a 10,000-row lookup opens a
+    /// picker as cheaply as it lists. Same mechanic as a grid otherwise —
+    /// `set_search` for typeahead, `set_viewport` for the visible band. A
+    /// `titles_only` picker and a full grid over the same query are distinct
+    /// sceneries (the grid hydrates, the picker doesn't).
+    pub fn titles_only(mut self) -> Self {
+        self.titles_only = true;
+        self
+    }
+
     /// Open the Scenery — runs `total_provider` (if configured),
     /// seeds the sparse map from the cache, spawns the reactor and
     /// viewport-debounce tasks, optionally schedules a background
@@ -86,11 +101,14 @@ impl TableSceneryBuilder {
             page_size,
             eager: _,
             initial_range,
+            titles_only,
         } = self;
 
-        // Dedup key over (shape, conditions, sort, search). A live scenery
-        // for the same query is shared — one reactor, one cache window, one
-        // in-flight JoinSet — instead of standing up a parallel copy.
+        // Dedup key over (shape, conditions, sort, search, titles_only). A live
+        // scenery for the same query is shared — one reactor, one cache window,
+        // one in-flight JoinSet — instead of standing up a parallel copy. A
+        // `titles_only` picker keys distinctly from a full grid so the picker
+        // never inherits the grid's detail hydration.
         let key = {
             let vista_sort = sort.as_ref().map(|(col, dir)| {
                 let dir = match dir {
@@ -100,9 +118,10 @@ impl TableSceneryBuilder {
                 (col.as_str(), dir)
             });
             format!(
-                "table\u{1}{}\u{1}{}",
+                "table\u{1}{}\u{1}{}\u{1}{}",
                 dio.master.index_key(&conditions, vista_sort),
                 search.as_deref().unwrap_or(""),
+                titles_only as u8,
             )
         };
         if let Some(existing) = dio.lookup_table_scenery(&key) {
@@ -151,6 +170,7 @@ impl TableSceneryBuilder {
             load_in_flight: Mutex::new(None),
             master_capabilities,
             two_pass,
+            titles_only,
             index: RwLock::new(index),
             registry_key: Mutex::new(Some(key.clone())),
             detail_in_flight: Mutex::new(std::collections::HashSet::new()),

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -168,8 +168,14 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     // Two-pass: a viewport drives the detail pass over the visible rows, not a
     // random-access chunk load. Hydration dedups against already-`Complete`
     // ids, so re-entering the same viewport is a no-op.
+    //
+    // A `titles_only` picker skips hydration entirely — it only needs the
+    // cheap list columns, so the viewport just commits (the `ViewportChanged`
+    // above) and no detail fetch is issued.
     if state.two_pass {
-        super::two_pass::run_detail_for_range(state.clone(), visible).await;
+        if !state.titles_only {
+            super::two_pass::run_detail_for_range(state.clone(), visible).await;
+        }
         return;
     }
 

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -67,6 +67,10 @@ pub(crate) struct TableSceneryState {
     // the legacy single-pass path.
     /// Whether this scenery drives two-pass (list + detail) loading.
     pub(crate) two_pass: bool,
+    /// Dropdown / autocomplete projection: serve the cheap list columns and
+    /// **skip the detail pass** even on a two-pass table. The list pass still
+    /// runs (rows carry id + title columns); per-row hydration never fires.
+    pub(crate) titles_only: bool,
     /// The shared per-query ordered index for this scenery's conditions/sort,
     /// keyed by [`Vista::index_key`](vantage_vista::Vista::index_key). `None` in single-pass mode.
     /// Swappable: a `set_sort` / `set_search` re-points it at the index for the

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -304,6 +304,53 @@ async fn sort_change_restarts_augmentation_without_scrolling() {
     assert!(scenery.row(0).is_some(), "row 0 never blanks on revert");
 }
 
+/// A `titles_only` picker (dropdown/autocomplete) over an augmented table lists
+/// the cheap columns and **never hydrates detail** — even as its viewport
+/// moves — while a full grid over the same query is a distinct scenery that
+/// does hydrate. The picker pays list cost only.
+#[tokio::test]
+async fn titles_only_picker_skips_detail_hydration() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    let picker = dio.table_scenery().titles_only().page_size(2).open().await.unwrap();
+    picker.set_viewport(0..2);
+    // Let the viewport debounce + (suppressed) detail path run.
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    // List columns are present; the row stays Incomplete and no detail ran.
+    assert_eq!(branch_of(&picker, 0).as_deref(), Some("main"), "title column listed");
+    assert!(
+        matches!(status_of(&picker, 0), Some(RowStatus::Incomplete)),
+        "picker rows stay Incomplete: {:?}",
+        status_of(&picker, 0)
+    );
+    assert!(detail_of(&picker, 0).is_none(), "no detail column");
+    assert_eq!(count_with_prefix(&log, "detail"), 0, "picker must not hydrate");
+    assert_eq!(count_with_prefix(&log, "list"), 1, "one list page");
+
+    // A full grid over the same query is a DISTINCT scenery (it hydrates), so
+    // the Dio now holds two live sceneries.
+    let grid = dio.table_scenery().page_size(2).open().await.unwrap();
+    assert!(
+        !std::sync::Arc::ptr_eq(&picker, &grid),
+        "titles_only keys distinctly from a full grid"
+    );
+    assert_eq!(dio.live_table_scenery_count(), 2);
+
+    grid.set_viewport(0..2);
+    eventually("grid hydrates", || {
+        matches!(status_of(&grid, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+    assert!(
+        count_with_prefix(&log, "detail") > 0,
+        "the full grid hydrates even though the picker didn't"
+    );
+}
+
 /// Sequential, no-total paging: each `request_load_more` fetches the next list
 /// page; a short final page flips `has_more` false and freezes the estimate.
 #[tokio::test]


### PR DESCRIPTION
Step 5 of taking the Scenery layer a level higher. **Stacked on #312.**

## What's in here (diorama core)
- `TableSceneryBuilder::titles_only()` — the dropdown / autocomplete shape. A picker binds to the same `TableScenery` a grid does (visible band → `set_viewport`, typeahead → `set_search`), projected to the title columns.
- On an **augmented (two-pass)** lookup, `titles_only` **suppresses the detail pass**: the picker serves cheap list-pass rows (id + title) and never hydrates, so a large lookup opens a picker as cheaply as it lists.
- `titles_only` keys distinctly in the dedup registry from a full grid over the same query, so neither inherits the other's hydration.

## Verification
`cargo test -p vantage-diorama`: full suite green incl. new `titles_only_picker_skips_detail_hydration` (0 detail calls; picker + grid are distinct sceneries, live count 2; grid still hydrates). Clippy clean.

## Follow-on (UI)
The GPUI `DropdownField`/`AutocompleteField` components in vantage-ui are the consumer of this mechanic — documented in README_ui.md ("Dropdowns & autocomplete reuse the grid mechanic") with the binding snippet; the diorama behaviour they rely on is what's proven here.