### PR TITLE
Table lifecycle hooks + docs refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/docs4/book.toml
+++ b/docs4/book.toml
@@ -2,7 +2,7 @@
 authors = ["Romans Malinovskis"]
 language = "en"
 src = "src"
-title = "Vantage 0.4 Framework"
+title = "Vantage Framework"
 
 [preprocessor.toc]
 max-level = 3

--- a/docs4/src/SUMMARY.md
+++ b/docs4/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [What's New in 0.4](./whats-new-04.md)
   - [What's New in 0.5](./whats-new-in-05.md)
 - [Expressions & Queries](./expressions.md)
+- [Records: Traversal, Invariants & Hooks](./record-lifecycle.md)
 - [Model-Driven Architecture](./mda.md)
   - [Three Paths for Developers](./three-paths.md)
 - [Adding a New Persistence](./new-persistence.md)

--- a/docs4/src/intro/step2-tables.md
+++ b/docs4/src/intro/step2-tables.md
@@ -188,63 +188,14 @@ side effects.
 
 ---
 
-## Type-erased tables
+## Listing any table
 
-`Table<SqliteDB, Product>` is great when you know the types at compile time. But what if you want to
-write a function that lists _any_ table — products, orders, customers — without knowing the entity
-type?
+`Table<SqliteDB, Product>` is great when you know the types at compile time. Sometimes you want a
+function that lists _any_ table — products, orders, customers — without naming the entity type.
 
-`AnyTable` wraps a concrete table and erases its type parameters.
-Values come back as `Record<serde_json::Value>` instead of typed entities. You can iterate columns
-by name and build a generic display:
+With **generics** you keep full type safety, limited to Rust callers:
 
 ```rust
-async fn list_table(table: &AnyTable) -> VantageResult<()> {
-    let columns = table.column_names();
-
-    // Header
-    print!("  {:<12}", "id");
-    for col in &columns {
-        print!("{:<16}", col);
-    }
-    println!();
-
-    // Rows
-    for (id, record) in table.list_values().await? {
-        print!("  {:<12}", id);
-        for col in &columns {
-            let val = record.get(col).map(|v| format!("{}", v)).unwrap_or_default();
-            print!("{:<16}", val);
-        }
-        println!();
-    }
-    Ok(())
-}
-```
-
-Convert any typed table into an `AnyTable` with `from_table()`:
-
-```rust
-let table = Product::table(db);
-let any = AnyTable::from_table(table);
-
-list_table(&any).await?;
-// id          name            price
-// cupcake     "Cupcake"       120
-// donut       "Doughnut"      135
-// ...
-```
-
-Under the hood, `AnyTable` converts values to and from `serde_json::Value` on the fly. Conditions,
-pagination, and all CRUD operations still work — you just lose compile-time type safety on the
-entity fields. This is the trade-off: `AnyTable` lets you build generic UI components, CLI tools,
-and admin panels that work with any table definition.
-
-```admonish info title="Generics vs type erasure"
-You can also write `list_table` using generics — that keeps type safety but limits you
-to Rust callers:
-
-~~~rust
 async fn list_table<E: Entity + std::fmt::Debug>(
     table: &impl ReadableDataSet<E>,
 ) -> VantageResult<()> {
@@ -253,11 +204,12 @@ async fn list_table<E: Entity + std::fmt::Debug>(
     }
     Ok(())
 }
-~~~
-
-If you plan to expose tables outside of Rust (Python bindings, FFI, a web admin UI),
-type erasure via `AnyTable` is the way to go.
 ```
+
+To go fully **type-erased** — iterate columns by name, get runtime values, and expose tables
+outside Rust (a web admin UI, FFI, scripting) — wrap the table in a **Vista**, the universal
+schema-bearing data handle. That's the subject of [its own chapter](./step4-vista.md); `Vista`
+replaced the older `AnyTable` carrier in 0.5.
 
 ---
 

--- a/docs4/src/introduction.md
+++ b/docs4/src/introduction.md
@@ -7,7 +7,7 @@ composable handle to records living in a remote data store. You define structure
 relations, and operations without loading data eagerly, and Vantage translates your intent into
 efficient queries for whichever backend you're using.
 
-This documentation covers Vantage **0.4**.
+This documentation tracks the current **0.6** release line.
 
 ## Getting Started
 
@@ -22,44 +22,3 @@ You'll need basic Rust experience (structs, traits, async/await, cargo). No prio
 required.
 
 **Start here:** [SQLite and the Query Builder](./intro/step1-first-query.md)
-
----
-
-<!-- internal use: concept coverage tracker — once covered in introduction, cross out here -->
-
-## TODO: Concept Coverage
-
-- [x] Expression basics (`sqlite_expr!`, parameter binding, injection safety)
-- [x] Identifier quoting (`ident()`, dialect-aware)
-- [ ] SqliteSelect via Selectable trait (with_source, with_field, with_condition, with_order,
-      with_limit) — partial, missing with_order, with_limit
-- [x] Executing queries (ExprDataSource, `db.execute()`) — `db.associate()` not covered
-- [ ] Aggregates on select (as_count, as_sum) — covered via `db.aggregate()` not `.as_count()` directly
-- [x] Table definition (Table::new, with_column_of, with_id_column, builder pattern)
-- [x] Table → select query (table.select() returns vendor-specific builder)
-- [x] DataSource concept (what it is, how you pass it to Table::new)
-- [x] Entity struct (plain Rust struct, no id field, `#[entity]` macro)
-- [x] Record\<V\> (persistence-native value bags)
-- [ ] Type system (vantage_type_system! macro, AnySqliteType, typed vs untyped values) — AnySqliteType mentioned, macro not shown
-- [x] ReadableDataSet (list, get, get_some, get_count)
-- [x] WritableDataSet (insert, delete)
-- [ ] ActiveEntity (get_entity, modify via DerefMut, save)
-- [x] Conditions (table["field"], .eq/.gt/.lt, with_condition returns new table)
-- [ ] Sync vs async — defining table is sync, hitting DB is async
-- [x] Relationships (with_one, with_many, declared on table not entity)
-- [x] Reference traversal (get_ref_as, subquery-based conditions)
-- [x] Computed fields (with_expression, correlated subqueries)
-- [x] AnyTable (from_table, JSON boundary, type-erased generic code)
-- [ ] Model crate pattern (entities + table constructors + relationships in one crate)
-- [ ] Multiple backends per entity (surreal_table, sqlite_table, csv_table)
-- [ ] DataSet trait hierarchy (ReadableDataSet, InsertableDataSet, WritableDataSet) — partial, ReadableDataSet only
-- [ ] ValueSet traits (schema-less Record-based access)
-- [x] Vendor-specific query builders (SqliteSelect, PostgresSelect, SurrealSelect)
-- [ ] Deferred expressions (cross-database defer/map)
-- [ ] Progressive persistence model (implement only what your backend supports)
-- [x] Error handling (VantageError, context, with_context) — partial (VantageError + context shown)
-- [ ] Connection management (DSN pattern, OnceLock)
-- [ ] Pagination (with_pagination)
-- [x] Search expressions (search_expression, vendor-specific LIKE/CONTAINS) — via `with_search`
-- [ ] models! macro (all_tables() generation)
-- [x] Extension traits (trait CategoryTable, ref_products, adding custom methods like print)

--- a/docs4/src/mda.md
+++ b/docs4/src/mda.md
@@ -42,7 +42,7 @@ bakery_model3/
  │    ├── order.rs        ← Order entity + table constructors
  │    └── product.rs      ← Product entity + table constructors
  └── examples/
-      ├── cli.rs          ← multi-source CLI using AnyTable
+      ├── cli.rs          ← multi-source CLI using Vista
       └── 0-intro.rs      ← direct SurrealDB queries
 ```
 
@@ -225,18 +225,20 @@ entity definitions and business rules.
 
 ## Type-erased access
 
-For truly generic code (UI grids, admin panels, config-driven tools), wrap tables with `AnyTable`:
+For truly generic code (UI grids, admin panels, config-driven tools), wrap tables in a
+[`Vista`](./new-persistence/step8-vista-integration.md) — the schema-bearing handle that replaced
+the removed `AnyTable` in 0.5:
 
 ```rust
-let tables: Vec<AnyTable> = vec![
-    AnyTable::from_table(Client::surreal_table(db.clone())),
-    AnyTable::from_table(Product::sqlite_table(sqlite.clone())),
-    AnyTable::from_table(Order::csv_table(csv.clone())),
+let vistas = vec![
+    db.vista_factory().from_table(Client::surreal_table(db.clone()))?,
+    sqlite.vista_factory().from_table(Product::sqlite_table(sqlite.clone()))?,
+    csv.vista_factory().from_table(Order::csv_table(csv.clone()))?,
 ];
 
 // Same code handles all three — different databases, same interface
-for table in &tables {
-    println!("{}: {} records", table.table_name(), table.get_count().await?);
+for v in &vistas {
+    println!("{} records", v.list_values().await?.len());
 }
 ```
 

--- a/docs4/src/new-persistence.md
+++ b/docs4/src/new-persistence.md
@@ -1,8 +1,8 @@
 # Adding a New Persistence
 
-So you want to connect Vantage to a new database? This guide walks through the process in eight
+So you want to connect Vantage to a new database? This guide walks through the process in nine
 incremental steps — each one unlocks more framework features. You don't have to implement all
-eight; stop whenever your persistence has enough capability for your use case.
+nine; stop whenever your persistence has enough capability for your use case.
 
 <!-- toc -->
 
@@ -18,8 +18,9 @@ eight; stop whenever your persistence has enough capability for your use case.
 | [4. Query Builder](./new-persistence/step4-query-builder.md)  | `Selectable`, `SelectableDataSource`                          | Composable SELECT with conditions, ordering, limits                  | Skip if your persistence has no query language |
 | [5. Table & CRUD](./new-persistence/step5-table-crud.md)      | `TableSource`, entity tables, aggregates, writes              | `Table<DB, Entity>`, full CRUD, `ReadableDataSet`, `WritableDataSet` | **Required** for table support                 |
 | [6. Relationships](./new-persistence/step6-relationships.md)  | `with_one`, `with_many`, correlated subqueries                | Reference traversal, expression fields                               | Skip if you don't need cross-table queries     |
-| [7. Multi-Backend](./new-persistence/step7-multi-backend.md)  | `AnyTable::from_table()`, CLI example                         | Type-erased tables, generic UI/API code                              | Skip if you only use one persistence           |
+| [7. Multi-Backend](./new-persistence/step7-multi-backend.md)  | model crate, `vista_factory().from_table()`, CLI example     | Type-erased tables, generic UI/API code                              | Skip if you only use one persistence           |
 | [8. Vista](./new-persistence/step8-vista-integration.md)      | `<Driver>VistaFactory`, `<Driver>TableShell`, YAML extras     | YAML-defined data handles consumed by UI / scripting / agents        | Skip if you don't need Vista support           |
+| [9. Contained Relations](./new-persistence/step9-contained-relations.md) | embedded object/array columns as sub-tables       | JSON/document sub-records surfaced as editable child sets            | Skip if you have no embedded collections       |
 
 ---
 
@@ -102,9 +103,11 @@ Skip this step if your persistence is flat (no foreign keys or cross-collection 
 
 ## Step 7: Multi-Backend Applications
 
-Wrap your tables with `AnyTable::from_table()` to erase the backend type. This enables generic UI,
-CLI, and API code that works identically across SurrealDB, SQLite, CSV, MongoDB, or your new
-persistence — all through a uniform `serde_json::Value`-based interface.
+Define your entities and table constructors once in a model crate, then erase the backend type with
+`db.vista_factory().from_table(table)` so generic UI, CLI, and API code works identically across
+SurrealDB, SQLite, CSV, MongoDB, or your new persistence. (Type erasure used to live in the
+now-removed `AnyTable`; it moved up to [`Vista`](./new-persistence/step8-vista-integration.md) in
+0.5.)
 
 **[Read Step 7 →](./new-persistence/step7-multi-backend.md)**
 
@@ -118,4 +121,17 @@ condition delegation so callers don't need a Rust entity struct.
 
 Skip this step if your driver is only consumed from typed Rust code.
 
-**[Read Step 8 →](./new-persistence/step8-vista.md)**
+**[Read Step 8 →](./new-persistence/step8-vista-integration.md)**
+
+---
+
+## Step 9: Contained Relations
+
+Surface an embedded object or array column (a JSON document, a Mongo sub-document) as an editable
+child sub-table. Declare it with `with_contained_one` / `with_contained_many`; reads project the
+embedded collection as records and writes patch it back into the host column. Native document
+backends and JSON-blob columns share the same path.
+
+Skip this step if your persistence has no embedded collections.
+
+**[Read Step 9 →](./new-persistence/step9-contained-relations.md)**

--- a/docs4/src/new-persistence/step3-operators.md
+++ b/docs4/src/new-persistence/step3-operators.md
@@ -1,4 +1,4 @@
-# Step 2b: Implement Operators
+# Step 3: Implement Operators
 
 Expressions let you build raw queries, but users shouldn't have to write
 `sqlite_expr!("{} > {}", (ident("price")), 100i64)` every time they want a condition. **Operators**

--- a/docs4/src/new-persistence/step4-query-builder.md
+++ b/docs4/src/new-persistence/step4-query-builder.md
@@ -1,4 +1,4 @@
-# Step 3: Statement Builders and SelectableDataSource
+# Step 4: Statement Builders and SelectableDataSource
 
 In practice, nobody writes raw expressions for every query. This step adds the `Selectable` trait
 implementation for your SELECT builder and wires it up through `SelectableDataSource` so the rest of

--- a/docs4/src/new-persistence/step5-table-crud.md
+++ b/docs4/src/new-persistence/step5-table-crud.md
@@ -1,4 +1,4 @@
-# Step 4: Table Abstraction and Entity CRUD
+# Step 5: Table Abstraction and Entity CRUD
 
 The same entities get used hundreds of times across a codebase — constructing a query from scratch
 every single time is tedious and error-prone. Vantage offers `Table<>` as an abstraction over your

--- a/docs4/src/new-persistence/step6-relationships.md
+++ b/docs4/src/new-persistence/step6-relationships.md
@@ -1,8 +1,14 @@
-# Step 5: Relationships
+# Step 6: Relationships
 
 Tables can declare relationships using `with_one` and `with_many`, then traverse them at runtime
 with `get_ref_as`. The relationship system is provided by `vantage-table` — your backend just needs
 `column_table_values_expr` implemented to make it work.
+
+```admonish tip
+This step covers what a *driver* must implement for relationships. For the *consumer* side —
+traversing from a loaded record with `get_ref`, and the foreign-key invariants traversal sets up —
+see [Records: Traversal, Invariants & Hooks](../record-lifecycle.md).
+```
 
 Implement `column_table_values_expr` — it builds a subquery for a single column respecting current
 conditions. For SQL backends this is a `SELECT "col" FROM "table" WHERE ...` expression.

--- a/docs4/src/new-persistence/step7-multi-backend.md
+++ b/docs4/src/new-persistence/step7-multi-backend.md
@@ -1,42 +1,45 @@
-# Step 6: Multi-Backend Applications
+# Step 7: Multi-Backend Applications
 
 At this point your backend works — you can define tables, query data, and traverse relationships.
 But a real application typically has a _model crate_ that defines entities once and offers table
 constructors for each backend. That's `bakery_model3` in the Vantage repo. The final piece is
-`AnyTable`, which lets you treat tables from different backends uniformly.
+type erasure, which lets you treat tables from different backends uniformly.
 
-### AnyTable: the type-erased wrapper
-
-`AnyTable` erases the backend and entity types behind a uniform `serde_json::Value`-based interface.
-This is what makes it possible to write generic UI, CLI, or API code that doesn't care which
-database is behind it.
-
-There are two ways to create one:
-
-```rust
-// 1. If your backend already uses serde_json::Value (rare):
-let any = AnyTable::new(my_table);
-
-// 2. For backends with custom value types (the common case):
-let any = AnyTable::from_table(Product::sqlite_table(db));
+```admonish info title="AnyTable is gone — use Vista"
+Earlier versions erased the backend with `AnyTable`. It was removed in 0.5.2; type erasure now
+lives one layer up in [`Vista`](./step8-vista-integration.md), reached through the driver's vista
+factory. The mechanism below is the supported replacement.
 ```
 
-`from_table` works as long as your `AnyType` implements `Into<serde_json::Value>` and
-`From<serde_json::Value>`. The `vantage_type_system!` macro generates the `Into` conversion
-automatically, and after Step 1 your backend should have the `From` direction covered too.
+### Vista: the type-erased handle
+
+`db.vista_factory().from_table(table)` erases the backend and entity types behind a uniform,
+schema-bearing [`Vista`](./step8-vista-integration.md) carrying `Record<ciborium::Value>`. This is
+what makes it possible to write generic UI, CLI, or API code that doesn't care which database is
+behind it:
+
+```rust
+// Wrap any typed Table<Driver, Entity> as a backend-agnostic Vista:
+let products = Product::sqlite_table(db).vista_factory().from_table(Product::sqlite_table(db));
+// (or surreal/csv/mongo — the call site is identical)
+```
+
+Erasure works because each driver's vista factory bridges its native `AnyType` to the CBOR value
+the Vista exposes — the `vantage_type_system!` macro and your Step 1 conversions already provide
+both directions. See [Step 8](./step8-vista-integration.md) for the factory and `TableShell` you
+implement to enable this.
 
 ### Building a multi-source CLI
 
 The CLI example in `bakery_model3/examples/cli.rs` shows the pattern. A `build_table` function
-matches on the user's chosen source, calls the right entity constructor, and wraps it with
-`AnyTable::from_table()`. Once you have an `AnyTable`, all commands are backend-agnostic —
-`list_values()`, `get_count()`, `get_some_value()`, `insert_value()`, and `delete()` all work
-identically regardless of which database is behind it.
+matches on the user's chosen source, calls the right entity constructor, and wraps it through the
+vista factory. Once you have a `Vista`, all commands are backend-agnostic — listing, counting,
+reading, inserting, and deleting all work identically regardless of which database is behind it.
 
-Because the values flow through as `serde_json::Value`, the CLI renderer can inspect types at
+Because the values flow through as a typed CBOR record, the CLI renderer can inspect types at
 runtime — booleans like `is_deleted` display as `true`/`false` with color highlighting, numbers stay
 numeric, and nulls render cleanly. Your type system work in Step 1 ensures these values arrive with
-the right JSON type rather than everything being a string.
+the right type rather than everything being a string.
 
 Try it out:
 
@@ -61,5 +64,5 @@ cargo run --example cli -- surreal bakery delete myid
 ```
 
 That's the payoff of implementing a proper type system and `TableSource` — one line of
-`AnyTable::from_table()` bridges the gap between your backend's native types and a uniform
-JSON-based interface.
+`vista_factory().from_table()` bridges the gap between your backend's native types and a uniform
+record-based interface.

--- a/docs4/src/new-persistence/step8-vista-integration.md
+++ b/docs4/src/new-persistence/step8-vista-integration.md
@@ -1,4 +1,4 @@
-# Step 7: Vista Integration
+# Step 8: Vista Integration
 
 By the end of Step 6 your backend is a fully-featured persistence — typed `Table<T, E>`, conditions,
 relationships, the lot. That's exactly what business logic wants. It's also exactly what generic

--- a/docs4/src/record-lifecycle.md
+++ b/docs4/src/record-lifecycle.md
@@ -1,0 +1,168 @@
+# Records: Traversal, Invariants & Hooks
+
+Once a backend implements `TableSource` (see [Adding a New Persistence](./new-persistence.md)),
+`vantage-table` gives every `Table<Db, Entity>` a uniform write pipeline. On each write the record
+flows through three stages before it reaches the datasource:
+
+```text
+record  →  lifecycle hooks (before)  →  set invariants  →  datasource write  →  hooks (after)
+```
+
+This page covers the consumer-facing features built on that pipeline: traversing a relation from a
+loaded record, the foreign-key **invariants** that traversal sets up, and the **lifecycle hooks**
+you can attach for audit, validation, soft-delete, and after-effects. They are backend-agnostic —
+everything here works the same on SQLite, Postgres, MySQL, Mongo, etc.
+
+## Traversing from a loaded record: `get_ref`
+
+`Table::get_ref_as` / `get_ref_from_row` traverse a relation from a *table*. The `GetRefExt` trait
+adds the record-level equivalent: traverse straight from a loaded `ActiveEntity` (typed) or
+`ActiveRecord` (untyped).
+
+```rust
+use vantage_table::prelude::GetRefExt;
+
+let launch = launches.get_entity(id).await?.expect("launch");
+
+// A child set scoped to this launch — and carrying its foreign key (see invariants below).
+let crew = launch.get_ref::<LaunchCrew>("launch_crew")?;
+crew.insert_return_id(&LaunchCrew { astronaut_id: Some(a), role: Some("Pilot".into()), ..Default::default() }).await?;
+```
+
+`get_ref::<E2>(relation)` returns a `Table<T, E2>` scoped to the parent. For a typed `ActiveEntity`
+the entity's id is injected into the row before traversal (so has-many relations resolve); an
+untyped `ActiveRecord` already holds the raw row and forwards directly. The same method exists on
+both handles.
+
+## Set invariants
+
+A table narrowed by a literal `column = value` is a **set**, and every row written into it must
+*conform* to that definition. Vantage records the pair as an **invariant** and enforces it on
+write. The most common source is relationship traversal: `launch.get_ref::<LaunchCrew>("launch_crew")`
+narrows the child set by `launch_id = <this launch>`, so an inserted crew row's `launch_id` is
+filled automatically.
+
+Invariants are registered automatically wherever the scope is a plain `column = value`:
+
+- `Table::with_id(id)` — narrows by the id column.
+- has-many / has-one traversal (`Reference::resolve_from_row`) — narrows by the foreign key.
+
+Expression scopes never register an invariant. You can also set one explicitly with
+`Table::with_invariant(column, value)` / `add_invariant`.
+
+On every insert / replace / patch, each invariant column is resolved by a four-way rule:
+
+| record's value for the column | result |
+| --- | --- |
+| absent | set to the invariant value |
+| present but null | set to the invariant value |
+| present and equal | kept |
+| present and **conflicting** | the write is rejected with an error |
+
+So a child row inserted through a relation needs no foreign key (it's filled), may state the
+matching one (kept), but cannot smuggle in a *different* one (error — it doesn't belong to this set).
+
+```rust
+let crew = launch.get_ref::<LaunchCrew>("launch_crew")?;
+
+// launch_id absent → filled from the set:
+crew.insert_return_id(&LaunchCrew { astronaut_id: Some(a), role: Some("Pilot".into()), ..Default::default() }).await?;
+
+// launch_id set to a *different* launch → Err:
+assert!(crew.insert_return_id(&LaunchCrew { launch_id: Some("other".into()), ..Default::default() }).await.is_err());
+```
+
+```admonish info title="Backends and InvariantValue"
+Enforcement needs two operations on a backend's value type — a null check and an equality check —
+provided by the `InvariantValue` trait (`vantage-types`). The `vantage_type_system!` macro emits it
+for every generated `Any*Type`; pass a `null_when:` pattern (e.g. `null_when: ciborium::Value::Null`
+for the SQL backends) so genuine nulls are recognised. Non-nullable value types (e.g. CSV's
+`String`) simply never match the null branch.
+```
+
+## Lifecycle hooks
+
+Attach async callbacks around writes with `Table::with_hook(Hook::…)`. Hooks are how audit stamps,
+normalization, validation, soft-delete, and after-effects are expressed — generically, on any
+backend.
+
+```rust
+use std::sync::Arc;
+use vantage_table::prelude::{Hook, Phase};
+
+let launches = Launch::table(db).with_hook(Hook::BeforeInsert(Phase::Populate, Arc::new(stamp_created)));
+```
+
+### The `Hook` variants
+
+One enum carries a placement-specific closure, so each hook receives exactly what's available at
+its stage. Before-write hooks get the record (mutable) and the entity-erased table; the delete hook
+gets the id and the row's former contents:
+
+| variant | when | receives | may |
+| --- | --- | --- | --- |
+| `BeforeInsert(Phase, _)` | before an insert | `&mut Record`, `&Table` | mutate / `Err` to cancel |
+| `BeforeUpdate(Phase, _)` | before replace/patch | `&mut Record`, `&Table` | mutate / `Err` to cancel |
+| `BeforeSave(Phase, _)` | before insert **and** update | `&mut Record`, `&Table` | mutate / `Err` to cancel |
+| `BeforeDelete(_)` | before a delete | `&Id`, `&Record` (former), `&Table` | `Err` to veto, or `HookReturn::Handled` to take over |
+| `AfterInsert` / `AfterUpdate` / `AfterSave` | after the write commits | `&Id`, `&Record`, `&Table` | side-effects |
+| `AfterDelete(_)` | after a delete | `&Id`, `&Record` (former), `&Table` | side-effects |
+
+The `&Table` handed to a hook is entity-erased, so it can traverse relations (`get_ref`) and reach
+the datasource — enough for cross-row validation and after-effects.
+
+### Ordering and control flow
+
+- **Before-write hooks run ahead of invariant enforcement**, ordered by `Phase`:
+  `Normalize` → `Populate` (the default) → `Validate`, then registration order within a phase. So
+  normalize inputs, then derive/stamp fields, then validate the final record.
+- **Returning `Err` from any before-hook cancels the operation** before anything is written.
+- **`BeforeDelete` returning `HookReturn::Handled`** skips the real delete and reports success —
+  this is how soft-delete works (patch a `deleted` marker, return `Handled`). A delete with hooks
+  loads the row once so before/after hooks see its contents; `delete_all` fires no hooks.
+- After-hooks run for side-effects only. Vantage favours idempotence over transactions: an
+  after-hook failure surfaces an error but does not roll back the committed write — design
+  after-effects to be safe to retry.
+
+### Writing a hook
+
+Hooks are boxed async closures. The reliable construction is a free `fn` returning a boxed future
+whose lifetime ties to the arguments, then `Arc::new(it)`:
+
+```rust
+use std::future::Future;
+use std::pin::Pin;
+use vantage_core::Result;
+use vantage_types::Record;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::table::Table;
+
+// before-insert: stamp an audit field
+fn stamp_created<'a>(
+    rec: &'a mut Record<AnySqliteType>,
+    _t: &'a Table<SqliteDB, vantage_types::EmptyEntity>,
+) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
+    Box::pin(async move {
+        rec.insert("created".into(), AnySqliteType::new(now_iso8601()));
+        Ok(())
+    })
+}
+
+// before-delete: soft-delete instead of removing the row
+fn soft_delete<'a>(
+    id: &'a String,
+    _former: &'a Record<AnySqliteType>,
+    table: &'a Table<SqliteDB, vantage_types::EmptyEntity>,
+) -> Pin<Box<dyn Future<Output = Result<vantage_table::prelude::HookReturn>> + Send + 'a>> {
+    Box::pin(async move {
+        let mut patch = Record::new();
+        patch.insert("deleted".into(), AnySqliteType::new(now_iso8601()));
+        table.patch_value(id.clone(), &patch).await?;
+        Ok(vantage_table::prelude::HookReturn::Handled)
+    })
+}
+```
+
+To pull in outside context (e.g. an `updated_by` actor), have the hook capture an `Arc` or read a
+task-local — the closure runs in async context. A capturing closure works too, but needs its boxed
+return type annotated explicitly so it coerces to the hook type.

--- a/docs4/src/three-paths.md
+++ b/docs4/src/three-paths.md
@@ -161,7 +161,7 @@ persistence becomes a first-class citizen in the entity framework.
 ## Convergence
 
 All three paths converge into the same **data abstraction layer**. Entity framework tables, raw
-query results, and custom persistence data all flow through `Table`, `DataSet`, and `AnyTable` —
+query results, and custom persistence data all flow through `Table`, `DataSet`, and `Vista` —
 giving you one interface for the entire organisation's data.
 
 ```text
