### PR TITLE
diorama: adaptive polling via ActivitySignal (active/standby/offline)

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.6.3 — unreleased
 
+- Adaptive polling via an app-activity signal. A new `ActivitySignal`
+  (`Active`/`Standby`/`Offline`), shared into a Lens with `.activity_signal(..)`,
+  drives the refresh cadence: `refresh_every` is the active interval,
+  `.standby_refresh_every(..)` the slower standby one, and `Offline` skips
+  polling entirely (resuming on reconnect). One signal, set by the UI from
+  window-focus / idle / network state, re-paces every Dio's refresh loop at
+  once. Replaces the fixed-interval ticker (semantics preserved: still skips the
+  t=0 tick).
 - No-flicker reload. The master Vista is now swappable, and `Dio::reload(new_master)`
   re-points a Dio at a freshly-built Vista (e.g. after its VistaFactory reloaded
   the YAML/script) and rebuilds the cache from it — without tearing the Dio down.

--- a/vantage-diorama/README_lens.md
+++ b/vantage-diorama/README_lens.md
@@ -619,3 +619,33 @@ the new master via your `on_start` (or `on_refresh`), and only then publishes on
 swap to the new data in a single atomic step on that `Invalidated` — so a grid
 mid-scroll never flashes empty, even though the dataset changed underneath it.
 "Responsive first, eventually precise," applied to a source reload.
+
+## Adaptive polling — let the app pace your refresh
+
+A fixed `refresh_every` is wasteful: it polls just as hard when the window is in
+the background or the user walked away, and it hammers a dead network while
+offline. The app knows all of this; hand it to the Lens through one shared
+`ActivitySignal`:
+
+```rust
+let activity = ActivitySignal::new();          // shared with the UI
+
+let lens = Lens::new()
+    .cache_at("cache.redb")
+    .on_refresh(pull_changes)
+    .refresh_every(Duration::from_secs(1))            // Active: snappy
+    .standby_refresh_every(Duration::from_secs(60))   // Standby: relaxed
+    .activity_signal(activity.clone())
+    .build()?;
+
+// …elsewhere, the desktop app flips it as window focus / idle / network change:
+activity.set(Activity::Active);    // foreground + interacting → 1s cadence
+activity.set(Activity::Standby);   // backgrounded or idle    → 60s cadence
+activity.set(Activity::Offline);   // no network → stop polling; resume on reconnect
+```
+
+Pass the *same* cloned `activity` to every Lens and one `set` re-paces them all.
+`Offline` skips the refresh body entirely (no doomed requests) and picks back up
+on the next tick once you flip it back. This is the data-layer half of the
+desktop app's visibility-aware refresh; the UI half (window-active / idle
+detection) just drives `activity.set(...)`.

--- a/vantage-diorama/src/lens/activity.rs
+++ b/vantage-diorama/src/lens/activity.rs
@@ -1,0 +1,55 @@
+//! App-activity signal that drives the Lens's **adaptive** refresh cadence.
+//!
+//! The desktop app knows things the data layer doesn't: whether its window is
+//! focused, whether the user has touched anything recently, whether the network
+//! is up. It funnels that into one cheap shared handle; every Lens given the
+//! handle polls fast while the app is active, slows right down on standby, and
+//! stops entirely while offline (resuming on reconnect). One signal, set by the
+//! UI, read by every Dio's refresh loop.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// What the app is currently doing, from the refresh scheduler's point of view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Activity {
+    /// Foreground + recently interacted: poll at the active interval.
+    Active = 0,
+    /// Backgrounded or idle: poll at the (slower) standby interval.
+    Standby = 1,
+    /// No network: skip polling until back online.
+    Offline = 2,
+}
+
+/// A cheap, cloneable, shared handle the app updates as window focus / idle /
+/// network state change. Pass one (cloned) into every Lens via
+/// [`activity_signal`](crate::lens::LensBuilder::activity_signal); flipping it
+/// re-paces all their refresh loops at once. Defaults to
+/// [`Active`](Activity::Active).
+#[derive(Debug, Clone)]
+pub struct ActivitySignal(Arc<AtomicU8>);
+
+impl ActivitySignal {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicU8::new(Activity::Active as u8)))
+    }
+
+    pub fn set(&self, activity: Activity) {
+        self.0.store(activity as u8, Ordering::Relaxed);
+    }
+
+    pub fn get(&self) -> Activity {
+        match self.0.load(Ordering::Relaxed) {
+            1 => Activity::Standby,
+            2 => Activity::Offline,
+            _ => Activity::Active,
+        }
+    }
+}
+
+impl Default for ActivitySignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -72,6 +72,7 @@ impl LensBuilder {
             callbacks: Arc::new(callbacks),
             defaults: self.defaults,
             runtime,
+            activity: self.activity,
         })
     }
 }

