### PR TITLE
diorama: diagnostics surface (Dio::diagnostics)

### DIFF
--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.6.3 — unreleased
 
+- Diagnostics surface. `dio.diagnostics().await` returns a `DioDiagnostics`
+  snapshot — cache row count, query-index count, and one `SceneryDiagnostic` per
+  open table scenery (its registry key, refcount, row count, and a
+  `RowStatusSummary` of fresh/incomplete/pending/failed). New
+  `TableScenery::status_summary()` backs it. Reads off the dedup registry
+  (nearly free) and prunes dead entries, so a released scenery vanishes from the
+  report — the basis for a "Diorama inspector" panel and leak assertions.
 - Adaptive polling via an app-activity signal. A new `ActivitySignal`
   (`Active`/`Standby`/`Offline`), shared into a Lens with `.activity_signal(..)`,
   drives the refresh cadence: `refresh_every` is the active interval,

--- a/vantage-diorama/README_rust_dev.md
+++ b/vantage-diorama/README_rust_dev.md
@@ -393,3 +393,27 @@ cache fresh against upstream changes.
 
 No reactive code. No Sceneries. No UI concerns. Diorama just made the slow
 backend usable.
+
+## Inspecting a live Dio
+
+`dio.diagnostics().await` snapshots what a Dio is doing right now — handy for a
+debug panel, a `/healthz`-style endpoint, or a test assertion:
+
+```rust
+let d = dio.diagnostics().await;
+println!("cache: {} rows, {} query indexes", d.cache_rows, d.query_indexes);
+for s in &d.sceneries {
+    // key = (shape, conditions, sort, search, titles_only); refcount = widgets holding it
+    println!(
+        "{}  x{}  rows={}  fresh={}/{} pending={} failed={}",
+        s.key, s.refcount, s.row_count,
+        s.status.fresh, s.status.loaded, s.status.pending_write, s.status.failed,
+    );
+}
+println!("augmented rows on screen: {}", d.augmented_rows());
+```
+
+It reads straight off the dedup registry, so it's nearly free and prunes dead
+entries as it goes — a released scenery disappears from the report, which is
+exactly how you confirm nothing leaked. `dio.live_table_scenery_count()` is the
+one-number version.

--- a/vantage-diorama/src/dio/diagnostics.rs
+++ b/vantage-diorama/src/dio/diagnostics.rs
@@ -1,0 +1,73 @@
+//! Read-only introspection of a Dio: what's open, what's hydrated, how big the
+//! cache is. Backed by the dedup scenery registry (so it's nearly free) — the
+//! data behind a "Diorama inspector" panel and the assertion surface for tests.
+
+use crate::dio::Dio;
+use crate::scenery::table::RowStatusSummary;
+
+/// A snapshot of one open table scenery.
+#[derive(Debug, Clone)]
+pub struct SceneryDiagnostic {
+    /// The registry key: `(shape, conditions, sort, search, titles_only)`.
+    pub key: String,
+    /// How many widgets currently hold this shared scenery.
+    pub refcount: usize,
+    /// Logical row count (a paged scenery reports its total, most unloaded).
+    pub row_count: usize,
+    /// Status breakdown over the rows actually materialized.
+    pub status: RowStatusSummary,
+}
+
+/// A snapshot of a Dio's live state.
+#[derive(Debug, Clone)]
+pub struct DioDiagnostics {
+    /// Rows currently in the Dio's cache table.
+    pub cache_rows: usize,
+    /// Number of distinct two-pass query indexes built.
+    pub query_indexes: usize,
+    /// One entry per open (live) table scenery.
+    pub sceneries: Vec<SceneryDiagnostic>,
+}
+
+impl DioDiagnostics {
+    /// Total rows augmented to `Fresh` across all open sceneries.
+    pub fn augmented_rows(&self) -> usize {
+        self.sceneries.iter().map(|s| s.status.fresh).sum()
+    }
+}
+
+impl Dio {
+    /// Snapshot this Dio's live state for diagnostics: cache size, query-index
+    /// count, and every open table scenery with its refcount and hydration
+    /// breakdown. Prunes dead registry entries as a side effect.
+    pub async fn diagnostics(&self) -> DioDiagnostics {
+        let cache_rows = self.inner.cache.count().await.unwrap_or(0).max(0) as usize;
+        let query_indexes = self.inner.query_indexes.lock().unwrap().len();
+
+        let mut sceneries = Vec::new();
+        {
+            let mut reg = self.inner.table_sceneries.lock().unwrap();
+            reg.retain(|_, weak| weak.strong_count() > 0);
+            for (key, weak) in reg.iter() {
+                // strong_count before upgrade = the widgets' holds (our upgrade
+                // would otherwise add one).
+                let refcount = weak.strong_count();
+                if let Some(scenery) = weak.upgrade() {
+                    sceneries.push(SceneryDiagnostic {
+                        key: key.clone(),
+                        refcount,
+                        row_count: scenery.row_count(),
+                        status: scenery.status_summary(),
+                    });
+                }
+            }
+        }
+        sceneries.sort_by(|a, b| a.key.cmp(&b.key));
+
+        DioDiagnostics {
+            cache_rows,
+            query_indexes,
+            sceneries,
+        }
+    }
+}

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -1,3 +1,4 @@
+pub mod diagnostics;
 pub mod event_bus;
 pub mod hot_tier;
 pub mod impls;

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -15,6 +15,7 @@ pub use augment::{
     SourceSpec, lower_augment,
 };
 pub use composition::Diorama;
+pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
 pub use dio::{Dio, DioEvent, DioShell, Generation};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
@@ -24,8 +25,8 @@ pub use lens::{
 };
 pub use ops::{ChangeEvent, QueryDescriptor, WriteOp};
 pub use scenery::{
-    Aggregate, CustomAggregate, EnrichedRecord, RecordScenery, RecordStatus, RowStatus, SortDir,
-    TableScenery, TableSceneryBuilder, ValueScenery, ValueSceneryBuilder, ValueStatus,
-    boxed_custom_aggregate,
+    Aggregate, CustomAggregate, EnrichedRecord, RecordScenery, RecordStatus, RowStatus,
+    RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder, ValueScenery, ValueSceneryBuilder,
+    ValueStatus, boxed_custom_aggregate,
 };
 pub use vantage_vista::VistaCapabilities;

--- a/vantage-diorama/src/scenery/mod.rs
+++ b/vantage-diorama/src/scenery/mod.rs
@@ -5,7 +5,7 @@ pub mod value;
 
 pub use enriched_record::{EnrichedRecord, RowStatus};
 pub use record::{RecordScenery, RecordStatus};
-pub use table::{SortDir, TableScenery, TableSceneryBuilder};
+pub use table::{RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder};
 pub use value::{
     Aggregate, CustomAggregate, ValueScenery, ValueSceneryBuilder, ValueStatus,
     boxed_custom_aggregate,

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -54,9 +54,28 @@ pub(crate) struct ViewportRequest {
     pub(crate) force_load: bool,
 }
 
+/// Breakdown of the row statuses currently materialized in a scenery's sparse
+/// map. Cheap to compute (iterates only loaded rows, not the full row count) —
+/// the per-scenery slice of the diagnostics surface.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RowStatusSummary {
+    /// Rows actually present in the sparse map (a paged scenery's `row_count`
+    /// can be far larger — most indices are unloaded).
+    pub loaded: usize,
+    pub fresh: usize,
+    pub incomplete: usize,
+    pub pending_write: usize,
+    /// `LoadFailed` + `WriteFailed` combined.
+    pub failed: usize,
+}
+
 /// Reactive view onto a Dio that exposes an ordered, paginated row set.
 pub trait TableScenery: Send + Sync {
     fn row_count(&self) -> usize;
+
+    /// Status breakdown over the rows currently in the sparse map. Used by the
+    /// diagnostics surface to report how much of a scenery is hydrated.
+    fn status_summary(&self) -> RowStatusSummary;
     fn has_more(&self) -> bool;
     fn estimated_total(&self) -> Option<usize>;
     fn row(&self, idx: usize) -> Option<Arc<EnrichedRecord>>;
@@ -114,6 +133,22 @@ impl TableScenery for TableSceneryImpl {
             return t;
         }
         self.inner.rows.read().unwrap().len()
+    }
+
+    fn status_summary(&self) -> RowStatusSummary {
+        use super::enriched_record::RowStatus;
+        let mut s = RowStatusSummary::default();
+        for row in self.inner.rows.read().unwrap().values() {
+            s.loaded += 1;
+            match &row.status {
+                RowStatus::Fresh => s.fresh += 1,
+                RowStatus::Incomplete => s.incomplete += 1,
+                RowStatus::PendingWrite => s.pending_write += 1,
+                RowStatus::LoadFailed { .. } | RowStatus::WriteFailed { .. } => s.failed += 1,
+                _ => {}
+            }
+        }
+        s
     }
 
     fn has_more(&self) -> bool {

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -351,6 +351,56 @@ async fn titles_only_picker_skips_detail_hydration() {
     );
 }
 