@@ -174,7 +174,7 @@ giving you one interface for the entire organisation's data.
 │   Table<LiveTable, Product>   ← cached + reactive            │
 │                                                              │
 │   All implement: DataSet · ValueSet · ActiveEntitySet         │
-│   All wrap into: AnyTable (type-erased, generic code)        │
+│   All wrap into: Vista (type-erased, generic code)          │
 └──────────────────────────────────────────────────────────────┘
                               │
               ┌───────────────┼───────────────┐

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.7 — 2026-06-25
+
+- Lifecycle hooks on `Table`, registered with `Table::with_hook(Hook::…)`. The `Hook` enum carries
+  a placement-specific async closure: `BeforeInsert`/`BeforeUpdate`/`BeforeSave` (and `After*`) run
+  on the record around a write; `BeforeDelete`/`AfterDelete` run around a delete. Before-write hooks
+  run ahead of invariant enforcement, ordered by `Phase` (`Normalize` → `Populate` → `Validate`,
+  then registration order), and may mutate the record (audit stamps, normalization) or return an
+  error to cancel the write. `BeforeDelete` may instead return `HookReturn::Handled` to take over —
+  e.g. a soft-delete that patches a marker and skips the real `DELETE`. After-commit hooks fire for
+  side-effects (the delete hook receives the row's former contents). Hooks receive the
+  entity-erased table for relation/datasource access. Both the typed-entity and raw-record write
+  paths fire them; `delete_all` does not.
+
 ## 0.6.6 — 2026-06-25
 
 - `ActiveEntity::get_ref::<E2>("rel")` and `ActiveRecord::get_ref::<E2>("rel")` (via the new

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/prelude.rs
+++ b/vantage-table/src/prelude.rs
@@ -4,6 +4,7 @@
 
 // Core table types
 pub use crate::table::Table;
+pub use crate::table::{Hook, HookReturn, Phase};
 
 // Column functionality
 pub use crate::column::collection::ColumnCollectionExt;

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -95,6 +95,31 @@ pub enum Hook<T: TableSource> {
     AfterDelete(AfterFn<T>),
 }
 
+/// A table's registered lifecycle hooks, split by placement. The before-write
+/// bands are kept ordered by [`Phase`]. Populated via [`Table::with_hook`].
+#[derive(Clone)]
+pub struct Hooks<T: TableSource> {
+    pub(super) before_insert: Vec<(Phase, BeforeFn<T>)>,
+    pub(super) before_update: Vec<(Phase, BeforeFn<T>)>,
+    pub(super) before_delete: Vec<BeforeDeleteFn<T>>,
+    pub(super) after_insert: Vec<AfterFn<T>>,
+    pub(super) after_update: Vec<AfterFn<T>>,
+    pub(super) after_delete: Vec<AfterFn<T>>,
+}
+
+impl<T: TableSource> Default for Hooks<T> {
+    fn default() -> Self {
+        Self {
+            before_insert: Vec::new(),
+            before_update: Vec::new(),
+            before_delete: Vec::new(),
+            after_insert: Vec::new(),
+            after_update: Vec::new(),
+            after_delete: Vec::new(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Table<T, E>
 where
@@ -124,14 +149,8 @@ where
     /// left null/absent is filled, a matching value is kept, and a conflicting
     /// value is rejected.
     pub(super) invariants: IndexMap<String, T::Value>,
-    /// Lifecycle hooks (see [`Hook`]), split by placement and kept phase-sorted
-    /// for the before-write bands. Registered via [`Self::with_hook`].
-    pub(super) before_insert: Vec<(Phase, BeforeFn<T>)>,
-    pub(super) before_update: Vec<(Phase, BeforeFn<T>)>,
-    pub(super) before_delete: Vec<BeforeDeleteFn<T>>,
-    pub(super) after_insert: Vec<AfterFn<T>>,
-    pub(super) after_update: Vec<AfterFn<T>>,
-    pub(super) after_delete: Vec<AfterFn<T>>,
+    /// Lifecycle hooks (see [`Hook`]). Registered via [`Self::with_hook`].
+    pub(super) hooks: Hooks<T>,
 }
 
 impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
@@ -154,12 +173,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             title_fields: Vec::new(),
             id_field: None,
             invariants: IndexMap::new(),
-            before_insert: Vec::new(),
-            before_update: Vec::new(),
-            before_delete: Vec::new(),
-            after_insert: Vec::new(),
-            after_update: Vec::new(),
-            after_delete: Vec::new(),
+            hooks: Hooks::default(),
         }
     }
 
@@ -186,12 +200,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             title_fields: self.title_fields,
             id_field: self.id_field,
             invariants: self.invariants,
-            before_insert: self.before_insert,
-            before_update: self.before_update,
-            before_delete: self.before_delete,
-            after_insert: self.after_insert,
-            after_update: self.after_update,
-            after_delete: self.after_delete,
+            hooks: self.hooks,
         }
     }
 
@@ -351,43 +360,44 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     }
 
     pub(crate) fn before_insert_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