--- a/vantage-diorama/src/lens/defaults.rs
+++ b/vantage-diorama/src/lens/defaults.rs
@@ -8,6 +8,12 @@ pub struct LensDefaults {
     /// manually.
     pub refresh_interval: Option<Duration>,
 
+    /// Slower refresh interval used while the app is on
+    /// [`Standby`](crate::Activity::Standby). `None` falls back to
+    /// `refresh_interval`. While [`Offline`](crate::Activity::Offline) the
+    /// scheduler skips the refresh body entirely until the app is back.
+    pub standby_refresh_interval: Option<Duration>,
+
     /// Maximum age a cache entry may reach before counting as stale.
     /// `None` means cache entries never expire on their own.
     pub cache_ttl: Option<Duration>,
@@ -37,6 +43,7 @@ impl Default for LensDefaults {
     fn default() -> Self {
         Self {
             refresh_interval: None,
+            standby_refresh_interval: None,
             cache_ttl: None,
             write_queue_capacity: 256,
             on_start_blocking: true,

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -14,7 +14,7 @@ use vantage_core::Result;
 use vantage_vista::Vista;
 
 use crate::dio::{Dio, DioEvent, DioInner, HotTier, worker::write_worker_loop};
-use crate::lens::Lens;
+use crate::lens::{Activity, ActivitySignal, Lens};
 
 impl Lens {
     /// Bind `master` to this Lens. Opens the cache table, spawns the
@@ -74,29 +74,50 @@ async fn spawn_write_worker(dio: &Dio, rx: mpsc::Receiver<crate::ops::WriteOp>) 
 }
 
 async fn spawn_refresh_task(dio: &Dio) {
-    let Some(interval) = dio.inner.lens.defaults.refresh_interval else {
+    let Some(active) = dio.inner.lens.defaults.refresh_interval else {
         return;
     };
     if dio.inner.lens.callbacks.on_refresh.is_none() {
         return;
     }
+    let standby = dio
+        .inner
+        .lens
+        .defaults
+        .standby_refresh_interval
+        .unwrap_or(active);
+    let signal = dio.inner.lens.activity.clone();
     let inner_weak = Arc::downgrade(&dio.inner);
     let handle = dio.inner.lens.runtime.spawn(async move {
-        refresh_loop(inner_weak, interval).await;
+        refresh_loop(inner_weak, active, standby, signal).await;
     });
     *dio.inner.refresh_task.lock().await = Some(handle);
 }
 
-async fn refresh_loop(inner: Weak<DioInner>, interval: Duration) {
-    let mut ticker = tokio::time::interval(interval);
-    // Skip the immediate tick — `on_start` typically just ran and refresh
-    // should fire after `interval`, not at t=0.
-    ticker.tick().await;
+/// Adaptive refresh ticker. Waits at the cadence the current
+/// [`Activity`] dictates, then fires `on_refresh` — unless the app is
+/// [`Offline`](Activity::Offline), in which case it skips the body so polling
+/// pauses but resumes promptly on reconnect. Sleeping *before* the first fire
+/// keeps the t=0 skip the interval ticker used to give.
+async fn refresh_loop(
+    inner: Weak<DioInner>,
+    active: Duration,
+    standby: Duration,
+    signal: ActivitySignal,
+) {
     loop {
-        ticker.tick().await;
+        let delay = match signal.get() {
+            Activity::Active => active,
+            Activity::Standby => standby,
+            Activity::Offline => active,
+        };
+        tokio::time::sleep(delay).await;
         let Some(strong) = inner.upgrade() else {
             return;
         };
+        if matches!(signal.get(), Activity::Offline) {
+            continue;
+        }
         let dio = Dio { inner: strong };
         let _ = dio.inner.event_bus.send(DioEvent::Refreshing);
         if let Some(cb) = dio.inner.lens.callbacks.on_refresh.as_ref()

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 pub mod build;
 pub mod cache_backend;
 pub mod callbacks;
@@ -19,6 +20,7 @@ use crate::dio::Dio;
 use crate::error::LensBuildError;
 use crate::ops::{ChangeEvent, QueryDescriptor, WriteOp};
 
+pub use activity::{Activity, ActivitySignal};
 pub use cache_backend::{CacheBackend, CacheStatus, CacheTable};
 pub use callbacks::{
     DioCallback, DioEventCallback, DioListPageCallback, DioLoadChunkCallback,
@@ -40,6 +42,9 @@ pub struct Lens {
     pub(crate) callbacks: Arc<LensCallbacks>,
     pub(crate) defaults: LensDefaults,
     pub(crate) runtime: Handle,
+    /// App-activity signal driving adaptive refresh cadence. Shared with the UI
+    /// (cloned), so flipping it re-paces every Dio's refresh loop at once.
+    pub(crate) activity: ActivitySignal,
 }
 
 impl Lens {
@@ -87,6 +92,7 @@ pub struct LensBuilder {
     pub(crate) catalog: Option<std::sync::Arc<vantage_vista_factory::VistaCatalog>>,
     pub(crate) defaults: LensDefaults,
     pub(crate) runtime: Option<Handle>,
+    pub(crate) activity: ActivitySignal,
 }
 
 impl Default for LensBuilder {
@@ -113,7 +119,24 @@ impl LensBuilder {
             catalog: None,
             defaults: LensDefaults::default(),
             runtime: None,
+            activity: ActivitySignal::new(),
         }
+    }
+
+    /// Share an app-activity signal so this Lens's refresh loops adapt their
+    /// cadence (active → fast, standby → slow, offline → paused). Pass the same
+    /// cloned handle to every Lens and update it from the UI.
+    pub fn activity_signal(mut self, signal: ActivitySignal) -> Self {
+        self.activity = signal;
+        self
+    }
+
+    /// The slower refresh interval used while the app is on
+    /// [`Standby`](Activity::Standby). Falls back to the active
+    /// [`refresh_every`](Self::refresh_every) interval when unset.
+    pub fn standby_refresh_every(mut self, interval: std::time::Duration) -> Self {
+        self.defaults.standby_refresh_interval = Some(interval);
+        self
     }
 
     /// Provide the cache backend explicitly. Use this when [`cache_at`](Self::cache_at)

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -18,9 +18,9 @@ pub use composition::Diorama;
 pub use dio::{Dio, DioEvent, DioShell, Generation};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
-    CacheBackend, ChunkRow, ChunkSink, DioCallback, DioEventCallback, DioLoadChunkCallback,
-    DioQueryCallback, DioTotalProviderCallback, DioWriteCallback, Lens, LensBuilder, LensCallbacks,
-    LensDefaults,
+    Activity, ActivitySignal, CacheBackend, ChunkRow, ChunkSink, DioCallback, DioEventCallback,
+    DioLoadChunkCallback, DioQueryCallback, DioTotalProviderCallback, DioWriteCallback, Lens,
+    LensBuilder, LensCallbacks, LensDefaults,
 };
 pub use ops::{ChangeEvent, QueryDescriptor, WriteOp};
 pub use scenery::{

--- a/vantage-diorama/tests/activity.rs
+++ b/vantage-diorama/tests/activity.rs
@@ -1,0 +1,150 @@
+//! Step 7: app-activity signal drives adaptive refresh cadence — fast while
+//! active, slow on standby, paused while offline (resuming on reconnect).
+//! Runs on a paused clock so ticks are deterministic.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Activity, ActivitySignal, Lens};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_id_column("id");
+    let mut rec = Record::new();
+    rec.insert("name".to_string(), CborValue::Text("alpha".into()));
+    let shell = MockShell::new().with_metadata(metadata).with_record("a", rec);
+    Vista::new("items", Box::new(shell))
+}
+
+/// Build a Lens that counts `on_refresh` invocations, with the given cadences
+/// and a shared activity signal.
+async fn counting_lens(
+    cache_path: std::path::PathBuf,
+    active: Duration,
+    standby: Option<Duration>,
+    signal: ActivitySignal,
+    counter: Arc<AtomicU64>,
+) -> Arc<Lens> {
+    let mut b = Lens::new()
+        .cache_at(cache_path)
+        .on_start(|dio| {
+            let dio = dio.clone();
+            async move {
+                let rows = dio.master().list_values().await?;
+                dio.cache().insert_values(rows).await
+            }
+        })
+        .on_refresh(move |_dio| {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .refresh_every(active)
+        .activity_signal(signal);
+    if let Some(s) = standby {
+        b = b.standby_refresh_every(s);
+    }
+    Arc::new(b.build().expect("build lens"))
+}
+
+/// Advance the paused clock by `d` in small steps, yielding between so the
+/// refresh loop's sleeps fire and its `on_refresh` futures run.
+async fn drive(d: Duration) {
+    let step = Duration::from_millis(50);
+    let mut left = d;
+    while !left.is_zero() {
+        let s = step.min(left);
+        tokio::time::advance(s).await;
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        left -= s;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn active_polls_fast_standby_polls_slow() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let signal = ActivitySignal::new(); // Active
+    let count = Arc::new(AtomicU64::new(0));
+    let lens = counting_lens(
+        tmp.path().join("c.redb"),
+        Duration::from_secs(1),
+        Some(Duration::from_secs(10)),
+        signal.clone(),
+        count.clone(),
+    )
+    .await;
+    let _dio = lens.make_dio(master()).await?;
+
+    // Active: ~1 tick/sec.
+    drive(Duration::from_secs(3)).await;
+    let active_ticks = count.load(Ordering::SeqCst);
+    assert!(
+        active_ticks >= 2,
+        "active should poll several times in 3s, got {active_ticks}"
+    );
+
+    // Standby: let any in-progress active sleep flush, then confirm the 10s
+    // cadence suppresses ticks across a 5s window.
+    signal.set(Activity::Standby);
+    drive(Duration::from_secs(2)).await;
+    let before = count.load(Ordering::SeqCst);
+    drive(Duration::from_secs(5)).await;
+    assert_eq!(
+        count.load(Ordering::SeqCst),
+        before,
+        "standby must not tick within its 10s interval"
+    );
+
+    // …but it does still poll, just slower — cross the interval.
+    drive(Duration::from_secs(12)).await;
+    assert!(
+        count.load(Ordering::SeqCst) > before,
+        "standby still polls after its (longer) interval"
+    );
+    Ok(())
+}
+
+#[tokio::test(start_paused = true)]
+async fn offline_pauses_polling_and_resumes_on_reconnect() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let signal = ActivitySignal::new();
+    let count = Arc::new(AtomicU64::new(0));
+    let lens = counting_lens(
+        tmp.path().join("c.redb"),
+        Duration::from_secs(1),
+        None,
+        signal.clone(),
+        count.clone(),
+    )
+    .await;
+    let _dio = lens.make_dio(master()).await?;
+
+    signal.set(Activity::Offline);
+    drive(Duration::from_secs(5)).await;
+    assert_eq!(
+        count.load(Ordering::SeqCst),
+        0,
+        "offline must not poll at all"
+    );
+
+    signal.set(Activity::Active);
+    drive(Duration::from_secs(3)).await;
+    assert!(
+        count.load(Ordering::SeqCst) >= 1,
+        "polling resumes once back online"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Step 7 of taking the Scenery layer a level higher. **Stacked on #314.**

## What's in here
- New `ActivitySignal` (`Active`/`Standby`/`Offline`) — a cheap shared handle. Pass it into a Lens via `.activity_signal(..)`; flipping it re-paces every Dio's refresh loop at once.
- Refresh cadence is now adaptive: `refresh_every` = active interval, `.standby_refresh_every(..)` = slower standby interval, `Offline` skips the refresh body entirely (no doomed requests) and resumes on reconnect.
- The fixed-interval ticker is replaced by a signal-aware sleep loop; t=0 skip semantics preserved.

## Why
A fixed interval polls just as hard backgrounded/idle/offline. The desktop app knows window focus, idle, and network state — this is the data-layer half; the UI half just calls `activity.set(...)`.

## Verification
`cargo test -p vantage-diorama`: full suite green incl. two new `start_paused` tests — active polls ~1/s, standby suppresses within its 10s interval but still ticks after it, offline polls 0× then resumes on reconnect. Existing `refresh_every` BDD (skip-first) unchanged. Clippy clean.