+/// `dio.diagnostics()` reports every open scenery with its refcount and
+/// hydration breakdown, the cache size, and dedup-aware sharing — and empties
+/// as handles are released.
+#[tokio::test]
+async fn diagnostics_report_sceneries_refcount_and_hydration() {
+    let tmp = TempDir::new().unwrap();
+    let log = tmp.path().join("calls.log");
+    let lens = two_pass_lens(tmp.path(), &log);
+    let dio = open_dio(&lens, &make_cmd(&log)).await;
+
+    // A picker (titles_only) lists cheap rows — Incomplete, never hydrated.
+    let picker = dio.table_scenery().titles_only().page_size(2).open().await.unwrap();
+    eventually("picker listed", || picker.row_count() >= 2).await;
+
+    let d = dio.diagnostics().await;
+    assert_eq!(d.sceneries.len(), 1);
+    assert_eq!(d.sceneries[0].refcount, 1);
+    assert!(
+        d.sceneries[0].status.incomplete >= 2,
+        "picker rows are Incomplete: {:?}",
+        d.sceneries[0].status
+    );
+    assert_eq!(d.sceneries[0].status.fresh, 0);
+
+    // Dedup: re-opening the same picker query shares it → refcount 2.
+    let picker2 = dio.table_scenery().titles_only().page_size(2).open().await.unwrap();
+    assert_eq!(dio.diagnostics().await.sceneries[0].refcount, 2);
+
+    // A full grid is a distinct scenery that hydrates → Fresh rows.
+    let grid = dio.table_scenery().page_size(2).open().await.unwrap();
+    grid.set_viewport(0..2);
+    eventually("grid hydrates both rows", || {
+        matches!(status_of(&grid, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&grid, 1), Some(RowStatus::Fresh))
+    })
+    .await;
+
+    let d = dio.diagnostics().await;
+    assert_eq!(d.sceneries.len(), 2, "picker + grid");
+    assert!(d.augmented_rows() >= 2, "grid contributes Fresh rows");
+    assert!(d.cache_rows >= 2);
+
+    // Releasing every handle empties the diagnostics (no leak).
+    drop(picker);
+    drop(picker2);
+    drop(grid);
+    let d = dio.diagnostics().await;
+    assert_eq!(d.sceneries.len(), 0, "released sceneries are pruned");
+}
+
 /// Sequential, no-total paging: each `request_load_more` fetches the next list
 /// page; a short final page flips `has_more` false and freezes the estimate.
 #[tokio::test]


### PR DESCRIPTION
Step 9 of taking the Scenery layer a level higher. **Stacked on #315.**

## What's in here
- `dio.diagnostics().await` → `DioDiagnostics`: cache row count, query-index count, and one `SceneryDiagnostic` per open table scenery (registry key, refcount, row count, and a `RowStatusSummary` of fresh/incomplete/pending/failed).
- New `TableScenery::status_summary()` (iterates only materialized rows — cheap).
- Reads off the Step 2 dedup registry and prunes dead entries, so a released scenery vanishes from the report — the basis for a "Diorama inspector" panel and leak assertions. `live_table_scenery_count()` is the one-number version.

## Verification
`cargo test -p vantage-diorama` green incl. new `diagnostics_report_sceneries_refcount_and_hydration`: a titles_only picker (Incomplete) + a deduped re-open (refcount 2) + a full grid (Fresh, augmented_rows ≥ 2), all released → report empties. Clippy clean.