-        &self.before_insert
+        &self.hooks.before_insert
     }
     pub(crate) fn before_update_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
-        &self.before_update
+        &self.hooks.before_update
     }
     pub(crate) fn before_delete_hooks(&self) -> &[BeforeDeleteFn<T>] {
-        &self.before_delete
+        &self.hooks.before_delete
     }
     pub(crate) fn after_insert_hooks(&self) -> &[AfterFn<T>] {
-        &self.after_insert
+        &self.hooks.after_insert
     }
     pub(crate) fn after_update_hooks(&self) -> &[AfterFn<T>] {
-        &self.after_update
+        &self.hooks.after_update
     }
     pub(crate) fn after_delete_hooks(&self) -> &[AfterFn<T>] {
-        &self.after_delete
+        &self.hooks.after_delete
     }
 
     /// Register a lifecycle [`Hook`]. Before-write hooks are kept ordered by
     /// [`Phase`] (then registration order); `BeforeSave`/`AfterSave` register
     /// for both insert and update.
     pub fn add_hook(&mut self, hook: Hook<T>) {
+        let hooks = &mut self.hooks;
         match hook {
-            Hook::BeforeInsert(phase, f) => push_phased(&mut self.before_insert, phase, f),
-            Hook::BeforeUpdate(phase, f) => push_phased(&mut self.before_update, phase, f),
+            Hook::BeforeInsert(phase, f) => push_phased(&mut hooks.before_insert, phase, f),
+            Hook::BeforeUpdate(phase, f) => push_phased(&mut hooks.before_update, phase, f),
             Hook::BeforeSave(phase, f) => {
-                push_phased(&mut self.before_insert, phase, f.clone());
-                push_phased(&mut self.before_update, phase, f);
+                push_phased(&mut hooks.before_insert, phase, f.clone());
+                push_phased(&mut hooks.before_update, phase, f);
             }
-            Hook::BeforeDelete(f) => self.before_delete.push(f),
-            Hook::AfterInsert(f) => self.after_insert.push(f),
-            Hook::AfterUpdate(f) => self.after_update.push(f),
+            Hook::BeforeDelete(f) => hooks.before_delete.push(f),
+            Hook::AfterInsert(f) => hooks.after_insert.push(f),
+            Hook::AfterUpdate(f) => hooks.after_update.push(f),
             Hook::AfterSave(f) => {
-                self.after_insert.push(f.clone());
-                self.after_update.push(f);
+                hooks.after_insert.push(f.clone());
+                hooks.after_update.push(f);
             }
-            Hook::AfterDelete(f) => self.after_delete.push(f),
+            Hook::AfterDelete(f) => hooks.after_delete.push(f),
         }
     }
 

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -1,14 +1,12 @@
-use std::future::Future;
 use std::marker::PhantomData;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
 use vantage_expressions::Expression;
