### PR TITLE
diorama: no-flicker Dio::reload (swappable master)

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.6.3 — unreleased
 
+- No-flicker reload. The master Vista is now swappable, and `Dio::reload(new_master)`
+  re-points a Dio at a freshly-built Vista (e.g. after its VistaFactory reloaded
+  the YAML/script) and rebuilds the cache from it — without tearing the Dio down.
+  Open sceneries keep their current rows visible until the new data is staged and
+  swap atomically on a single trailing `Invalidated`, so a grid never flashes
+  empty even when the dataset changes wholesale. `Dio::master()` now returns
+  `Arc<Vista>` (was `&Vista`); the `dio.vista()` facade snapshots its schema at
+  construction. Stale per-query indexes are dropped on reload.
 - `titles_only()` table-scenery projection — the dropdown / autocomplete shape.
   A picker binds to the same `TableScenery` a grid does (visible band →
   `set_viewport`, typeahead → `set_search`), projected to the title columns. On

--- a/vantage-diorama/README_lens.md
+++ b/vantage-diorama/README_lens.md
@@ -595,3 +595,27 @@ let report_lens = Arc::new(
 
 Dios under different Lenses are independent. Cross-Lens invalidation, if you
 need it, is done explicitly in callbacks.
+
+## Reloading — when the source itself changes
+
+A Vista is produced by a VistaFactory, and that factory can reload: someone edits
+the YAML that defines a table, or the script that backs it, and the dataset is now
+*wholly different* — not just a few changed rows. That's not a refresh (same
+shape, new values); it's a **reload** (new master Vista, new data).
+
+`dio.reload(new_master)` handles it without tearing the Dio down or blanking the
+UI:
+
+```rust
+// The catalog rebuilt this model's Vista; hand the Dio the new one.
+let fresh = catalog.build_vista("orders")?;
+dio.reload(fresh).await?;
+```
+
+What it does, in order: swaps the master Vista, drops the stale per-query indexes
+(two-pass orders rebuild against the new data), clears and refills the cache from
+the new master via your `on_start` (or `on_refresh`), and only then publishes one
+`Invalidated`. Open sceneries keep showing their current rows the whole time and
+swap to the new data in a single atomic step on that `Invalidated` — so a grid
+mid-scroll never flashes empty, even though the dataset changed underneath it.
+"Responsive first, eventually precise," applied to a source reload.

