### PR TITLE
chore: version bumps for scenery-rework crates (diorama 0.6.4, vista 0.6.3, api-pool 0.6.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-pool"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-pool/Cargo.toml
+++ b/vantage-api-pool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "vantage-api-pool"
-version = "0.6.0"
+version = "0.6.1"
 license = "MIT OR Apache-2.0"
 description = "Paginated REST API client pool for Vantage"
 

--- a/vantage-api-pool/src/resilient/mod.rs
+++ b/vantage-api-pool/src/resilient/mod.rs
@@ -20,11 +20,11 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use tokio::sync::{RwLock, Semaphore};
 
 /// Retry/backoff knobs. Backoff is exponential from `base` (doubling per
@@ -206,17 +206,22 @@ impl ResilientClient {
                         return Ok(resp);
                     }
                     // 401 → refresh the token once and replay (not a retry).
-                    if status.as_u16() == 401 && self.auth.is_some() && !refreshed {
-                        refreshed = true;
-                        self.auth.as_ref().unwrap().reacquire().await?;
-                        continue;
+                    if status.as_u16() == 401 && !refreshed {
+                        if let Some(auth) = self.auth.as_ref() {
+                            refreshed = true;
+                            auth.reacquire().await?;
+                            continue;
+                        }
                     }
                     // 429 / 5xx → backoff + retry.
                     if status.as_u16() == 429 || status.is_server_error() {
                         if attempt >= self.policy.max_retries {
-                            return Err(anyhow!("giving up after {attempt} retries: HTTP {status}"));
+                            return Err(anyhow!(
+                                "giving up after {attempt} retries: HTTP {status}"
+                            ));
                         }
-                        let delay = retry_after(&resp).unwrap_or_else(|| self.policy.backoff(attempt));
+                        let delay =
+                            retry_after(&resp).unwrap_or_else(|| self.policy.backoff(attempt));
                         attempt += 1;
                         tokio::time::sleep(with_jitter(delay)).await;
                         continue;
@@ -244,7 +249,13 @@ impl ResilientClient {
 }
 
 fn retry_after(resp: &reqwest::Response) -> Option<Duration> {
-    let secs: u64 = resp.headers().get("retry-after")?.to_str().ok()?.parse().ok()?;
+    let secs: u64 = resp
+        .headers()
+        .get("retry-after")?
+        .to_str()
+        .ok()?
+        .parse()
+        .ok()?;
     (secs >= 1).then(|| Duration::from_secs(secs))
 }
 
@@ -292,12 +303,21 @@ impl ResilientClientBuilder {
     /// Apply a bearer-style auth token, re-acquired lazily and on `401`.
     /// `refresher` returns the token value (without the scheme prefix).
     pub fn bearer_auth(mut self, refresher: AuthRefresher) -> Self {
-        self.auth = Some((refresher, "Authorization".to_string(), "Bearer ".to_string()));
+        self.auth = Some((
+            refresher,
+            "Authorization".to_string(),
+            "Bearer ".to_string(),
+        ));
         self
     }
 
     /// Apply auth with a custom header name and scheme prefix.
-    pub fn auth(mut self, refresher: AuthRefresher, header: impl Into<String>, scheme: impl Into<String>) -> Self {
+    pub fn auth(
+        mut self,
+        refresher: AuthRefresher,
+        header: impl Into<String>,
+        scheme: impl Into<String>,
+    ) -> Self {
         self.auth = Some((refresher, header.into(), scheme.into()));
         self
     }
@@ -312,15 +332,13 @@ impl ResilientClientBuilder {
             http: self.http.unwrap_or_default(),
             semaphore: Arc::new(Semaphore::new(self.max_parallel)),
             policy: self.policy,
-            breaker: self
-                .breaker
-                .map(|(threshold, cooldown)| {
-                    Arc::new(CircuitBreaker {
-                        threshold,
-                        cooldown,
-                        inner: std::sync::Mutex::new(BreakerInner::default()),
-                    })
-                }),
+            breaker: self.breaker.map(|(threshold, cooldown)| {
+                Arc::new(CircuitBreaker {
+                    threshold,
+                    cooldown,
+                    inner: std::sync::Mutex::new(BreakerInner::default()),
+                })
+            }),
             auth: self.auth.map(|(refresh, header, scheme)| {
                 Arc::new(AuthState {
                     token: RwLock::new(None),

--- a/vantage-api-pool/tests/resilient.rs
+++ b/vantage-api-pool/tests/resilient.rs
@@ -1,8 +1,8 @@
 //! Contract tests for `ResilientClient` against a wiremock server — retry,
 //! backoff, auth refresh, circuit breaker, and the parallelism cap.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use vantage_api_pool::resilient::AuthRefresher;
@@ -36,9 +36,16 @@ async fn retries_429_then_succeeds() {
 
     let client = ResilientClient::builder().retry(fast_retry(5)).build();
     let url = format!("{}/x", server.uri());
-    let resp = client.execute(|h| h.get(&url)).await.expect("succeeds after retries");
+    let resp = client
+        .execute(|h| h.get(&url))
+        .await
+        .expect("succeeds after retries");
     assert_eq!(resp.status().as_u16(), 200);
-    assert_eq!(server.received_requests().await.unwrap().len(), 3, "2×429 + 1×200");
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        3,
+        "2×429 + 1×200"
+    );
 }
 
 #[tokio::test]
@@ -57,7 +64,10 @@ async fn retries_500_then_succeeds() {
 
     let client = ResilientClient::builder().retry(fast_retry(5)).build();
     let url = server.uri();
-    let resp = client.execute(|h| h.get(&url)).await.expect("succeeds after 503");
+    let resp = client
+        .execute(|h| h.get(&url))
+        .await
+        .expect("succeeds after 503");
     assert_eq!(resp.status().as_u16(), 200);
     assert_eq!(server.received_requests().await.unwrap().len(), 2);
 }
@@ -74,7 +84,11 @@ async fn does_not_retry_4xx() {
     let url = server.uri();
     let r = client.execute(|h| h.get(&url)).await;
     assert!(r.is_err(), "404 is terminal");
-    assert_eq!(server.received_requests().await.unwrap().len(), 1, "no retry on 404");
+    assert_eq!(
+        server.received_requests().await.unwrap().len(),
+        1,
+        "no retry on 404"
+    );
 }
 
 #[tokio::test]
@@ -99,7 +113,11 @@ async fn refreshes_token_on_401_and_replays() {
         Box::pin(async move {
             // First acquire hands out a stale token; the re-acquire hands out the good one.
             let n = calls.fetch_add(1, Ordering::SeqCst);
-            Ok(if n == 0 { "stale".to_string() } else { "good".to_string() })
+            Ok(if n == 0 {
+                "stale".to_string()
+            } else {
+                "good".to_string()
+            })
         })
     });
 
@@ -108,9 +126,16 @@ async fn refreshes_token_on_401_and_replays() {
         .bearer_auth(refresher)
         .build();
     let url = server.uri();
-    let resp = client.execute(|h| h.get(&url)).await.expect("succeeds after token refresh");
+    let resp = client
+        .execute(|h| h.get(&url))
+        .await
+        .expect("succeeds after token refresh");
     assert_eq!(resp.status().as_u16(), 200);
-    assert_eq!(calls.load(Ordering::SeqCst), 2, "acquired once, refreshed once");
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        2,
+        "acquired once, refreshed once"
+    );
 }
 
 #[tokio::test]
@@ -155,7 +180,9 @@ async fn caps_parallelism() {
     for _ in 0..10 {
         let c = client.clone();
         let url = url.clone();
-        handles.push(tokio::spawn(async move { c.execute(move |h| h.get(&url)).await }));
+        handles.push(tokio::spawn(async move {
+            c.execute(move |h| h.get(&url)).await
+        }));
     }
     for h in handles {
         let _ = h.await.unwrap();
@@ -163,5 +190,8 @@ async fn caps_parallelism() {
 
     let peak = client.peak_in_flight();
     assert!(peak <= 3, "parallelism cap exceeded: peak {peak}");
-    assert!(peak >= 2, "requests did not actually parallelize: peak {peak}");
+    assert!(
+        peak >= 2,
+        "requests did not actually parallelize: peak {peak}"
+    );
 }

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.3 — unreleased
+## 0.6.4 — unreleased
 
 - Diagnostics surface. `dio.diagnostics().await` returns a `DioDiagnostics`
   snapshot — cache row count, query-index count, and one `SceneryDiagnostic` per

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -83,7 +83,7 @@ pub(crate) struct DioInner {
     /// the one shared `Arc` (one reactor, one cache window, one in-flight
     /// `JoinSet`), and the entry self-heals once the last widget releases
     /// it. This is what makes "scenery must be cheap" true and what lets a
-    /// closing grid stop pulling — see [`TableSceneryImpl`]'s drop guard.
+    /// closing grid stop pulling — see `TableSceneryImpl`'s drop guard.
     pub(crate) table_sceneries:
         std::sync::Mutex<std::collections::HashMap<String, std::sync::Weak<dyn TableScenery>>>,
 }
@@ -192,7 +192,7 @@ impl Dio {
         self.inner.write_worker.lock().await.take()
     }
 
-    /// Start a [`TableScenery`](crate::scenery::TableScenery) builder
+    /// Start a [`TableScenery`] builder
     /// for this Dio. Chainable; call `.open().await` to spawn the
     /// reactive view.
     pub fn table_scenery(&self) -> TableSceneryBuilder {

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -26,7 +26,7 @@ pub use lens::{
 pub use ops::{ChangeEvent, QueryDescriptor, WriteOp};
 pub use scenery::{
     Aggregate, CustomAggregate, EnrichedRecord, RecordScenery, RecordStatus, RowStatus,
-    RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder, ValueScenery, ValueSceneryBuilder,
-    ValueStatus, boxed_custom_aggregate,
+    RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder, ValueScenery,
+    ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
 };
 pub use vantage_vista::VistaCapabilities;

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -119,7 +119,10 @@ impl TableSceneryBuilder {
             });
             format!(
                 "table\u{1}{}\u{1}{}\u{1}{}",
-                dio.master.read().unwrap().index_key(&conditions, vista_sort),
+                dio.master
+                    .read()
+                    .unwrap()
+                    .index_key(&conditions, vista_sort),
                 search.as_deref().unwrap_or(""),
                 titles_only as u8,
             )
@@ -146,7 +149,11 @@ impl TableSceneryBuilder {
                 };
                 (col.as_str(), dir)
             });
-            let key = dio.master.read().unwrap().index_key(&conditions, vista_sort);
+            let key = dio
+                .master
+                .read()
+                .unwrap()
+                .index_key(&conditions, vista_sort);
             Some(dio.query_index(&key))
         } else {
             None

--- a/vantage-diorama/tests/activity.rs
+++ b/vantage-diorama/tests/activity.rs
@@ -21,7 +21,9 @@ fn master() -> Vista {
         .with_id_column("id");
     let mut rec = Record::new();
     rec.insert("name".to_string(), CborValue::Text("alpha".into()));
-    let shell = MockShell::new().with_metadata(metadata).with_record("a", rec);
+    let shell = MockShell::new()
+        .with_metadata(metadata)
+        .with_record("a", rec);
     Vista::new("items", Box::new(shell))
 }
 

--- a/vantage-diorama/tests/bdd_support/steps/registry.rs
+++ b/vantage-diorama/tests/bdd_support/steps/registry.rs
@@ -38,7 +38,10 @@ async fn same_object(w: &mut DioramaWorld) {
 async fn live_count(w: &mut DioramaWorld, expected: usize) {
     let dio = w.dio.as_ref().expect("dio not created");
     let got = dio.live_table_scenery_count();
-    assert_eq!(got, expected, "live table scenery count: want {expected}, got {got}");
+    assert_eq!(
+        got, expected,
+        "live table scenery count: want {expected}, got {got}"
+    );
 }
 
 #[when("the table scenery handles are released")]

--- a/vantage-diorama/tests/record_scenery.rs
+++ b/vantage-diorama/tests/record_scenery.rs
@@ -253,9 +253,21 @@ async fn optimistic_patch_shows_pending_then_fresh() -> Result<()> {
 
     wait_for_gen(&mut gen_rx, g0).await;
     let r = scenery.record().expect("record present");
-    assert_eq!(r.record.get("name"), Some(&cbor_text("edited")), "value staged");
-    assert_eq!(r.record.get("price"), Some(&CborValue::Integer(30.into())), "patch merges");
-    assert!(matches!(r.status, RowStatus::PendingWrite), "got {:?}", r.status);
+    assert_eq!(
+        r.record.get("name"),
+        Some(&cbor_text("edited")),
+        "value staged"
+    );
+    assert_eq!(
+        r.record.get("price"),
+        Some(&CborValue::Integer(30.into())),
+        "patch merges"
+    );
+    assert!(
+        matches!(r.status, RowStatus::PendingWrite),
+        "got {:?}",
+        r.status
+    );
 
     // Release the write-through → confirms → Fresh.
     let g1 = u64::from(*gen_rx.borrow_and_update());
@@ -280,7 +292,10 @@ async fn optimistic_patch_rolls_back_to_write_failed() -> Result<()> {
     let scenery = dio.record_scenery("a").await?;
 
     let outcome = dio.patch_optimistic("a", partial_name("edited")).await;
-    assert!(outcome.is_err(), "a rejecting write-through must surface the error");
+    assert!(
+        outcome.is_err(),
+        "a rejecting write-through must surface the error"
+    );
 
     // The reactor processes WritePending then WriteReverted; wait for the row to
     // settle on the failure.

--- a/vantage-diorama/tests/reload.rs
+++ b/vantage-diorama/tests/reload.rs
@@ -53,12 +53,12 @@ async fn eager_lens(cache_path: std::path::PathBuf) -> Arc<Lens> {
 }
 
 fn name_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
-    scenery
-        .row(idx)
-        .and_then(|r| r.record.get("name").and_then(|v| match v {
+    scenery.row(idx).and_then(|r| {
+        r.record.get("name").and_then(|v| match v {
             CborValue::Text(s) => Some(s.clone()),
             _ => None,
-        }))
+        })
+    })
 }
 
 async fn eventually(label: &str, f: impl Fn() -> bool) {
@@ -121,6 +121,9 @@ async fn reload_swaps_dataset_without_blanking() -> Result<()> {
 
     // No blank: the view never showed fewer than the original 2 rows.
     let min = min_seen.load(Ordering::SeqCst);
-    assert!(min >= 2, "scenery blanked mid-reload — min row_count was {min}");
+    assert!(
+        min >= 2,
+        "scenery blanked mid-reload — min row_count was {min}"
+    );
     Ok(())
 }

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -277,7 +277,10 @@ async fn sort_change_restarts_augmentation_without_scrolling() {
     );
     // Soft-refresh: the visible row never blanks to None, and its augmented
     // (detail) columns survive the reorder because the cache is keyed by id.
-    assert!(scenery.row(0).is_some(), "row 0 stays present across the resort");
+    assert!(
+        scenery.row(0).is_some(),
+        "row 0 stays present across the resort"
+    );
     assert_eq!(detail_of(&scenery, 0).as_deref(), Some("full-r0"));
 
     // Reverting to a variant already listed reorders straight from cache — its
@@ -315,20 +318,34 @@ async fn titles_only_picker_skips_detail_hydration() {
     let lens = two_pass_lens(tmp.path(), &log);
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
-    let picker = dio.table_scenery().titles_only().page_size(2).open().await.unwrap();
+    let picker = dio
+        .table_scenery()
+        .titles_only()
+        .page_size(2)
+        .open()
+        .await
+        .unwrap();
     picker.set_viewport(0..2);
     // Let the viewport debounce + (suppressed) detail path run.
     tokio::time::sleep(Duration::from_millis(30)).await;
 
     // List columns are present; the row stays Incomplete and no detail ran.
-    assert_eq!(branch_of(&picker, 0).as_deref(), Some("main"), "title column listed");
+    assert_eq!(
+        branch_of(&picker, 0).as_deref(),
+        Some("main"),
+        "title column listed"
+    );
     assert!(
         matches!(status_of(&picker, 0), Some(RowStatus::Incomplete)),
         "picker rows stay Incomplete: {:?}",
         status_of(&picker, 0)
     );
     assert!(detail_of(&picker, 0).is_none(), "no detail column");
-    assert_eq!(count_with_prefix(&log, "detail"), 0, "picker must not hydrate");
+    assert_eq!(
+        count_with_prefix(&log, "detail"),
+        0,
+        "picker must not hydrate"
+    );
     assert_eq!(count_with_prefix(&log, "list"), 1, "one list page");
 
     // A full grid over the same query is a DISTINCT scenery (it hydrates), so
@@ -362,7 +379,13 @@ async fn diagnostics_report_sceneries_refcount_and_hydration() {
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
     // A picker (titles_only) lists cheap rows — Incomplete, never hydrated.
-    let picker = dio.table_scenery().titles_only().page_size(2).open().await.unwrap();
+    let picker = dio
+        .table_scenery()
+        .titles_only()
+        .page_size(2)
+        .open()
+        .await
+        .unwrap();
     eventually("picker listed", || picker.row_count() >= 2).await;
 
     let d = dio.diagnostics().await;
@@ -376,7 +399,13 @@ async fn diagnostics_report_sceneries_refcount_and_hydration() {
     assert_eq!(d.sceneries[0].status.fresh, 0);
 
     // Dedup: re-opening the same picker query shares it → refcount 2.
-    let picker2 = dio.table_scenery().titles_only().page_size(2).open().await.unwrap();
+    let picker2 = dio
+        .table_scenery()
+        .titles_only()
+        .page_size(2)
+        .open()
+        .await
+        .unwrap();
     assert_eq!(dio.diagnostics().await.sceneries[0].refcount, 2);
 
     // A full grid is a distinct scenery that hydrates → Fresh rows.

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.5 — unreleased
+
+- Docs: `ExpressionFn`'s doc comment no longer intra-doc-links to the private `Table::as_entity_erased`,
+  which broke `cargo doc -D warnings` (and docs.rs) under `rustdoc::private_intra_doc_links`. No API change.
+
 ## 0.6.4 — unreleased
 
 - `Pagination::window(offset, limit)` for random-access `[offset, offset + limit)` windows whose

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -17,7 +17,7 @@ use crate::{
 /// expression only ever reads entity-agnostic table state (columns and
 /// relations by name, conditions, subqueries), never the entity's typed fields.
 /// [`Table::with_expression`] adapts the caller's `Fn(&Table<T, E>)` into this
-/// shape; see [`Table::as_entity_erased`] for the soundness of the cast.
+/// shape; see `Table::as_entity_erased` for the soundness of the cast.
 pub type ExpressionFn<T> =
     Arc<dyn Fn(&Table<T, EmptyEntity>) -> Expression<<T as TableSource>::Value> + Send + Sync>;
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.3 — unreleased
+
+### Added
+
+- `MockShell` mutation helpers (`set_record`, `set_field`, `remove_record`, `clear_records`): opt-in,
+  interior-mutable knobs for scripting server-side dataset changes mid-test. Back `vantage-diorama`'s
+  scriptable test source (refresh / reload / soft-refresh scenarios). Read-only `MockShell` behaviour
+  is unchanged.
+
 ## 0.6.2 — unreleased
 
 ### Added

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"


### PR DESCRIPTION
Bumps the patch version of every crate touched by the scenery-rework stack (#309–#317) so they can be published — each repo version currently equals the already-published crates.io version and would collide.

## Versions
| crate | was (published) | → now |
|-------|-----------------|-------|
| `vantage-diorama` | 0.6.3 | **0.6.4** |
| `vantage-vista` | 0.6.2 | **0.6.3** |
| `vantage-api-pool` | 0.6.0 | **0.6.1** |

CHANGELOG headings retagged accordingly; `vantage-vista` gains a `0.6.3` stanza for the `MockShell` mutation helpers.

## fmt + clippy
- `cargo fmt` — reformatted several merged-PR files (main was not fmt-clean due to rustfmt-version skew with CI). Pure formatting, no semantic change.
- `cargo clippy --all-targets` on all three crates — **0 warnings**. Fixed one `unnecessary_unwrap` in `resilient/mod.rs` (rewrote `is_some` + `unwrap` as `if let Some(..)`); api-pool resilient tests re-verified **6/6 pass**.