-use vantage_types::{EmptyEntity, Entity, Record};
+use vantage_types::{EmptyEntity, Entity};
 
 use crate::{
-    pagination::Pagination, references::Reference, sorting::SortDirection,
+    pagination::Pagination, references::Reference, sorting::SortDirection, table::hooks::Hooks,
     traits::table_source::TableSource, traits::table_source_spec::TableSourceSpec,
 };
 
@@ -22,103 +20,6 @@ use crate::{
 /// shape; see `Table::as_entity_erased` for the soundness of the cast.
 pub type ExpressionFn<T> =
     Arc<dyn Fn(&Table<T, EmptyEntity>) -> Expression<<T as TableSource>::Value> + Send + Sync>;
-
-/// Ordering band for before-write hooks. Hooks run in this order (and in
-/// registration order within a band), ahead of set-invariant enforcement.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Phase {
-    /// Clean inputs (trim, default empties).
-    Normalize,
-    /// Set or compute fields (audit stamps, derived values). The default.
-    Populate,
-    /// Read-only checks, last — so they see the final record.
-    Validate,
-}
-
-/// What a `before_delete` hook decided.
-pub enum HookReturn {
-    /// Carry out the underlying operation.
-    Proceed,
-    /// The hook already performed the operation (e.g. a soft-delete patch); skip
-    /// the real one and report success.
-    Handled,
-}
-
-/// A before-write hook: mutate the record in place ahead of invariant
-/// enforcement, returning `Err` to cancel the write. Receives the record being
-/// written and the (entity-erased) table for relation/datasource access.
-pub type BeforeFn<T> = Arc<
-    dyn for<'r> Fn(
-            &'r mut Record<<T as TableSource>::Value>,
-            &'r Table<T, EmptyEntity>,
-        ) -> Pin<Box<dyn Future<Output = vantage_core::Result<()>> + Send + 'r>>
-        + Send
-        + Sync,
->;
-
-/// A before-delete hook: receives the row id and its current contents; may
-/// `Err` to veto, or return [`HookReturn::Handled`] to take over (soft-delete).
-pub type BeforeDeleteFn<T> = Arc<
-    dyn for<'r> Fn(
-            &'r <T as TableSource>::Id,
-            &'r Record<<T as TableSource>::Value>,
-            &'r Table<T, EmptyEntity>,
-        )
-            -> Pin<Box<dyn Future<Output = vantage_core::Result<HookReturn>> + Send + 'r>>
-        + Send
-        + Sync,
->;
-
-/// An after-commit hook: side-effects on the committed row (id + record). Used
-/// for inserts, updates, and deletes (where the record is the former contents).
-pub type AfterFn<T> = Arc<
-    dyn for<'r> Fn(
-            &'r <T as TableSource>::Id,
-            &'r Record<<T as TableSource>::Value>,
-            &'r Table<T, EmptyEntity>,
-        ) -> Pin<Box<dyn Future<Output = vantage_core::Result<()>> + Send + 'r>>
-        + Send
-        + Sync,
->;
-
-/// A lifecycle hook attached to a table via [`Table::with_hook`]. Each variant
-/// carries a closure receiving exactly the references available at that stage.
-/// `BeforeSave`/`AfterSave` are sugar that register for both insert and update.
-pub enum Hook<T: TableSource> {
-    BeforeInsert(Phase, BeforeFn<T>),
-    BeforeUpdate(Phase, BeforeFn<T>),
-    BeforeSave(Phase, BeforeFn<T>),
-    BeforeDelete(BeforeDeleteFn<T>),
-    AfterInsert(AfterFn<T>),
-    AfterUpdate(AfterFn<T>),
-    AfterSave(AfterFn<T>),
-    AfterDelete(AfterFn<T>),
-}
-
-/// A table's registered lifecycle hooks, split by placement. The before-write
-/// bands are kept ordered by [`Phase`]. Populated via [`Table::with_hook`].
-#[derive(Clone)]
-pub struct Hooks<T: TableSource> {
-    pub(super) before_insert: Vec<(Phase, BeforeFn<T>)>,
-    pub(super) before_update: Vec<(Phase, BeforeFn<T>)>,
-    pub(super) before_delete: Vec<BeforeDeleteFn<T>>,
-    pub(super) after_insert: Vec<AfterFn<T>>,
-    pub(super) after_update: Vec<AfterFn<T>>,
-    pub(super) after_delete: Vec<AfterFn<T>>,
-}
-
-impl<T: TableSource> Default for Hooks<T> {
-    fn default() -> Self {
-        Self {
-            before_insert: Vec::new(),
-            before_update: Vec::new(),
-            before_delete: Vec::new(),
-            after_insert: Vec::new(),
-            after_update: Vec::new(),
-            after_delete: Vec::new(),
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct Table<T, E>
@@ -358,65 +259,6 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self.add_invariant(column, value);
         self
     }
-
-    pub(crate) fn before_insert_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
-        &self.hooks.before_insert
-    }
-    pub(crate) fn before_update_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
-        &self.hooks.before_update
-    }
-    pub(crate) fn before_delete_hooks(&self) -> &[BeforeDeleteFn<T>] {
-        &self.hooks.before_delete
-    }
-    pub(crate) fn after_insert_hooks(&self) -> &[AfterFn<T>] {
-        &self.hooks.after_insert
-    }
-    pub(crate) fn after_update_hooks(&self) -> &[AfterFn<T>] {
-        &self.hooks.after_update
-    }
-    pub(crate) fn after_delete_hooks(&self) -> &[AfterFn<T>] {
-        &self.hooks.after_delete
-    }
-
-    /// Register a lifecycle [`Hook`]. Before-write hooks are kept ordered by
-    /// [`Phase`] (then registration order); `BeforeSave`/`AfterSave` register
-    /// for both insert and update.
-    pub fn add_hook(&mut self, hook: Hook<T>) {
-        let hooks = &mut self.hooks;
-        match hook {
-            Hook::BeforeInsert(phase, f) => push_phased(&mut hooks.before_insert, phase, f),
-            Hook::BeforeUpdate(phase, f) => push_phased(&mut hooks.before_update, phase, f),
-            Hook::BeforeSave(phase, f) => {
-                push_phased(&mut hooks.before_insert, phase, f.clone());
-                push_phased(&mut hooks.before_update, phase, f);
-            }
-            Hook::BeforeDelete(f) => hooks.before_delete.push(f),
-            Hook::AfterInsert(f) => hooks.after_insert.push(f),
-            Hook::AfterUpdate(f) => hooks.after_update.push(f),
-            Hook::AfterSave(f) => {
-                hooks.after_insert.push(f.clone());
-                hooks.after_update.push(f);
-            }
-            Hook::AfterDelete(f) => hooks.after_delete.push(f),
-        }
-    }
-
-    /// Builder form of [`Self::add_hook`].
-    pub fn with_hook(mut self, hook: Hook<T>) -> Self {
-        self.add_hook(hook);
-        self
-    }
-}
-
-/// Append a before-write hook and keep the vector ordered by phase (stable, so
-/// registration order is preserved within a phase).
-fn push_phased<T: TableSource>(
-    hooks: &mut Vec<(Phase, BeforeFn<T>)>,
-    phase: Phase,
-    f: BeforeFn<T>,
-) {
-    hooks.push((phase, f));
-    hooks.sort_by_key(|(p, _)| *p);
 }
 
 impl<T: TableSource, E: Entity<T::Value>> std::ops::Index<&str> for Table<T, E> {

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -1,9 +1,11 @@
+use std::future::Future;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
 use vantage_expressions::Expression;
-use vantage_types::{EmptyEntity, Entity};
+use vantage_types::{EmptyEntity, Entity, Record};
 
 use crate::{
     pagination::Pagination, references::Reference, sorting::SortDirection,
@@ -20,6 +22,78 @@ use crate::{
 /// shape; see `Table::as_entity_erased` for the soundness of the cast.
 pub type ExpressionFn<T> =
     Arc<dyn Fn(&Table<T, EmptyEntity>) -> Expression<<T as TableSource>::Value> + Send + Sync>;
+
+/// Ordering band for before-write hooks. Hooks run in this order (and in
+/// registration order within a band), ahead of set-invariant enforcement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Phase {
+    /// Clean inputs (trim, default empties).
+    Normalize,
+    /// Set or compute fields (audit stamps, derived values). The default.
+    Populate,
+    /// Read-only checks, last — so they see the final record.
+    Validate,
+}
+
+/// What a `before_delete` hook decided.
+pub enum HookReturn {
+    /// Carry out the underlying operation.
+    Proceed,
+    /// The hook already performed the operation (e.g. a soft-delete patch); skip
+    /// the real one and report success.
+    Handled,
+}
+
+/// A before-write hook: mutate the record in place ahead of invariant
+/// enforcement, returning `Err` to cancel the write. Receives the record being
+/// written and the (entity-erased) table for relation/datasource access.
+pub type BeforeFn<T> = Arc<
+    dyn for<'r> Fn(
+            &'r mut Record<<T as TableSource>::Value>,
+            &'r Table<T, EmptyEntity>,
+        ) -> Pin<Box<dyn Future<Output = vantage_core::Result<()>> + Send + 'r>>
+        + Send
+        + Sync,
+>;
+
+/// A before-delete hook: receives the row id and its current contents; may
+/// `Err` to veto, or return [`HookReturn::Handled`] to take over (soft-delete).
+pub type BeforeDeleteFn<T> = Arc<
+    dyn for<'r> Fn(
+            &'r <T as TableSource>::Id,
+            &'r Record<<T as TableSource>::Value>,
+            &'r Table<T, EmptyEntity>,
+        )
+            -> Pin<Box<dyn Future<Output = vantage_core::Result<HookReturn>> + Send + 'r>>
+        + Send
+        + Sync,
+>;
+
+/// An after-commit hook: side-effects on the committed row (id + record). Used
+/// for inserts, updates, and deletes (where the record is the former contents).
+pub type AfterFn<T> = Arc<
+    dyn for<'r> Fn(
+            &'r <T as TableSource>::Id,
+            &'r Record<<T as TableSource>::Value>,
+            &'r Table<T, EmptyEntity>,
+        ) -> Pin<Box<dyn Future<Output = vantage_core::Result<()>> + Send + 'r>>
+        + Send
+        + Sync,
+>;
+
+/// A lifecycle hook attached to a table via [`Table::with_hook`]. Each variant
+/// carries a closure receiving exactly the references available at that stage.
+/// `BeforeSave`/`AfterSave` are sugar that register for both insert and update.
+pub enum Hook<T: TableSource> {
+    BeforeInsert(Phase, BeforeFn<T>),
+    BeforeUpdate(Phase, BeforeFn<T>),
+    BeforeSave(Phase, BeforeFn<T>),
+    BeforeDelete(BeforeDeleteFn<T>),
+    AfterInsert(AfterFn<T>),
+    AfterUpdate(AfterFn<T>),
+    AfterSave(AfterFn<T>),
+    AfterDelete(AfterFn<T>),
+}
 
 #[derive(Clone)]
 pub struct Table<T, E>
