### PR TITLE
api-pool: ResilientClient async-native transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,7 +196,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -896,6 +906,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,6 +1487,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2433,6 +2467,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
 ]
 
 [[package]]
@@ -4637,6 +4681,7 @@ dependencies = [
  "vantage-expressions",
  "vantage-table",
  "vantage-types",
+ "wiremock",
 ]
 
 [[package]]
@@ -5507,6 +5552,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/vantage-api-pool/CHANGELOG.md
+++ b/vantage-api-pool/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.1 — unreleased
+
+- `ResilientClient` — async-native HTTP transport that replaces the worker-pool
+  + oneshot-matcher model (`AwwPool` / `HttpClientPool` / `EventualRequest`).
+  Concurrency is bounded by a semaphore (per-API parallelism cap), and the
+  genuinely-valuable policies are inline middleware: retry with exponential
+  backoff + jitter on 429/5xx/network (honoring `Retry-After`, bounded by
+  `max_retries`), auth-token refresh on 401 (re-acquire + replay), and a circuit
+  breaker (fail fast after N consecutive failures, half-open probe after a
+  cooldown). Cancellation is structural — drop the future, drop the request.
+  Covered by wiremock contract tests. The old `AwwPool` path is unchanged and
+  will be retired once consumers (the Vantage REST datasource, the desktop app)
+  migrate onto `ResilientClient`.
+
 ## 0.6.0 — unreleased
 
 - Coordinated 0.6 release; internal dependencies realigned to 0.6. No public API changes.

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -33,3 +33,4 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 urlencoding = "2.1"
 vantage-cli-util = { path = "../vantage-cli-util" }
+wiremock = "0.6"

--- a/vantage-api-pool/README.md
+++ b/vantage-api-pool/README.md
@@ -197,6 +197,42 @@ println!("Population: {}", rosario.population);
 Pagination is driven by `total_pages` from the first response. Pages are fetched as `?page=N` query
 parameters.
 