--- a/vantage-diorama/src/dio/impls/table_shell.rs
+++ b/vantage-diorama/src/dio/impls/table_shell.rs
@@ -13,15 +13,15 @@ impl TableShell for DioShell {
     // ---- Schema forwarding to master ----------------------------------------
 
     fn columns(&self) -> &IndexMap<String, Column> {
-        self.dio.master.source.columns()
+        &self.columns
     }
 
     fn references(&self) -> &IndexMap<String, Reference> {
-        self.dio.master.source.references()
+        &self.references
     }
 
     fn id_column(&self) -> Option<&str> {
-        self.dio.master.source.id_column()
+        self.id_column.as_deref()
     }
 
     // ---- Reads — cache-first --------------------------------------------------

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -59,7 +59,10 @@ pub struct Dio {
 
 pub(crate) struct DioInner {
     pub(crate) lens: Arc<Lens>,
-    pub(crate) master: Vista,
+    /// The master Vista, swappable so a [`reload`](Dio::reload) can re-point the
+    /// Dio at a freshly-built Vista (e.g. after its VistaFactory reloaded)
+    /// without tearing the Dio down. Read via [`Dio::master`].
+    pub(crate) master: std::sync::RwLock<Arc<Vista>>,
     pub(crate) cache: Arc<dyn CacheTable>,
     pub(crate) cache_table_name: String,
     pub(crate) write_queue: mpsc::Sender<WriteOp>,
@@ -125,8 +128,36 @@ impl DioInner {
 }
 
 impl Dio {
-    pub fn master(&self) -> &Vista {
-        &self.inner.master
+    /// The current master Vista (cloned `Arc`). Cheap; safe to hold across
+    /// awaits even while a concurrent [`reload`](Self::reload) swaps it.
+    pub fn master(&self) -> Arc<Vista> {
+        self.inner.master.read().unwrap().clone()
+    }
+
+    /// Re-point this Dio at a freshly-built master Vista and rebuild its cache
+    /// from it — the "its VistaFactory reloaded, the dataset may be wholly
+    /// different" path. The swap is **non-blanking**: open sceneries keep
+    /// showing their current rows until the cache is refilled, then soft-reseed
+    /// in one atomic swap on the trailing `Invalidated`. Stale per-query indexes
+    /// are dropped so two-pass orders rebuild against the new data.
+    pub async fn reload(&self, new_master: Vista) -> Result<()> {
+        *self.inner.master.write().unwrap() = Arc::new(new_master);
+        self.inner.query_indexes.lock().unwrap().clear();
+
+        // Refill the cache from the new master. The cache is briefly empty
+        // here — so we deliberately do NOT emit `Refreshing` (which an eager
+        // scenery would reseed on, blanking to the empty cache). No scenery
+        // reseeds until the single `Invalidated` below, by which point the new
+        // data is staged; open sceneries keep their old rows visible until then
+        // and swap in one atomic step, so nothing blanks.
+        self.inner.cache.clear().await?;
+        if let Some(on_start) = self.inner.lens.callbacks.on_start.as_ref() {
+            on_start(self).await?;
+        } else if let Some(on_refresh) = self.inner.lens.callbacks.on_refresh.as_ref() {
+            on_refresh(self).await?;
+        }
+        let _ = self.inner.event_bus.send(DioEvent::Invalidated);
+        Ok(())
     }
 
     pub fn cache(&self) -> &Arc<dyn CacheTable> {
@@ -230,7 +261,7 @@ impl Dio {
     /// etc.) while reads route through the cache and writes route
     /// through the Dio's queue.
     pub fn vista(&self) -> Vista {
-        let name = self.inner.master.name().to_string();
+        let name = self.master().name().to_string();
         let shell = DioShell::new(self.inner.clone());
         Vista::new(name, Box::new(shell))
     }

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -1,23 +1,34 @@
 use std::sync::Arc;
 
-use vantage_vista::VistaCapabilities;
+use indexmap::IndexMap;
+use vantage_vista::{Column, Reference, VistaCapabilities};
 
 use super::DioInner;
 
 /// `TableShell` impl that backs the Vista returned by `Dio::vista()`.
 ///
 /// Holds the shared inner Dio state so reads/writes route through the
-/// Dio's machinery while schema (columns, refs, id) is forwarded to
-/// the master Vista. Capability advertisement is the union of the
+/// Dio's machinery. Schema (columns, refs, id) is **snapshotted** from the
+/// master at construction so the facade doesn't borrow the now-swappable
+/// master across reads; a fresh `dio.vista()` after a [`reload`](crate::Dio::reload)
+/// captures the new schema. Capability advertisement is the union of the
 /// master's capabilities and what the Lens's callbacks unlock.
 pub struct DioShell {
     pub(crate) dio: Arc<DioInner>,
     pub(crate) capabilities: VistaCapabilities,
+    pub(crate) columns: IndexMap<String, Column>,
+    pub(crate) references: IndexMap<String, Reference>,
+    pub(crate) id_column: Option<String>,
 }
 
 impl DioShell {
     pub(crate) fn new(dio: Arc<DioInner>) -> Self {
-        let master_caps = dio.master.capabilities().clone();
+        let master = dio.master.read().unwrap();
+        let master_caps = master.capabilities().clone();
+        let columns = master.source.columns().clone();
+        let references = master.source.references().clone();
+        let id_column = master.source.id_column().map(str::to_string);
+        drop(master);
         let cbs = &dio.lens.callbacks;
         let has_on_write = cbs.on_write.is_some();
         let has_on_event = cbs.on_event.is_some();
@@ -48,6 +59,12 @@ impl DioShell {
             can_traverse_to_set: master_caps.can_traverse_to_set,
             can_build_ref_via_script: master_caps.can_build_ref_via_script,
         };
-        Self { dio, capabilities }
+        Self {
+            dio,
+            capabilities,
+            columns,
+            references,
+            id_column,
+        }
     }
 }

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -29,7 +29,7 @@ impl Lens {
 
         let inner = Arc::new(DioInner {
             lens: self.clone(),
-            master,
+            master: std::sync::RwLock::new(Arc::new(master)),
             cache,
             cache_table_name,
             write_queue: write_tx,

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -119,7 +119,7 @@ impl TableSceneryBuilder {
             });
             format!(
                 "table\u{1}{}\u{1}{}\u{1}{}",
-                dio.master.index_key(&conditions, vista_sort),
+                dio.master.read().unwrap().index_key(&conditions, vista_sort),
                 search.as_deref().unwrap_or(""),
                 titles_only as u8,
             )
@@ -131,7 +131,7 @@ impl TableSceneryBuilder {
         let (gen_tx, _gen_rx) = watch::channel(Generation::default());
         let (viewport_tx, viewport_rx) = mpsc::unbounded_channel();
 
-        let master_capabilities = dio.master.capabilities().clone();
+        let master_capabilities = dio.master.read().unwrap().capabilities().clone();
 
         // Two-pass engages only when the Lens registers an `on_load_detail`
         // callback. The shared per-query index is keyed by the master Vista's
@@ -146,7 +146,7 @@ impl TableSceneryBuilder {
                 };
                 (col.as_str(), dir)
             });
-            let key = dio.master.index_key(&conditions, vista_sort);
+            let key = dio.master.read().unwrap().index_key(&conditions, vista_sort);
             Some(dio.query_index(&key))
         } else {
             None

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -180,7 +180,11 @@ pub(crate) async fn resort(state: Arc<TableSceneryState>) {
         };
         (col.as_str(), dir)
     });
-    let key = dio_inner.master.index_key(&conditions, vista_sort);
+    let key = dio_inner
+        .master
+        .read()
+        .unwrap()
+        .index_key(&conditions, vista_sort);
     let new_index = dio_inner.query_index(&key);
     state.set_index(Some(new_index.clone()));
 

--- a/vantage-diorama/tests/reload.rs
+++ b/vantage-diorama/tests/reload.rs
@@ -1,0 +1,126 @@
+//! Step 6: `Dio::reload` — swap the master Vista + dataset in place without
+//! blanking open sceneries (the "its VistaFactory reloaded" path).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Lens, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn cbor_text(s: &str) -> CborValue {
+    CborValue::Text(s.to_string())
+}
+
+fn named(name: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("name".to_string(), cbor_text(name));
+    r
+}
+
+/// A master over an in-memory shell seeded with `(id, name)` rows.
+fn master(rows: &[(&str, &str)]) -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_id_column("id");
+    let mut shell = MockShell::new().with_metadata(metadata);
+    for (id, name) in rows {
+        shell = shell.with_record(*id, named(name));
+    }
+    Vista::new("items", Box::new(shell))
+}
+
+async fn eager_lens(cache_path: std::path::PathBuf) -> Arc<Lens> {
+    Arc::new(
+        Lens::new()
+            .cache_at(cache_path)
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .build()
+            .expect("build lens"),
+    )
+}
+
+fn name_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery
+        .row(idx)
+        .and_then(|r| r.record.get("name").and_then(|v| match v {
+            CborValue::Text(s) => Some(s.clone()),
+            _ => None,
+        }))
+}
+
+async fn eventually(label: &str, f: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if f() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("condition '{label}' not met within timeout");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reload_swaps_dataset_without_blanking() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = eager_lens(tmp.path().join("cache.redb")).await;
+    let dio = lens
+        .make_dio(master(&[("a", "alpha"), ("b", "beta")]))
+        .await?;
+
+    let scenery = dio.table_scenery().open().await?;
+    eventually("initial seed", || scenery.row_count() == 2).await;
+
+    // Sample row_count continuously while the reload runs — a non-blanking
+    // reload never lets it dip below the original 2 (the new rows swap in
+    // atomically; the cache being briefly empty must not reach the view).
+    let stop = Arc::new(AtomicBool::new(false));
+    let min_seen = Arc::new(AtomicUsize::new(usize::MAX));
+    let sampler = {
+        let sc = scenery.clone();
+        let stop = stop.clone();
+        let min_seen = min_seen.clone();
+        tokio::spawn(async move {
+            while !stop.load(Ordering::Acquire) {
+                min_seen.fetch_min(sc.row_count(), Ordering::SeqCst);
+                tokio::task::yield_now().await;
+            }
+            // one final sample after the flag flips
+            min_seen.fetch_min(sc.row_count(), Ordering::SeqCst);
+        })
+    };
+
+    // Reload with a wholly different dataset (3 rows, new ids).
+    dio.reload(master(&[("x", "ex"), ("y", "why"), ("z", "zee")]))
+        .await?;
+    eventually("reseed to new data", || scenery.row_count() == 3).await;
+
+    stop.store(true, Ordering::Release);
+    sampler.await.unwrap();
+
+    // New data is in view, old ids gone.
+    assert_eq!(scenery.row_count(), 3);
+    assert_eq!(name_at(&scenery, 0).as_deref(), Some("ex"));
+    assert!(
+        (0..3).all(|i| name_at(&scenery, i) != Some("alpha".into())),
+        "old rows must be gone after reload"
+    );
+    // The master swapped too.
+    assert_eq!(dio.master().get_count().await?, 3);
+
+    // No blank: the view never showed fewer than the original 2 rows.
+    let min = min_seen.load(Ordering::SeqCst);
+    assert!(min >= 2, "scenery blanked mid-reload — min row_count was {min}");
+    Ok(())
+}


### PR DESCRIPTION
Step 6 of taking the Scenery layer a level higher. **Stacked on #313.**

## What's in here
- Master Vista is now swappable (`RwLock<Arc<Vista>>`). `Dio::reload(new_master)` re-points a Dio at a freshly-built Vista (e.g. after its VistaFactory reloaded the YAML/script) and rebuilds the cache from it — without tearing the Dio down.
- **Non-blanking**: open sceneries keep their current rows until the new data is staged, then swap atomically on a single trailing `Invalidated`. A grid mid-scroll never flashes empty even when the dataset changes wholesale. (Crucially, `reload` does *not* emit `Refreshing` after clearing the cache — that would reseed an eager scenery to empty.)
- `Dio::master()` now returns `Arc<Vista>` (was `&Vista`); the `dio.vista()` facade snapshots its schema at construction so it doesn't borrow the live master. Stale per-query indexes dropped on reload.

## Verification
`cargo test -p vantage-diorama`: full suite green incl. new `reload_swaps_dataset_without_blanking` — a concurrent sampler asserts the scenery's `row_count` never dips below the original while the dataset swaps. **Rigor**: temporarily re-adding the premature `Refreshing` makes the test fail ('min row_count was 0'), proving it catches flicker. Clippy clean; `bakery_model4` still compiles.

## Note
`Dio::master()` return-type change is a (small, localized) breaking API change — all in-repo callers use method chains that deref through `Arc<Vista>` unchanged.