@@ -50,6 +124,14 @@ where
     /// left null/absent is filled, a matching value is kept, and a conflicting
     /// value is rejected.
     pub(super) invariants: IndexMap<String, T::Value>,
+    /// Lifecycle hooks (see [`Hook`]), split by placement and kept phase-sorted
+    /// for the before-write bands. Registered via [`Self::with_hook`].
+    pub(super) before_insert: Vec<(Phase, BeforeFn<T>)>,
+    pub(super) before_update: Vec<(Phase, BeforeFn<T>)>,
+    pub(super) before_delete: Vec<BeforeDeleteFn<T>>,
+    pub(super) after_insert: Vec<AfterFn<T>>,
+    pub(super) after_update: Vec<AfterFn<T>>,
+    pub(super) after_delete: Vec<AfterFn<T>>,
 }
 
 impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
@@ -72,6 +154,12 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             title_fields: Vec::new(),
             id_field: None,
             invariants: IndexMap::new(),
+            before_insert: Vec::new(),
+            before_update: Vec::new(),
+            before_delete: Vec::new(),
+            after_insert: Vec::new(),
+            after_update: Vec::new(),
+            after_delete: Vec::new(),
         }
     }
 
@@ -98,6 +186,12 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             title_fields: self.title_fields,
             id_field: self.id_field,
             invariants: self.invariants,