+## `ResilientClient` — the async-native transport
+
+`ResilientClient` is the structured-concurrency replacement for the
+`AwwPool` / `HttpClientPool` / `EventualRequest` worker-pool + oneshot-matcher
+machinery. Instead of detaching requests onto a pool and matching responses back
+by id, you just `.await` a request; concurrency is bounded by a semaphore and the
+resilience policies are inline middleware.
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+use vantage_api_pool::{ResilientClient, RetryPolicy};
+use vantage_api_pool::resilient::AuthRefresher;
+
+let refresher: AuthRefresher = Arc::new(|| Box::pin(async { Ok(fetch_token().await?) }));
+
+let client = ResilientClient::builder()
+    .max_parallel(8)                                   // per-API parallelism cap
+    .retry(RetryPolicy::default())                     // 429/5xx/network → backoff + jitter
+    .bearer_auth(refresher)                            // 401 → re-acquire token + replay
+    .circuit_breaker(5, Duration::from_secs(30))       // fail fast after repeated failures
+    .build();
+
+// `build` is called once per attempt, so retries/auth re-apply on a fresh builder:
+let resp = client.execute(|http| http.get("https://api.example.com/cities")).await?;
+```
+
+Fan out with the cap respected automatically — e.g. load many pages or augment
+many rows in parallel via `futures::stream::iter(reqs).map(|r| client.execute(r)).buffer_unordered(n)`;
+the semaphore keeps in-flight requests ≤ `max_parallel`. Cancellation is
+structural: drop the future and the in-flight request goes with it.
+
+This is what a Vantage REST datasource (and Diorama's `on_load_chunk` /
+augmentation fan-out) should run through. The older `AwwPool` path remains for
+now and will be retired once consumers migrate.
+
 ## License
 
 MIT OR Apache-2.0

--- a/vantage-api-pool/src/lib.rs
+++ b/vantage-api-pool/src/lib.rs
@@ -31,3 +31,6 @@ pub use paginator::PaginatedStream3;
 
 mod pool_api;
 pub use pool_api::PoolApi;
+
+pub mod resilient;
+pub use resilient::{AuthRefresher, ResilientClient, ResilientClientBuilder, RetryPolicy};

--- a/vantage-api-pool/src/resilient/mod.rs
+++ b/vantage-api-pool/src/resilient/mod.rs
@@ -1,0 +1,336 @@
+//! `ResilientClient` — an async-native HTTP transport.
+//!
+//! This is the structured-concurrency replacement for the worker-pool +
+//! oneshot-matcher machinery ([`AwwPool`](crate::AwwPool) /
+//! [`HttpClientPool`](crate::HttpClientPool) /
+//! [`EventualRequest`](crate::EventualRequest)). Instead of detaching requests
+//! onto a pool and matching responses back by id, a caller just `.await`s
+//! [`execute`](ResilientClient::execute): concurrency is bounded by a
+//! [`Semaphore`], and the genuinely-valuable policies live as inline middleware:
+//!
+//! - **parallelism cap** — at most `max_parallel` requests in flight per client,
+//! - **retry with backoff + jitter** on `429` / `5xx` / network errors, honoring
+//!   `Retry-After`, bounded by `max_retries`,
+//! - **auth refresh** — a `401` triggers one token re-acquire + replay,
+//! - **circuit breaker** — after N consecutive failures the client fails fast
+//!   for a cooldown, then probes (half-open).
+//!
+//! Cancellation is structural: drop the future and the in-flight request is
+//! dropped with it — no detached task outlives its caller.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow};
+use tokio::sync::{RwLock, Semaphore};
+
+/// Retry/backoff knobs. Backoff is exponential from `base` (doubling per
+/// attempt), capped at `max`, with jitter added before each sleep.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    pub max_retries: usize,
+    pub base_backoff: Duration,
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 4,
+            base_backoff: Duration::from_millis(50),
+            max_backoff: Duration::from_secs(10),
+        }
+    }
+}
+
+impl RetryPolicy {
+    fn backoff(&self, attempt: usize) -> Duration {
+        let factor = 2u32.saturating_pow(attempt as u32);
+        let raw = self.base_backoff.saturating_mul(factor);
+        raw.min(self.max_backoff)
+    }
+}
+
+/// Add up to +25% jitter so retrying clients don't synchronize (thundering
+/// herd). Entropy is the wall-clock subsecond — cheap and dependency-free.
+fn with_jitter(d: Duration) -> Duration {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|t| t.subsec_nanos())
+        .unwrap_or(0);
+    let frac = (nanos % 250) as f64 / 1000.0; // 0.0..0.25
+    d + d.mul_f64(frac)
+}
+
+/// Future returned by the auth token refresher.
+pub type AuthFuture = Pin<Box<dyn Future<Output = Result<String>> + Send>>;
+/// Acquire (or re-acquire) an auth token — called lazily and on `401`.
+pub type AuthRefresher = Arc<dyn Fn() -> AuthFuture + Send + Sync>;
+
+struct AuthState {
+    token: RwLock<Option<String>>,
+    refresh: AuthRefresher,
+    header: String,
+    scheme: String,
+}
+
+impl AuthState {
+    async fn current(&self) -> Result<String> {
+        if let Some(t) = self.token.read().await.clone() {
+            return Ok(t);
+        }
+        self.reacquire().await
+    }
+
+    async fn reacquire(&self) -> Result<String> {
+        let t = (self.refresh)().await?;
+        *self.token.write().await = Some(t.clone());
+        Ok(t)
+    }
+}
+
+#[derive(Default)]
+struct BreakerInner {
+    consecutive_failures: usize,
+    open_until: Option<Instant>,
+}
+
+struct CircuitBreaker {
+    threshold: usize,
+    cooldown: Duration,
+    inner: std::sync::Mutex<BreakerInner>,
+}
+
+impl CircuitBreaker {
+    /// Whether a request may proceed. When the breaker is open and the cooldown
+    /// has elapsed, this returns `true` once (half-open probe) and re-arms.
+    fn allow(&self) -> bool {
+        let mut s = self.inner.lock().unwrap();
+        if let Some(until) = s.open_until {
+            if Instant::now() < until {
+                return false;
+            }
+            s.open_until = None; // half-open: let one through
+        }
+        true
+    }
+
+    fn record_success(&self) {
+        let mut s = self.inner.lock().unwrap();
+        s.consecutive_failures = 0;
+        s.open_until = None;
+    }
+
+    fn record_failure(&self) {
+        let mut s = self.inner.lock().unwrap();
+        s.consecutive_failures += 1;
+        if s.consecutive_failures >= self.threshold {
+            s.open_until = Some(Instant::now() + self.cooldown);
+        }
+    }
+}
+
+/// A cheap-to-clone resilient HTTP client. Build via [`ResilientClient::builder`].
+#[derive(Clone)]
+pub struct ResilientClient {
+    http: reqwest::Client,
+    semaphore: Arc<Semaphore>,
+    policy: RetryPolicy,
+    breaker: Option<Arc<CircuitBreaker>>,
+    auth: Option<Arc<AuthState>>,
+    in_flight: Arc<AtomicUsize>,
+    peak_in_flight: Arc<AtomicUsize>,
+}
+
+impl ResilientClient {
+    pub fn builder() -> ResilientClientBuilder {
+        ResilientClientBuilder::default()
+    }
+
+    /// Execute a request with all policies applied. `build` is called once per
+    /// attempt with the shared `reqwest::Client`, so retries and auth re-apply
+    /// against a fresh `RequestBuilder` (a `RequestBuilder` is single-use).
+    ///
+    /// Returns the first successful (`2xx`) response, or an error after retries
+    /// are exhausted / the breaker is open / a non-retryable status.
+    pub async fn execute<F>(&self, build: F) -> Result<reqwest::Response>
+    where
+        F: Fn(&reqwest::Client) -> reqwest::RequestBuilder,
+    {
+        if let Some(b) = &self.breaker {
+            if !b.allow() {
+                return Err(anyhow!("circuit breaker open"));
+            }
+        }
+        let _permit = self
+            .semaphore
+            .acquire()
+            .await
+            .map_err(|_| anyhow!("client closed"))?;
+
+        let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.peak_in_flight.fetch_max(cur, Ordering::SeqCst);
+
+        let result = self.attempt_loop(&build).await;
+
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        if let Some(b) = &self.breaker {
+            match &result {
+                Ok(_) => b.record_success(),
+                Err(_) => b.record_failure(),
+            }
+        }
+        result
+    }
+
+    async fn attempt_loop<F>(&self, build: &F) -> Result<reqwest::Response>
+    where
+        F: Fn(&reqwest::Client) -> reqwest::RequestBuilder,
+    {
+        let mut attempt = 0usize;
+        let mut refreshed = false;
+        loop {
+            let mut req = build(&self.http);
+            if let Some(auth) = &self.auth {
+                let token = auth.current().await?;
+                req = req.header(&auth.header, format!("{}{token}", auth.scheme));
+            }
+
+            match req.send().await {
+                Ok(resp) => {
+                    let status = resp.status();
+                    if status.is_success() {
+                        return Ok(resp);
+                    }
+                    // 401 → refresh the token once and replay (not a retry).
+                    if status.as_u16() == 401 && self.auth.is_some() && !refreshed {
+                        refreshed = true;
+                        self.auth.as_ref().unwrap().reacquire().await?;
+                        continue;
+                    }
+                    // 429 / 5xx → backoff + retry.
+                    if status.as_u16() == 429 || status.is_server_error() {
+                        if attempt >= self.policy.max_retries {
+                            return Err(anyhow!("giving up after {attempt} retries: HTTP {status}"));
+                        }
+                        let delay = retry_after(&resp).unwrap_or_else(|| self.policy.backoff(attempt));
+                        attempt += 1;
+                        tokio::time::sleep(with_jitter(delay)).await;
+                        continue;
+                    }
+                    // other 4xx → not retryable.
+                    return Err(anyhow!("HTTP {status}"));
+                }
+                Err(e) => {
+                    if attempt >= self.policy.max_retries {
+                        return Err(anyhow!("giving up after {attempt} retries: {e}"));
+                    }
+                    let delay = self.policy.backoff(attempt);
+                    attempt += 1;
+                    tokio::time::sleep(with_jitter(delay)).await;
+                }
+            }
+        }
+    }
+
+    /// Highest number of simultaneously in-flight requests this client has
+    /// observed — proves the parallelism cap holds. Test/diagnostic hook.
+    pub fn peak_in_flight(&self) -> usize {
+        self.peak_in_flight.load(Ordering::SeqCst)
+    }
+}
+
+fn retry_after(resp: &reqwest::Response) -> Option<Duration> {
+    let secs: u64 = resp.headers().get("retry-after")?.to_str().ok()?.parse().ok()?;
+    (secs >= 1).then(|| Duration::from_secs(secs))
+}
+
+/// Builder for [`ResilientClient`].
+pub struct ResilientClientBuilder {
+    http: Option<reqwest::Client>,
+    max_parallel: usize,
+    policy: RetryPolicy,
+    breaker: Option<(usize, Duration)>,
+    auth: Option<(AuthRefresher, String, String)>,
+}
+
+impl Default for ResilientClientBuilder {
+    fn default() -> Self {
+        Self {
+            http: None,
+            max_parallel: 8,
+            policy: RetryPolicy::default(),
+            breaker: None,
+            auth: None,
+        }
+    }
+}
+
+impl ResilientClientBuilder {
+    /// Cap concurrent in-flight requests for this client (the per-API
+    /// parallelism limit). Default 8.
+    pub fn max_parallel(mut self, n: usize) -> Self {
+        self.max_parallel = n.max(1);
+        self
+    }
+
+    pub fn retry(mut self, policy: RetryPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Open the breaker after `threshold` consecutive failures; stay open for
+    /// `cooldown`, then allow one half-open probe.
+    pub fn circuit_breaker(mut self, threshold: usize, cooldown: Duration) -> Self {
+        self.breaker = Some((threshold.max(1), cooldown));
+        self
+    }
+
+    /// Apply a bearer-style auth token, re-acquired lazily and on `401`.
+    /// `refresher` returns the token value (without the scheme prefix).
+    pub fn bearer_auth(mut self, refresher: AuthRefresher) -> Self {
+        self.auth = Some((refresher, "Authorization".to_string(), "Bearer ".to_string()));
+        self
+    }
+
+    /// Apply auth with a custom header name and scheme prefix.
+    pub fn auth(mut self, refresher: AuthRefresher, header: impl Into<String>, scheme: impl Into<String>) -> Self {
+        self.auth = Some((refresher, header.into(), scheme.into()));
+        self
+    }
+
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.http = Some(client);
+        self
+    }
+
+    pub fn build(self) -> ResilientClient {
+        ResilientClient {
+            http: self.http.unwrap_or_default(),
+            semaphore: Arc::new(Semaphore::new(self.max_parallel)),
+            policy: self.policy,
+            breaker: self
+                .breaker
+                .map(|(threshold, cooldown)| {
+                    Arc::new(CircuitBreaker {
+                        threshold,
+                        cooldown,
+                        inner: std::sync::Mutex::new(BreakerInner::default()),
+                    })
+                }),
+            auth: self.auth.map(|(refresh, header, scheme)| {
+                Arc::new(AuthState {
+                    token: RwLock::new(None),
+                    refresh,
+                    header,
+                    scheme,
+                })
+            }),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            peak_in_flight: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}

--- a/vantage-api-pool/tests/resilient.rs
+++ b/vantage-api-pool/tests/resilient.rs
@@ -1,0 +1,167 @@
+//! Contract tests for `ResilientClient` against a wiremock server — retry,
+//! backoff, auth refresh, circuit breaker, and the parallelism cap.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use vantage_api_pool::resilient::AuthRefresher;
+use vantage_api_pool::{ResilientClient, RetryPolicy};
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn fast_retry(max: usize) -> RetryPolicy {
+    RetryPolicy {
+        max_retries: max,
+        base_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(5),
+    }
+}
+
+#[tokio::test]
+async fn retries_429_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/x"))
+        .respond_with(ResponseTemplate::new(429))
+        .up_to_n_times(2)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/x"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("ok"))
+        .mount(&server)
+        .await;
+
+    let client = ResilientClient::builder().retry(fast_retry(5)).build();
+    let url = format!("{}/x", server.uri());
+    let resp = client.execute(|h| h.get(&url)).await.expect("succeeds after retries");
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(server.received_requests().await.unwrap().len(), 3, "2×429 + 1×200");
+}
+
+#[tokio::test]
+async fn retries_500_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let client = ResilientClient::builder().retry(fast_retry(5)).build();
+    let url = server.uri();
+    let resp = client.execute(|h| h.get(&url)).await.expect("succeeds after 503");
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(server.received_requests().await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn does_not_retry_4xx() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let client = ResilientClient::builder().retry(fast_retry(5)).build();
+    let url = server.uri();
+    let r = client.execute(|h| h.get(&url)).await;
+    assert!(r.is_err(), "404 is terminal");
+    assert_eq!(server.received_requests().await.unwrap().len(), 1, "no retry on 404");
+}
+
+#[tokio::test]
+async fn refreshes_token_on_401_and_replays() {
+    let server = MockServer::start().await;
+    // Only a request bearing the *refreshed* token succeeds.
+    Mock::given(method("GET"))
+        .and(header("Authorization", "Bearer good"))
+        .respond_with(ResponseTemplate::new(200))
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls2 = calls.clone();
+    let refresher: AuthRefresher = Arc::new(move || {
+        let calls = calls2.clone();
+        Box::pin(async move {
+            // First acquire hands out a stale token; the re-acquire hands out the good one.
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            Ok(if n == 0 { "stale".to_string() } else { "good".to_string() })
+        })
+    });
+
+    let client = ResilientClient::builder()
+        .retry(fast_retry(2))
+        .bearer_auth(refresher)
+        .build();
+    let url = server.uri();
+    let resp = client.execute(|h| h.get(&url)).await.expect("succeeds after token refresh");
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(calls.load(Ordering::SeqCst), 2, "acquired once, refreshed once");
+}
+
+#[tokio::test]
+async fn circuit_breaker_opens_and_fails_fast() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let client = ResilientClient::builder()
+        .retry(fast_retry(0)) // 1 request per execute
+        .circuit_breaker(2, Duration::from_secs(60))
+        .build();
+    let url = server.uri();
+
+    assert!(client.execute(|h| h.get(&url)).await.is_err()); // failure 1
+    assert!(client.execute(|h| h.get(&url)).await.is_err()); // failure 2 → opens
+    let third = client.execute(|h| h.get(&url)).await;
+    assert!(third.is_err(), "breaker open → fast fail");
+
+    // The third call never reached the server.
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        2,
+        "breaker short-circuited the third request"
+    );
+}
+
+#[tokio::test]
+async fn caps_parallelism() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_millis(100)))
+        .mount(&server)
+        .await;
+
+    let client = ResilientClient::builder().max_parallel(3).build();
+    let url = server.uri();
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let c = client.clone();
+        let url = url.clone();
+        handles.push(tokio::spawn(async move { c.execute(move |h| h.get(&url)).await }));
+    }
+    for h in handles {
+        let _ = h.await.unwrap();
+    }
+
+    let peak = client.peak_in_flight();
+    assert!(peak <= 3, "parallelism cap exceeded: peak {peak}");
+    assert!(peak >= 2, "requests did not actually parallelize: peak {peak}");
+}


### PR DESCRIPTION
Step 8 of taking the Scenery layer a level higher. **Off `main`** (independent of the diorama PR stack #309–#316 — different crate).

## What's in here
`ResilientClient` — the structured-concurrency replacement for the `AwwPool`/`HttpClientPool`/`EventualRequest` worker-pool + oneshot-matcher model. You `.await` a request instead of detaching it onto a pool and matching responses by id:
- **parallelism cap** via a semaphore (per-API limit),
- **retry** with exponential backoff + jitter on 429/5xx/network, honoring `Retry-After`, bounded by `max_retries`,
- **auth refresh** — a 401 re-acquires the token and replays,
- **circuit breaker** — fail fast after N consecutive failures, half-open probe after cooldown.
- Cancellation is structural — drop the future, drop the request.

Nothing in the workspace depended on the old machinery except its own example, so this is purely additive; the old `AwwPool` path is unchanged and retired once consumers migrate.

## Verification
`cargo test -p vantage-api-pool`: 6 new wiremock contract tests green (retry 429/500, no-retry 4xx, 401→refresh→replay carrying the new token, breaker fast-fail, parallelism cap peak ≤ max), plus the 11 existing tests. Clippy clean.

## Follow-on
Pointing `vantage-ui`'s REST datasource at `ResilientClient` (and Diorama's `on_load_chunk`/augmentation fan-out) is the integration step — a separate change in that repo, with a manual verify in the running app.