+            before_insert: self.before_insert,
+            before_update: self.before_update,
+            before_delete: self.before_delete,
+            after_insert: self.after_insert,
+            after_update: self.after_update,
+            after_delete: self.after_delete,
         }
     }
 
@@ -255,6 +349,64 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self.add_invariant(column, value);
         self
     }
+
+    pub(crate) fn before_insert_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
+        &self.before_insert
+    }
+    pub(crate) fn before_update_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
+        &self.before_update
+    }
+    pub(crate) fn before_delete_hooks(&self) -> &[BeforeDeleteFn<T>] {
+        &self.before_delete
+    }
+    pub(crate) fn after_insert_hooks(&self) -> &[AfterFn<T>] {
+        &self.after_insert
+    }
+    pub(crate) fn after_update_hooks(&self) -> &[AfterFn<T>] {
+        &self.after_update
+    }
+    pub(crate) fn after_delete_hooks(&self) -> &[AfterFn<T>] {
+        &self.after_delete
+    }
+
+    /// Register a lifecycle [`Hook`]. Before-write hooks are kept ordered by
+    /// [`Phase`] (then registration order); `BeforeSave`/`AfterSave` register
+    /// for both insert and update.
+    pub fn add_hook(&mut self, hook: Hook<T>) {
+        match hook {
+            Hook::BeforeInsert(phase, f) => push_phased(&mut self.before_insert, phase, f),
+            Hook::BeforeUpdate(phase, f) => push_phased(&mut self.before_update, phase, f),
+            Hook::BeforeSave(phase, f) => {
+                push_phased(&mut self.before_insert, phase, f.clone());
+                push_phased(&mut self.before_update, phase, f);
+            }
+            Hook::BeforeDelete(f) => self.before_delete.push(f),
+            Hook::AfterInsert(f) => self.after_insert.push(f),
+            Hook::AfterUpdate(f) => self.after_update.push(f),
+            Hook::AfterSave(f) => {
+                self.after_insert.push(f.clone());
+                self.after_update.push(f);
+            }
+            Hook::AfterDelete(f) => self.after_delete.push(f),
+        }
+    }
+
+    /// Builder form of [`Self::add_hook`].
+    pub fn with_hook(mut self, hook: Hook<T>) -> Self {
+        self.add_hook(hook);
+        self
+    }
+}
+
+/// Append a before-write hook and keep the vector ordered by phase (stable, so
+/// registration order is preserved within a phase).
+fn push_phased<T: TableSource>(
+    hooks: &mut Vec<(Phase, BeforeFn<T>)>,
+    phase: Phase,
+    f: BeforeFn<T>,
+) {
+    hooks.push((phase, f));
+    hooks.sort_by_key(|(p, _)| *p);
 }
 
 impl<T: TableSource, E: Entity<T::Value>> std::ops::Index<&str> for Table<T, E> {

--- a/vantage-table/src/table/hooks.rs
+++ b/vantage-table/src/table/hooks.rs
@@ -1,0 +1,172 @@
+//! Lifecycle hooks attached to a [`Table`].
+//!
+//! Register them with [`Table::with_hook`] / [`Table::add_hook`]. Before-write
+//! hooks run ahead of set-invariant enforcement, ordered by [`Phase`]; the
+//! firing itself lives in [`crate::table::sets::hooks`].
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use vantage_types::{EmptyEntity, Entity, Record};
+
+use crate::table::Table;
+use crate::traits::table_source::TableSource;
+
+/// Ordering band for before-write hooks. Hooks run in this order (and in
+/// registration order within a band), ahead of set-invariant enforcement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Phase {
+    /// Clean inputs (trim, default empties).
+    Normalize,
+    /// Set or compute fields (audit stamps, derived values). The default.
+    Populate,
+    /// Read-only checks, last — so they see the final record.
+    Validate,
+}
+
+/// What a `before_delete` hook decided.
+pub enum HookReturn {
+    /// Carry out the underlying operation.
+    Proceed,
+    /// The hook already performed the operation (e.g. a soft-delete patch); skip
+    /// the real one and report success.
+    Handled,
+}
+
+/// A before-write hook: mutate the record in place ahead of invariant
+/// enforcement, returning `Err` to cancel the write. Receives the record being
+/// written and the (entity-erased) table for relation/datasource access.
+pub type BeforeFn<T> = Arc<
+    dyn for<'r> Fn(
+            &'r mut Record<<T as TableSource>::Value>,
+            &'r Table<T, EmptyEntity>,
+        ) -> Pin<Box<dyn Future<Output = vantage_core::Result<()>> + Send + 'r>>
+        + Send
+        + Sync,
+>;
+
+/// A before-delete hook: receives the row id and its current contents; may
+/// `Err` to veto, or return [`HookReturn::Handled`] to take over (soft-delete).
+pub type BeforeDeleteFn<T> = Arc<
+    dyn for<'r> Fn(
+            &'r <T as TableSource>::Id,
+            &'r Record<<T as TableSource>::Value>,
+            &'r Table<T, EmptyEntity>,
+        )
+            -> Pin<Box<dyn Future<Output = vantage_core::Result<HookReturn>> + Send + 'r>>
+        + Send
+        + Sync,
+>;
+
+/// An after-commit hook: side-effects on the committed row (id + record). Used
+/// for inserts, updates, and deletes (where the record is the former contents).
+pub type AfterFn<T> = Arc<
+    dyn for<'r> Fn(
+            &'r <T as TableSource>::Id,
+            &'r Record<<T as TableSource>::Value>,
+            &'r Table<T, EmptyEntity>,
+        ) -> Pin<Box<dyn Future<Output = vantage_core::Result<()>> + Send + 'r>>
+        + Send
+        + Sync,
+>;
+
+/// A lifecycle hook attached to a table via [`Table::with_hook`]. Each variant
+/// carries a closure receiving exactly the references available at that stage.
+/// `BeforeSave`/`AfterSave` are sugar that register for both insert and update.
+pub enum Hook<T: TableSource> {
+    BeforeInsert(Phase, BeforeFn<T>),
+    BeforeUpdate(Phase, BeforeFn<T>),
+    BeforeSave(Phase, BeforeFn<T>),
+    BeforeDelete(BeforeDeleteFn<T>),
+    AfterInsert(AfterFn<T>),
+    AfterUpdate(AfterFn<T>),
+    AfterSave(AfterFn<T>),
+    AfterDelete(AfterFn<T>),
+}
+
+/// A table's registered lifecycle hooks, split by placement. The before-write
+/// bands are kept ordered by [`Phase`]. Populated via [`Table::with_hook`].
+#[derive(Clone)]
+pub struct Hooks<T: TableSource> {
+    pub(crate) before_insert: Vec<(Phase, BeforeFn<T>)>,
+    pub(crate) before_update: Vec<(Phase, BeforeFn<T>)>,
+    pub(crate) before_delete: Vec<BeforeDeleteFn<T>>,
+    pub(crate) after_insert: Vec<AfterFn<T>>,
+    pub(crate) after_update: Vec<AfterFn<T>>,
+    pub(crate) after_delete: Vec<AfterFn<T>>,
+}
+
+impl<T: TableSource> Default for Hooks<T> {
+    fn default() -> Self {
+        Self {
+            before_insert: Vec::new(),
+            before_update: Vec::new(),
+            before_delete: Vec::new(),
+            after_insert: Vec::new(),
+            after_update: Vec::new(),
+            after_delete: Vec::new(),
+        }
+    }
+}
+
+impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
+    pub(crate) fn before_insert_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
+        &self.hooks.before_insert
+    }
+    pub(crate) fn before_update_hooks(&self) -> &[(Phase, BeforeFn<T>)] {
+        &self.hooks.before_update
+    }
+    pub(crate) fn before_delete_hooks(&self) -> &[BeforeDeleteFn<T>] {
+        &self.hooks.before_delete
+    }
+    pub(crate) fn after_insert_hooks(&self) -> &[AfterFn<T>] {
+        &self.hooks.after_insert
+    }
+    pub(crate) fn after_update_hooks(&self) -> &[AfterFn<T>] {
+        &self.hooks.after_update
+    }
+    pub(crate) fn after_delete_hooks(&self) -> &[AfterFn<T>] {
+        &self.hooks.after_delete
+    }
+
+    /// Register a lifecycle [`Hook`]. Before-write hooks are kept ordered by
+    /// [`Phase`] (then registration order); `BeforeSave`/`AfterSave` register
+    /// for both insert and update.
+    pub fn add_hook(&mut self, hook: Hook<T>) {
+        let hooks = &mut self.hooks;
+        match hook {
+            Hook::BeforeInsert(phase, f) => push_phased(&mut hooks.before_insert, phase, f),
+            Hook::BeforeUpdate(phase, f) => push_phased(&mut hooks.before_update, phase, f),
+            Hook::BeforeSave(phase, f) => {
+                push_phased(&mut hooks.before_insert, phase, f.clone());
+                push_phased(&mut hooks.before_update, phase, f);
+            }
+            Hook::BeforeDelete(f) => hooks.before_delete.push(f),
+            Hook::AfterInsert(f) => hooks.after_insert.push(f),
+            Hook::AfterUpdate(f) => hooks.after_update.push(f),
+            Hook::AfterSave(f) => {
+                hooks.after_insert.push(f.clone());
+                hooks.after_update.push(f);
+            }
+            Hook::AfterDelete(f) => hooks.after_delete.push(f),
+        }
+    }
+
+    /// Builder form of [`Self::add_hook`].
+    pub fn with_hook(mut self, hook: Hook<T>) -> Self {
+        self.add_hook(hook);
+        self
+    }
+}
+
+/// Append a before-write hook and keep the vector ordered by phase (stable, so
+/// registration order is preserved within a phase).
+fn push_phased<T: TableSource>(
+    hooks: &mut Vec<(Phase, BeforeFn<T>)>,
+    phase: Phase,
+    f: BeforeFn<T>,
+) {
+    hooks.push((phase, f));
+    hooks.sort_by_key(|(p, _)| *p);
+}

--- a/vantage-table/src/table/hooks.rs
+++ b/vantage-table/src/table/hooks.rs
@@ -2,7 +2,7 @@
 //!
 //! Register them with [`Table::with_hook`] / [`Table::add_hook`]. Before-write
 //! hooks run ahead of set-invariant enforcement, ordered by [`Phase`]; the
-//! firing itself lives in [`crate::table::sets::hooks`].
+//! firing itself lives in the `table::sets` write paths.
 
 use std::future::Future;
 use std::pin::Pin;

--- a/vantage-table/src/table/mod.rs
+++ b/vantage-table/src/table/mod.rs
@@ -18,6 +18,9 @@
 pub mod base;
 pub use base::*;
 
+pub mod hooks;
+pub use hooks::*;
+
 pub mod impls;
 pub use impls::*;
 

--- a/vantage-table/src/table/sets/hooks.rs
+++ b/vantage-table/src/table/sets/hooks.rs
@@ -75,6 +75,8 @@ mod tests {
         })
     }
 
+    // `&String` (not `&str`) is dictated by the hook signature — `T::Id` is `String`.
+    #[allow(clippy::ptr_arg)]
     fn veto<'a>(
         _id: &'a String,
         _rec: &'a Record<Value>,
@@ -83,6 +85,7 @@ mod tests {
         Box::pin(async move { Err(vantage_core::error!("deletion not allowed")) })
     }
 
+    #[allow(clippy::ptr_arg)]
     fn soft_delete<'a>(
         id: &'a String,
         _rec: &'a Record<Value>,

--- a/vantage-table/src/table/sets/hooks.rs
+++ b/vantage-table/src/table/sets/hooks.rs
@@ -1,0 +1,199 @@
+//! Fire a table's lifecycle hooks around a write.
+//!
+//! Before-write hooks run on the record about to be written, in phase order,
+//! just ahead of set-invariant enforcement; an error cancels the operation.
+//! `before_delete` hooks may instead return [`HookReturn::Handled`] to take over
+//! (soft-delete). After-commit hooks run for their side-effects. Hooks receive
+//! the entity-erased table for relation/datasource access.
+
+use vantage_core::Result;
+use vantage_types::{EmptyEntity, Record};
+
+use crate::table::{AfterFn, BeforeDeleteFn, BeforeFn, HookReturn, Phase, Table};
+use crate::traits::table_source::TableSource;
+
+pub(crate) async fn run_before<T: TableSource>(
+    hooks: &[(Phase, BeforeFn<T>)],
+    record: &mut Record<T::Value>,
+    table: &Table<T, EmptyEntity>,
+) -> Result<()> {
+    for (_phase, hook) in hooks {
+        hook(record, table).await?;
+    }
+    Ok(())
+}
+
+pub(crate) async fn run_after<T: TableSource>(
+    hooks: &[AfterFn<T>],
+    id: &T::Id,
+    record: &Record<T::Value>,
+    table: &Table<T, EmptyEntity>,
+) -> Result<()> {
+    for hook in hooks {
+        hook(id, record, table).await?;
+    }
+    Ok(())
+}
+
+/// Run before-delete hooks; the first `Handled` short-circuits and signals the
+/// caller to skip the underlying delete.
+pub(crate) async fn run_before_delete<T: TableSource>(
+    hooks: &[BeforeDeleteFn<T>],
+    id: &T::Id,
+    record: &Record<T::Value>,
+    table: &Table<T, EmptyEntity>,
+) -> Result<HookReturn> {
+    for hook in hooks {
+        if let HookReturn::Handled = hook(id, record, table).await? {
+            return Ok(HookReturn::Handled);
+        }
+    }
+    Ok(HookReturn::Proceed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::mock_table_source::MockTableSource;
+    use crate::table::{AfterFn, BeforeFn, Hook};
+    use serde_json::{Value, json};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use vantage_dataset::prelude::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+
+    type MockTable = Table<MockTableSource, EmptyEntity>;
+
+    // Non-capturing hooks are free fns returning a boxed future with an elided
+    // lifetime tied to the args; `Arc::new(f)` coerces to the hook type.
+    fn stamp<'a>(
+        rec: &'a mut Record<Value>,
+        _t: &'a MockTable,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            rec.insert("created".into(), json!("yes"));
+            Ok(())
+        })
+    }
+
+    fn veto<'a>(
+        _id: &'a String,
+        _rec: &'a Record<Value>,
+        _t: &'a MockTable,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<HookReturn>> + Send + 'a>> {
+        Box::pin(async move { Err(vantage_core::error!("deletion not allowed")) })
+    }
+
+    fn soft_delete<'a>(
+        id: &'a String,
+        _rec: &'a Record<Value>,
+        table: &'a MockTable,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<HookReturn>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut patch = Record::new();
+            patch.insert("deleted".into(), json!("2026-01-01"));
+            table.patch_value(id.clone(), &patch).await?;
+            Ok(HookReturn::Handled)
+        })
+    }
+
+    #[tokio::test]
+    async fn before_insert_mutates_record() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src)
+            .with_hook(Hook::BeforeInsert(Phase::Populate, Arc::new(stamp)));
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"name": "a"})))
+            .await
+            .unwrap();
+        assert_eq!(
+            table.get_value(id).await.unwrap().unwrap()["created"],
+            json!("yes")
+        );
+    }
+
+    #[tokio::test]
+    async fn before_delete_vetoes() {
+        let src = MockTableSource::new()
+            .with_data("t", vec![json!({"id": "1", "name": "a"})])
+            .await;
+        let table = MockTable::new("t", src).with_hook(Hook::BeforeDelete(Arc::new(veto)));
+        assert!(table.delete("1").await.is_err());
+        assert!(table.get_value("1".to_string()).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn before_delete_handled_soft_deletes() {
+        let src = MockTableSource::new()
+            .with_data("t", vec![json!({"id": "1", "name": "a"})])
+            .await;
+        let table = MockTable::new("t", src).with_hook(Hook::BeforeDelete(Arc::new(soft_delete)));
+        table.delete("1").await.unwrap();
+        // Real delete skipped; the row is still there, now marked.
+        let row = table.get_value("1".to_string()).await.unwrap().unwrap();
+        assert_eq!(row["deleted"], json!("2026-01-01"));
+    }
+
+    #[tokio::test]
+    async fn after_delete_runs_side_effect() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let seen = hits.clone();
+        let hook: AfterFn<MockTableSource> = Arc::new(
+            move |_id: &String,
+                  _rec: &Record<Value>,
+                  _t: &MockTable|
+                  -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<()>> + Send + '_>,
+            > {
+                let seen = seen.clone();
+                Box::pin(async move {
+                    seen.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+            },
+        );
+        let src = MockTableSource::new()
+            .with_data("t", vec![json!({"id": "1", "name": "a"})])
+            .await;
+        let table = MockTable::new("t", src).with_hook(Hook::AfterDelete(hook));
+        table.delete("1").await.unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn before_hooks_run_in_phase_order() {
+        let order = Arc::new(std::sync::Mutex::new(Vec::<&'static str>::new()));
+        let recorder = |label: &'static str,
+                        log: Arc<std::sync::Mutex<Vec<&'static str>>>|
+         -> BeforeFn<MockTableSource> {
+            Arc::new(
+                move |_r: &mut Record<Value>,
+                      _t: &MockTable|
+                      -> std::pin::Pin<
+                    Box<dyn std::future::Future<Output = Result<()>> + Send + '_>,
+                > {
+                    let log = log.clone();
+                    Box::pin(async move {
+                        log.lock().unwrap().push(label);
+                        Ok(())
+                    })
+                },
+            )
+        };
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        // Registered Validate-first, but Normalize must run first.
+        let table = MockTable::new("t", src)
+            .with_hook(Hook::BeforeInsert(
+                Phase::Validate,
+                recorder("validate", order.clone()),
+            ))
+            .with_hook(Hook::BeforeInsert(
+                Phase::Normalize,
+                recorder("normalize", order.clone()),
+            ));
+        table
+            .insert_return_id_value(&Record::from(json!({"name": "a"})))
+            .await
+            .unwrap();
+        assert_eq!(*order.lock().unwrap(), vec!["normalize", "validate"]);
+    }
+}

--- a/vantage-table/src/table/sets/insertable_value_set.rs
+++ b/vantage-table/src/table/sets/insertable_value_set.rs
@@ -3,22 +3,34 @@ use vantage_core::Result;
 use vantage_dataset::prelude::InsertableValueSet;
 use vantage_types::{Entity, InvariantValue, Record};
 
-use crate::{prelude::TableSource, table::Table, table::sets::invariants::enforce_invariants};
+use crate::{
+    prelude::TableSource,
+    table::Table,
+    table::sets::{
+        hooks::{run_after, run_before},
+        invariants::enforce_invariants,
+    },
+};
 
-// Implement InsertableValueSet by enforcing set invariants, then delegating to
-// the data source. The typed-entity path (insertable_dataset) funnels through
-// here too, so conformance is applied in exactly one place.
+// Implement InsertableValueSet by running before-insert hooks, enforcing set
+// invariants, writing, then running after-insert hooks. The typed-entity path
+// (insertable_dataset) funnels through here too, so all of it runs in one place.
 #[async_trait]
 impl<T: TableSource, E: Entity<T::Value>> InsertableValueSet for Table<T, E>
 where
     T::Value: InvariantValue,
 {
     async fn insert_return_id_value(&self, record: &Record<Self::Value>) -> Result<Self::Id> {
+        let erased = self.as_entity_erased();
         let mut record = record.clone();
+        run_before(self.before_insert_hooks(), &mut record, erased).await?;
         enforce_invariants(&mut record, self.invariants())?;
-        self.data_source()
+        let id = self
+            .data_source()
             .insert_table_return_id_value(self, &record)
-            .await
+            .await?;
+        run_after(self.after_insert_hooks(), &id, &record, erased).await?;
+        Ok(id)
     }
 }
 

--- a/vantage-table/src/table/sets/mod.rs
+++ b/vantage-table/src/table/sets/mod.rs
@@ -3,6 +3,7 @@ use vantage_types::Entity;
 
 use crate::{prelude::TableSource, table::Table};
 
+pub(crate) mod hooks;
 pub mod insertable_dataset;
 pub mod insertable_value_set;
 pub(crate) mod invariants;

--- a/vantage-table/src/table/sets/writable_value_set.rs
+++ b/vantage-table/src/table/sets/writable_value_set.rs
@@ -80,17 +80,22 @@ where
         let id = id.into();
         // Load the row once so delete hooks can inspect it (the after-hook needs
         // its former contents). Only pay this when delete hooks are present.
-        if !self.before_delete_hooks().is_empty() || !self.after_delete_hooks().is_empty() {
-            if let Some(former) = self.get_value(id.clone()).await? {
-                let erased = self.as_entity_erased();
-                let outcome =
-                    run_before_delete(self.before_delete_hooks(), &id, &former, erased).await?;
-                if let HookReturn::Proceed = outcome {
-                    self.data_source().delete_table_value(self, &id).await?;
-                }
-                run_after(self.after_delete_hooks(), &id, &former, erased).await?;
-                return Ok(());
+        let has_hooks =
+            !self.before_delete_hooks().is_empty() || !self.after_delete_hooks().is_empty();
+        let former = if has_hooks {
+            self.get_value(id.clone()).await?
+        } else {
+            None
+        };
+        if let Some(former) = former {
+            let erased = self.as_entity_erased();
+            let outcome =
+                run_before_delete(self.before_delete_hooks(), &id, &former, erased).await?;
+            if let HookReturn::Proceed = outcome {
+                self.data_source().delete_table_value(self, &id).await?;
             }
+            run_after(self.after_delete_hooks(), &id, &former, erased).await?;
+            return Ok(());
         }
         self.data_source().delete_table_value(self, &id).await
     }

--- a/vantage-table/src/table/sets/writable_value_set.rs
+++ b/vantage-table/src/table/sets/writable_value_set.rs
@@ -1,13 +1,22 @@
 use async_trait::async_trait;
 use vantage_core::Result;
-use vantage_dataset::WritableValueSet;
+use vantage_dataset::{ReadableValueSet, WritableValueSet};
 use vantage_types::{Entity, InvariantValue, Record};
 
-use crate::{prelude::TableSource, table::Table, table::sets::invariants::enforce_invariants};
+use crate::{
+    prelude::TableSource,
+    table::HookReturn,
+    table::Table,
+    table::sets::{
+        hooks::{run_after, run_before, run_before_delete},
+        invariants::enforce_invariants,
+    },
+};
 
-// Implement WritableValueSet by enforcing set invariants, then delegating to the
-// data source. A row written into a scoped set must conform however it is
-// written, so insert/replace/patch all run the same check.
+// Implement WritableValueSet by running lifecycle hooks and enforcing set
+// invariants, then delegating to the data source. A row written into a scoped
+// set must conform however it is written, so insert/replace/patch all run
+// invariants; before/after hooks fire around each operation.
 #[async_trait]
 impl<T: TableSource, E: Entity<T::Value>> WritableValueSet for Table<T, E>
 where
@@ -19,11 +28,16 @@ where
         record: &Record<Self::Value>,
     ) -> Result<Record<Self::Value>> {
         let id = id.into();
+        let erased = self.as_entity_erased();
         let mut record = record.clone();
+        run_before(self.before_insert_hooks(), &mut record, erased).await?;
         enforce_invariants(&mut record, self.invariants())?;
-        self.data_source()
+        let result = self
+            .data_source()
             .insert_table_value(self, &id, &record)
-            .await
+            .await?;
+        run_after(self.after_insert_hooks(), &id, &result, erased).await?;
+        Ok(result)
     }
 
     async fn replace_value(
@@ -32,11 +46,16 @@ where
         record: &Record<Self::Value>,
     ) -> Result<Record<Self::Value>> {
         let id = id.into();
+        let erased = self.as_entity_erased();
         let mut record = record.clone();
+        run_before(self.before_update_hooks(), &mut record, erased).await?;
         enforce_invariants(&mut record, self.invariants())?;
-        self.data_source()
+        let result = self
+            .data_source()
             .replace_table_value(self, &id, &record)
-            .await
+            .await?;
+        run_after(self.after_update_hooks(), &id, &result, erased).await?;
+        Ok(result)
     }
 
     async fn patch_value(
@@ -45,15 +64,34 @@ where
         partial: &Record<Self::Value>,
     ) -> Result<Record<Self::Value>> {
         let id = id.into();
+        let erased = self.as_entity_erased();
         let mut partial = partial.clone();
+        run_before(self.before_update_hooks(), &mut partial, erased).await?;
         enforce_invariants(&mut partial, self.invariants())?;
-        self.data_source()
+        let result = self
+            .data_source()
             .patch_table_value(self, &id, &partial)
-            .await
+            .await?;
+        run_after(self.after_update_hooks(), &id, &result, erased).await?;
+        Ok(result)
     }
 
     async fn delete(&self, id: impl Into<Self::Id> + Send) -> Result<()> {
         let id = id.into();
+        // Load the row once so delete hooks can inspect it (the after-hook needs
+        // its former contents). Only pay this when delete hooks are present.
+        if !self.before_delete_hooks().is_empty() || !self.after_delete_hooks().is_empty() {
+            if let Some(former) = self.get_value(id.clone()).await? {
+                let erased = self.as_entity_erased();
+                let outcome =
+                    run_before_delete(self.before_delete_hooks(), &id, &former, erased).await?;
+                if let HookReturn::Proceed = outcome {
+                    self.data_source().delete_table_value(self, &id).await?;
+                }
+                run_after(self.after_delete_hooks(), &id, &former, erased).await?;
+                return Ok(());
+            }
+        }
         self.data_source().delete_table_value(self, &id).await
     }
 


### PR DESCRIPTION
Lifecycle hooks for `Table`, plus a documentation refresh that documents them and clears accumulated drift.

## Hooks (vantage-table 0.6.7)

`table.with_hook(Hook::…)` attaches async callbacks around writes. One enum carries a placement-specific closure, so each hook receives exactly what's available at its stage:

| variant | when | receives | may |
|---|---|---|---|
| `BeforeInsert(Phase, _)` / `BeforeUpdate` / `BeforeSave` | before a write | `&mut Record`, `&Table` | mutate / `Err` to cancel |
| `BeforeDelete(_)` | before a delete | `&Id`, former `&Record`, `&Table` | `Err` to veto, or `HookReturn::Handled` to take over (soft-delete) |
| `AfterInsert` / `AfterUpdate` / `AfterSave` / `AfterDelete` | after commit | `&Id`, `&Record`, `&Table` | side-effects |

- **Before-write hooks run ahead of invariant enforcement**, ordered by `Phase` (`Normalize` → `Populate` → `Validate`, then registration order).
- **`Err` from any before-hook cancels** the operation before the datasource is touched.
- **`BeforeDelete` → `HookReturn::Handled`** skips the real delete and reports success (soft-delete: patch a marker, return `Handled`). A delete with hooks loads the row once so before/after hooks see its contents; `delete_all` fires no hooks.
- The `&Table` is entity-erased, giving hooks `get_ref` + datasource access for cross-row validation and after-effects.
- Both typed-entity and raw-record write paths fire them (so `ActiveEntity::save`/`delete` do too).

By design: no transactions (vantage favours idempotence); external context (e.g. `updated_by`) is supplied by the hook capturing an `Arc`/global.

Tests (mock backend): before-insert mutate, before-delete veto, before-delete handled/soft-delete, after-delete side-effect, phase ordering. `cargo build --workspace` + `cargo fmt --check` pass; sqlite invariants stay green.

## Documentation refresh (`docs4`)

A full audit of the book surfaced drift; this PR fixes it and fills the gaps:

- **New page** *Records: Traversal, Invariants & Hooks* (`record-lifecycle.md`) — the consumer side: `get_ref` from a loaded record, the equality-scope **invariants** (4-way conform rule + auto-registration + `InvariantValue`), and the full hook model.
- **Vista replaces `AnyTable`** everywhere it was still taught as current (`intro/step2-tables`, `mda`, `three-paths`, new-persistence Step 7) — `AnyTable` was removed in 0.5.
- Book is no longer pinned to "0.4"; removed an internal TODO tracker that had leaked into the published intro.
- new-persistence: corrected "eight"→"nine" steps, added the Step 9 entry, fixed the broken Step 8 link, and fixed off-by-one step headings.
- `mdbook build` passes.

Still flagged for a follow-up (not in this PR): `step8-vista-integration.md` internals still reference removed `AnyTable`/`get_ref`/`with_foreign`; `custom-types.md` is a stub; the `whats-new` "still coming" sections are stale.
