### PR TITLE
Generated ids + audit timestamps; SQL NULL-id handling; diorama grid fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,7 +4633,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4991,10 +4991,11 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-stream",
  "async-trait",
+ "chrono",
  "ciborium",
  "futures-core",
  "indexmap",
@@ -5006,6 +5007,7 @@ dependencies = [
  "surreal-client",
  "tokio",
  "url",
+ "uuid",
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.4 — 2026-06-26
+
+- REST: with `.debug(true)`, each GET now logs the resolved request URL
+  (`target: "vantage_api_client::rest"`) so a failing query can be replayed by hand.
+
 ## 0.6.3 — 2026-06-25
 
 - `AnyGraphqlType` declares `null_when: serde_json::Value::Null`, so it implements `InvariantValue`

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.3"
+version = "0.6.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -379,6 +379,10 @@ impl RestApi {
         let query = self.build_query_string(window, &conds, &query_consumed);
         let url = join_query(&endpoint, &query);
 
+        if self.debug {
+            tracing::info!(target: "vantage_api_client::rest", table = table_name, url = %url, "REST GET");
+        }
+
         let mut request = self.client.get(&url);
         if let Some(ref auth) = self.auth_header {
             request = request.header("Authorization", auth);

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.4 — unreleased
+## 0.6.5 — 2026-06-26
 
 - Diagnostics surface. `dio.diagnostics().await` returns a `DioDiagnostics`
   snapshot — cache row count, query-index count, and one `SceneryDiagnostic` per
@@ -74,6 +74,18 @@
   failed refetch leaves the existing rows untouched — instead of clearing the cache and
   waiting for a refill. Previously any refill lag or error (e.g. a slow/`504` page) left
   the visible rows blank while their count survived.
+- Refresh-on-open now hits the server even when the cache seed already filled the range. The
+  cache is id-keyed (arbitrary order) but the server applies the query's ordering, so the open
+  fetch uses `force_load` to replace the seed with ordered rows — a freshly-opened grid is ordered
+  without a manual refresh.
+- A chunk load only bumps the generation when it actually changes a visible row. `write_chunk_row`
+  skips a slot that already holds the same `Fresh` record, so a refresh that re-fetches
+  byte-identical rows no longer triggers a repaint.
+- A short page (fewer rows than the requested window) is treated as the end of the set, so the
+  grand `total` is derived from the fetch itself (no separate count request). This self-corrects a
+  list opened before its rows existed, whose `total` was counted once at 0 and would otherwise
+  never grow. `set_search` also drops the stale cached total, since a new query matches a different
+  set.
 
 ## 0.6.2 — unreleased
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/enriched_record.rs
+++ b/vantage-diorama/src/scenery/enriched_record.rs
@@ -79,7 +79,7 @@ impl EnrichedRecord {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RowStatus {
     Fresh,
     /// Only the list pass has run — cheap columns present, detail columns

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -175,6 +175,8 @@ impl TableSceneryBuilder {
             viewport_tx,
             viewport_queue_depth: AtomicUsize::new(0),
             load_in_flight: Mutex::new(None),
+            load_dirty: std::sync::atomic::AtomicBool::new(false),
+            load_push_count: AtomicUsize::new(0),
             master_capabilities,
             two_pass,
             titles_only,
@@ -233,6 +235,12 @@ impl TableSceneryBuilder {
         //    the first page in the background. Skipped for two-pass — its
         //    detail pass must wait for an explicit viewport so that opening
         //    never triggers detail fetches.
+        //
+        //    `force_load` so the fetch runs even when the cache seed already
+        //    filled this range: the cache is id-keyed (arbitrary order), but the
+        //    server applies the query's ordering, so the on-open fetch must
+        //    actually hit the server to replace the seed with ordered rows —
+        //    otherwise the grid shows cache order until a manual refresh.
         if !two_pass
             && dio.lens.defaults.refresh_on_open
             && dio.lens.callbacks.on_load_chunk.is_some()
@@ -242,7 +250,7 @@ impl TableSceneryBuilder {
                 &state,
                 ViewportRequest {
                     range,
-                    force_load: false,
+                    force_load: true,
                 },
             );
         }

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -282,6 +282,9 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         force_load,
         "fire_chunk_load: dispatching on_load_chunk",
     );
+    // Clear the dirty flag so it reflects only the rows this load writes;
+    // `write_chunk_row` sets it when a row's content actually changes.
+    state.reset_load_dirty();
     let result = cb(&dio, effective_range.clone(), sink).await;
 
     *state.load_in_flight.lock().unwrap() = None;
@@ -289,7 +292,23 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     let cached_after = state.rows.read().unwrap().len();
     match result {
         Ok(()) => {
-            state.bump_generation();
+            // A short page — fewer rows than the requested window — is the end
+            // of the set, so the grand total is `start + received`. This keeps
+            // `total` self-correcting from the fetch we already did (no separate
+            // count request), and fixes a list opened before its rows existed:
+            // its `total` was counted once at 0 and would otherwise never grow.
+            let pushed = state.load_push_count();
+            let total_changed = if pushed < effective_len {
+                state.set_total(Some(effective_range.start + pushed))
+            } else {
+                false
+            };
+            // Bump when a row changed (a refresh of byte-identical rows leaves
+            // the flag clear) or when the total moved (so `row_count` consumers
+            // — scrollbars, `ListDio` — repaint).
+            if state.take_load_dirty() || total_changed {
+                state.bump_generation();
+            }
             tracing::debug!(
                 target: "vantage_diorama::viewport",
                 effective = ?effective_range,

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -241,6 +241,10 @@ impl TableScenery for TableSceneryImpl {
     fn set_search(&self, query: Option<String>) {
         self.inner.deregister();
         *self.inner.search.write().unwrap() = query;
+        // The cached total belongs to the previous query; a new search matches a
+        // different set. Drop it so `row_count` falls back to the loaded rows
+        // until the re-fetch's short page (or a re-count) sets it for this query.
+        self.inner.set_total(None);
         self.inner.reload_notify.notify_one();
     }
 

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -309,10 +309,11 @@ impl SceneryChunkTarget for TableSceneryState {
         // only a dirty load bumps the generation (see `loader::fire_chunk_load`).
         {
             let rows = self.rows.read().unwrap();
-            if let Some(existing) = rows.get(&idx) {
-                if existing.status == RowStatus::Fresh && existing.record == record {
-                    return;
-                }
+            if let Some(existing) = rows.get(&idx)
+                && existing.status == RowStatus::Fresh
+                && existing.record == record
+            {
+                return;
             }
         }
         let enriched = Arc::new(EnrichedRecord::fresh(record));

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -125,7 +125,7 @@ impl TableSceneryState {
         self.load_dirty.swap(false, Ordering::SeqCst)
     }
 
-    /// Rows the just-finished chunk load received (see [`load_push_count`]).
+    /// Rows the just-finished chunk load received (reads the `load_push_count` field).
     pub(crate) fn load_push_count(&self) -> usize {
         self.load_push_count.load(Ordering::SeqCst)
     }

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -53,6 +53,19 @@ pub(crate) struct TableSceneryState {
     /// `request_load_more` from queueing the same range twice in a row.
     pub(crate) load_in_flight: Mutex<Option<Range<usize>>>,
 
+    /// Set by [`write_chunk_row`](Self::write_chunk_row) whenever a chunk load
+    /// actually changes a row's visible content (new slot, status change, or a
+    /// different record). The loader reads and clears it after the load and
+    /// bumps the generation only when it is set — so a refresh that re-fetches
+    /// byte-identical rows does not signal a repaint.
+    pub(crate) load_dirty: std::sync::atomic::AtomicBool,
+
+    /// Count of rows the in-flight chunk load *received* (every push, including
+    /// those `write_chunk_row` skips as unchanged). A short page — fewer rows
+    /// than the requested window — means the end of the set, so the loader
+    /// derives the grand `total` from it (no separate count request).
+    pub(crate) load_push_count: AtomicUsize,
+
     /// Snapshot of the master Vista's capability flags taken at open
     /// time. Sceneries hand this back through
     /// `TableScenery::master_capabilities` so UI delegates can route
@@ -97,6 +110,33 @@ impl TableSceneryState {
 
     pub(crate) fn current_generation(&self) -> u64 {
         self.generation.load(Ordering::SeqCst)
+    }
+
+    /// Clear the per-load trackers (dirty flag + push count) before dispatching
+    /// a load, so they reflect only the rows written by that load.
+    pub(crate) fn reset_load_dirty(&self) {
+        self.load_dirty.store(false, Ordering::SeqCst);
+        self.load_push_count.store(0, Ordering::SeqCst);
+    }
+
+    /// Read and clear the chunk-load dirty flag. `true` means the load changed
+    /// at least one row's content (so a generation bump is warranted).
+    pub(crate) fn take_load_dirty(&self) -> bool {
+        self.load_dirty.swap(false, Ordering::SeqCst)
+    }
+
+    /// Rows the just-finished chunk load received (see [`load_push_count`]).
+    pub(crate) fn load_push_count(&self) -> usize {
+        self.load_push_count.load(Ordering::SeqCst)
+    }
+
+    /// Overwrite the cached grand total. Returns `true` if it changed (so the
+    /// loader can bump the generation for `row_count` consumers).
+    pub(crate) fn set_total(&self, total: Option<usize>) -> bool {
+        let mut guard = self.total.write().unwrap();
+        let changed = *guard != total;
+        *guard = total;
+        changed
     }
 
     /// Current two-pass index (cloned `Arc`), or `None` in single-pass mode.
@@ -260,8 +300,24 @@ impl TableSceneryState {
 
 impl SceneryChunkTarget for TableSceneryState {
     fn write_chunk_row(&self, idx: usize, id: String, record: Record<CborValue>) {
+        // Count every received row (before the skip below), so the loader can
+        // tell a short page (end of set) from a full one.
+        self.load_push_count.fetch_add(1, Ordering::SeqCst);
+        // Skip the write entirely when this slot already holds the same fresh
+        // record: a refresh that re-fetches identical data must not look like a
+        // change. Only a new/!Fresh slot or a different record is "dirty", and
+        // only a dirty load bumps the generation (see `loader::fire_chunk_load`).
+        {
+            let rows = self.rows.read().unwrap();
+            if let Some(existing) = rows.get(&idx) {
+                if existing.status == RowStatus::Fresh && existing.record == record {
+                    return;
+                }
+            }
+        }
         let enriched = Arc::new(EnrichedRecord::fresh(record));
         self.rows.write().unwrap().insert(idx, enriched);
         self.id_to_idx.write().unwrap().insert(id, idx);
+        self.load_dirty.store(true, Ordering::SeqCst);
     }
 }

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.4 — 2026-06-26
+
+- A NULL id read back from a row is no longer coerced to the literal string `"Null"`: rows with a
+  NULL id are skipped on read, and an insert whose `RETURNING` id comes back NULL (a `PRIMARY KEY`
+  with no `DEFAULT`/sequence and no supplied id) fails with an explanatory error instead of a bogus
+  id. Pair such tables with `Table::with_generated_id` to mint the id client-side. Applies to the
+  SQLite, Postgres, and MySQL table sources.
+- On the explicit-id insert/replace paths the id the caller passes is now applied after the record,
+  so it stays authoritative even when a `before_insert` hook (e.g. an id generator) also wrote an id
+  into the record.
+
 ## 0.6.3 — 2026-06-25
 
 - `AnySqliteType` implements `InvariantValue` (via the type-system macro's `null_when:

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -46,6 +46,7 @@ fn parse_rows(
             _ => continue,
         };
 
+        let mut id_seen = false;
         let mut id = None;
         let mut record = Record::new();
         for (k, v) in map {
@@ -54,17 +55,29 @@ fn parse_rows(
                 _ => continue,
             };
             if key == id_field_name {
-                id = Some(match &v {
-                    CborValue::Text(s) => s.clone(),
-                    CborValue::Integer(i) => i128::from(*i).to_string(),
-                    CborValue::Float(f) => f.to_string(),
-                    _ => format!("{:?}", v),
-                });
+                id_seen = true;
+                // A SQL NULL id (e.g. a table whose id column has neither a
+                // DEFAULT nor AUTO_INCREMENT, so an omitted id inserts NULL) is
+                // not a usable key: leave it `None` so the row is skipped rather
+                // than keyed under the literal "Null" — which would also collide
+                // every such row onto a single map entry.
+                id = match &v {
+                    CborValue::Text(s) => Some(s.clone()),
+                    CborValue::Integer(i) => Some(i128::from(*i).to_string()),
+                    CborValue::Float(f) => Some(f.to_string()),
+                    CborValue::Null => None,
+                    other => Some(format!("{other:?}")),
+                };
             }
             record.insert(key, AnyMysqlType::untyped(v));
         }
 
-        let id = id.ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+        // A row that never carried the id column at all is a query-construction
+        // bug worth surfacing; a present-but-NULL id is degenerate data we skip.
+        if !id_seen {
+            return Err(error!("row missing id field", field = id_field_name));
+        }
+        let Some(id) = id else { continue };
         records.insert(id, record);
     }
 
@@ -266,8 +279,11 @@ impl TableSource for MysqlDB {
             .unwrap_or_else(|| "id".to_string());
 
         let insert = crate::mysql::statements::MysqlInsert::new(table.table_name())
-            .with_field(&id_field_name, id_value(id))
-            .with_record(record);
+            .with_record(record)
+            // The explicit id param is authoritative on this path, so apply it
+            // after the record — a record-carried id (e.g. one a generator hook
+            // filled) must not override the id the caller asked to write.
+            .with_field(&id_field_name, id_value(id));
         self.execute(&insert.expr()).await?;
 
         self.get_table_value(table, id)
@@ -291,8 +307,11 @@ impl TableSource for MysqlDB {
 
         // MySQL: INSERT ... ON DUPLICATE KEY UPDATE ...
         let insert = crate::mysql::statements::MysqlInsert::new(table.table_name())
-            .with_field(&id_field_name, id_value(id))
-            .with_record(record);
+            .with_record(record)
+            // The explicit id param is authoritative on this path, so apply it
+            // after the record — a record-carried id (e.g. one a generator hook
+            // filled) must not override the id the caller asked to write.
+            .with_field(&id_field_name, id_value(id));
         let base = insert.expr();
 
         let set_parts: Vec<Expression<AnyMysqlType>> = if record.is_empty() {

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -49,6 +49,7 @@ fn parse_rows(
             _ => continue,
         };
 
+        let mut id_seen = false;
         let mut id = None;
         let mut record = Record::new();
         for (k, v) in map {
@@ -57,17 +58,29 @@ fn parse_rows(
                 _ => continue,
             };
             if key == id_field_name {
-                id = Some(match &v {
-                    CborValue::Text(s) => s.clone(),
-                    CborValue::Integer(i) => i128::from(*i).to_string(),
-                    CborValue::Float(f) => f.to_string(),
-                    _ => format!("{:?}", v),
-                });
+                id_seen = true;
+                // A SQL NULL id (e.g. a table whose id column has neither a
+                // DEFAULT nor a sequence, so an omitted id inserts NULL) is not
+                // a usable key: leave it `None` so the row is skipped rather than
+                // keyed under the literal "Null" — which would also collide every
+                // such row onto a single map entry.
+                id = match &v {
+                    CborValue::Text(s) => Some(s.clone()),
+                    CborValue::Integer(i) => Some(i128::from(*i).to_string()),
+                    CborValue::Float(f) => Some(f.to_string()),
+                    CborValue::Null => None,
+                    other => Some(format!("{other:?}")),
+                };
             }
             record.insert(key, AnyPostgresType::untyped(v));
         }
 
-        let id = id.ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+        // A row that never carried the id column at all is a query-construction
+        // bug worth surfacing; a present-but-NULL id is degenerate data we skip.
+        if !id_seen {
+            return Err(error!("row missing id field", field = id_field_name));
+        }
+        let Some(id) = id else { continue };
         records.insert(id, record);
     }
 
@@ -271,8 +284,11 @@ impl TableSource for PostgresDB {
             .unwrap_or_else(|| "id".to_string());
 
         let insert = crate::postgres::statements::PostgresInsert::new(table.table_name())
-            .with_field(&id_field_name, id_value(id))
-            .with_record(record);
+            .with_record(record)
+            // The explicit id param is authoritative on this path, so apply it
+            // after the record — a record-carried id (e.g. one a generator hook
+            // filled) must not override the id the caller asked to write.
+            .with_field(&id_field_name, id_value(id));
         self.execute(&insert.expr()).await?;
 
         self.get_table_value(table, id)
@@ -296,8 +312,11 @@ impl TableSource for PostgresDB {
 
         // PostgreSQL: INSERT ... ON CONFLICT (id) DO UPDATE SET ...
         let insert = crate::postgres::statements::PostgresInsert::new(table.table_name())
-            .with_field(&id_field_name, id_value(id))
-            .with_record(record);
+            .with_record(record)
+            // The explicit id param is authoritative on this path, so apply it
+            // after the record — a record-carried id (e.g. one a generator hook
+            // filled) must not override the id the caller asked to write.
+            .with_field(&id_field_name, id_value(id));
         let base = insert.expr();
 
         let set_parts: Vec<Expression<AnyPostgresType>> = if record.is_empty() {
@@ -407,9 +426,13 @@ impl TableSource for PostgresDB {
         let returning = expr_any!("{} RETURNING {}", (base), (ident(&id_field_name)));
         let result = self.execute(&returning).await?;
         let mut rows = parse_rows(result, &id_field_name)?;
-        rows.swap_remove_index(0)
-            .map(|(id, _)| id)
-            .ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
+        rows.swap_remove_index(0).map(|(id, _)| id).ok_or_else(|| {
+            error!(
+                "insert returned no usable id — the row's id came back NULL; \
+                     does the table's id column have a DEFAULT or sequence?",
+                table = table.table_name()
+            )
+        })
     }
 
     fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -39,6 +39,7 @@ fn parse_rows(
             _ => continue,
         };
 
+        let mut id_seen = false;
         let mut id = None;
         let mut record = Record::new();
         for (k, v) in map {
@@ -47,17 +48,29 @@ fn parse_rows(
                 _ => continue,
             };
             if key == id_field_name {
-                id = Some(match &v {
-                    CborValue::Text(s) => s.clone(),
-                    CborValue::Integer(i) => i128::from(*i).to_string(),
-                    CborValue::Float(f) => f.to_string(),
-                    _ => format!("{:?}", v),
-                });
+                id_seen = true;
+                // A SQL NULL id (e.g. a table whose id column has neither a
+                // DEFAULT nor AUTOINCREMENT, so an omitted id inserts NULL) is
+                // not a usable key: leave it `None` so the row is skipped rather
+                // than keyed under the literal "Null" — which would also collide
+                // every such row onto a single map entry.
+                id = match &v {
+                    CborValue::Text(s) => Some(s.clone()),
+                    CborValue::Integer(i) => Some(i128::from(*i).to_string()),
+                    CborValue::Float(f) => Some(f.to_string()),
+                    CborValue::Null => None,
+                    other => Some(format!("{other:?}")),
+                };
             }
             record.insert(key, AnySqliteType::untyped(v));
         }
 
-        let id = id.ok_or_else(|| error!("row missing id field", field = id_field_name))?;
+        // A row that never carried the id column at all is a query-construction
+        // bug worth surfacing; a present-but-NULL id is degenerate data we skip.
+        if !id_seen {
+            return Err(error!("row missing id field", field = id_field_name));
+        }
+        let Some(id) = id else { continue };
         records.insert(id, record);
     }
 
@@ -257,8 +270,11 @@ impl TableSource for SqliteDB {
             .unwrap_or_else(|| "id".to_string());
 
         let insert = crate::sqlite::statements::SqliteInsert::new(table.table_name())
-            .with_field(&id_field_name, AnySqliteType::from(id.clone()))
-            .with_record(record);
+            .with_record(record)
+            // The explicit id param is authoritative on this path, so apply it
+            // after the record — a record-carried id (e.g. one a generator hook
+            // filled) must not override the id the caller asked to write.
+            .with_field(&id_field_name, AnySqliteType::from(id.clone()));
         self.execute(&insert.expr()).await?;
 
         self.get_table_value(table, id)
@@ -282,8 +298,11 @@ impl TableSource for SqliteDB {
 
         // SQLite INSERT OR REPLACE handles both insert and update
         let insert = crate::sqlite::statements::SqliteInsert::new(table.table_name())
-            .with_field(&id_field_name, AnySqliteType::from(id.clone()))
-            .with_record(record);
+            .with_record(record)
+            // The explicit id param is authoritative on this path, so apply it
+            // after the record — a record-carried id (e.g. one a generator hook
+            // filled) must not override the id the caller asked to write.
+            .with_field(&id_field_name, AnySqliteType::from(id.clone()));
         // Rewrite as INSERT OR REPLACE
         let expr = insert.expr();
         let replace_expr = Expression::new(
@@ -371,9 +390,13 @@ impl TableSource for SqliteDB {
         let returning = expr_any!("{} RETURNING {}", (base), (ident(&id_field_name)));
         let result = self.execute(&returning).await?;
         let mut rows = parse_rows(result, &id_field_name)?;
-        rows.swap_remove_index(0)
-            .map(|(id, _)| id)
-            .ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
+        rows.swap_remove_index(0).map(|(id, _)| id).ok_or_else(|| {
+            error!(
+                "insert returned no usable id — the row's id came back NULL; \
+                     does the table's id column have a DEFAULT or AUTOINCREMENT?",
+                table = table.table_name()
+            )
+        })
     }
 
     fn related_in_condition<SourceE: Entity<Self::Value> + 'static>(

--- a/vantage-sql/tests/sqlite/4_editable_data_set.rs
+++ b/vantage-sql/tests/sqlite/4_editable_data_set.rs
@@ -5,6 +5,7 @@
 #[allow(unused_imports)]
 use vantage_sql::sqlite::SqliteType;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_table::prelude::IdGenerator;
 use vantage_table::table::Table;
 use vantage_types::entity;
 
@@ -147,4 +148,62 @@ async fn test_insert_return_id() {
     let fetched = table.get(id).await.unwrap().expect("inserted row");
     assert_eq!(fetched.name, "Auto");
     assert_eq!(fetched.price, 42);
+}
+
+#[tokio::test]
+async fn test_insert_return_id_null_pk_errors() {
+    // `item`'s id is a bare `TEXT PRIMARY KEY` — no DEFAULT, no AUTOINCREMENT.
+    // Omitting the id inserts SQL NULL, so RETURNING hands back a NULL id, which
+    // is not usable. It must surface as an error, not a bogus "Null" string.
+    let (_db, table) = setup().await;
+
+    let item = Item {
+        name: "Orphan".into(),
+        price: 7,
+    };
+    let err = table
+        .insert_return_id(&item)
+        .await
+        .expect_err("a NULL primary key must not be returned as a usable id");
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("Null"),
+        "error should explain the NULL id, not echo it: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_generated_id_fills_bare_primary_key() {
+    // Same bare `TEXT PRIMARY KEY` as above, but `with_generated_id` mints the id
+    // client-side before the INSERT, so `insert_return_id` succeeds and hands
+    // back the generated key.
+    let (_db, table) = setup().await;
+    let table = table.with_generated_id(IdGenerator::UuidV7);
+
+    let item = Item {
+        name: "Minted".into(),
+        price: 7,
+    };
+    let id = table.insert_return_id(&item).await.unwrap();
+    assert!(id.contains('-'), "expected a uuid, got {id:?}");
+
+    let fetched = table.get(id).await.unwrap().expect("inserted row");
+    assert_eq!(fetched.name, "Minted");
+    assert_eq!(fetched.price, 7);
+}
+
+#[tokio::test]
+async fn test_generated_id_kept_on_explicit_insert() {
+    // With a generator registered, the explicit-id insert path still writes the
+    // id the caller passed — the generator never clobbers it.
+    let (_db, table) = setup().await;
+    let table = table.with_generated_id(IdGenerator::UuidV7);
+
+    let item = Item {
+        name: "Explicit".into(),
+        price: 9,
+    };
+    table.insert("z", &item).await.unwrap();
+    let fetched = table.get("z").await.unwrap().expect("row z");
+    assert_eq!(fetched.name, "Explicit");
 }

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.8 — 2026-06-26
+
+- `Table::with_generated_id(IdGenerator)` mints a record's id on insert when the backend does not
+  (a bare SQL `PRIMARY KEY` with no `DEFAULT`, a client-keyed REST resource). `IdGenerator` offers
+  `UuidV7` (time-ordered, index-friendly — the recommended default), `UuidV4`, and `Custom` for any
+  other scheme. Built on a `before_insert` hook: it fills the id only when the record carries none
+  (absent or null) and only on insert — `patch`/`replace`/`update`/`upsert` never touch the id, and
+  a caller-supplied id is always kept, so generation stays idempotent.
+- `Table::with_timestamps()` / `with_audit(Timestamps)` stamp audit columns from the wall clock:
+  `created_at` once on insert (only if the caller left it empty), `updated_at` on every write. Values
+  are RFC 3339 UTC strings; column names are overridable via `Timestamps`. Built on the same
+  before-write hooks, so a nullable `TEXT` column is all the backend needs.
+
 ## 0.6.7 — 2026-06-25
 
 - Lifecycle hooks on `Table`, registered with `Table::with_hook(Hook::…)`. The `Hook` enum carries

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"
@@ -32,6 +32,8 @@ mockall = "0.12"
 paste = "1.0"
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "sync"] }
 rust_decimal = { version = "1.42.0", features = ["macros", "serde"] }
+uuid = { version = "1", features = ["v4", "v7"] }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "sync"] }

--- a/vantage-table/src/prelude.rs
+++ b/vantage-table/src/prelude.rs
@@ -4,7 +4,7 @@
 
 // Core table types
 pub use crate::table::Table;
-pub use crate::table::{Hook, HookReturn, Phase};
+pub use crate::table::{Hook, HookReturn, IdGenerator, Phase, Timestamps};
 
 // Column functionality
 pub use crate::column::collection::ColumnCollectionExt;

--- a/vantage-table/src/table/audit.rs
+++ b/vantage-table/src/table/audit.rs
@@ -136,9 +136,7 @@ mod tests {
     use super::*;
     use crate::mocks::mock_table_source::MockTableSource;
     use serde_json::json;
-    use vantage_dataset::prelude::{
-        InsertableValueSet, ReadableValueSet, WritableValueSet,
-    };
+    use vantage_dataset::prelude::{InsertableValueSet, ReadableValueSet, WritableValueSet};
 
     type MockTable = Table<MockTableSource, EmptyEntity>;
 

--- a/vantage-table/src/table/audit.rs
+++ b/vantage-table/src/table/audit.rs
@@ -1,0 +1,216 @@
+//! Auto-stamping of audit timestamps on write.
+//!
+//! [`Table::with_timestamps`] fills `created_at`/`updated_at` columns from the
+//! wall clock using the before-write hook machinery (see [`crate::table::hooks`]):
+//! `created_at` once, when a row is first inserted and only if the caller left it
+//! empty; `updated_at` on every insert and update. Values are RFC 3339 UTC
+//! strings (e.g. `2026-06-25T12:00:00Z`).
+//!
+//! Like [`crate::table::id_generator`], it leans on the same `From<String>`
+//! value bound, so it works against any backend whose value type can carry a
+//! string — the column itself can be plain `TEXT`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use vantage_core::Result;
+use vantage_types::{EmptyEntity, Entity, InvariantValue, Record};
+
+use crate::table::{BeforeFn, Hook, Phase, Table};
+use crate::traits::table_source::TableSource;
+
+/// Which columns the audit stamps write. Defaults to `created_at` / `updated_at`.
+#[derive(Clone, Debug)]
+pub struct Timestamps {
+    created_column: String,
+    updated_column: String,
+}
+
+impl Default for Timestamps {
+    fn default() -> Self {
+        Self {
+            created_column: "created_at".to_string(),
+            updated_column: "updated_at".to_string(),
+        }
+    }
+}
+
+impl Timestamps {
+    /// The default `created_at` / `updated_at` pair.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the created-timestamp column name.
+    pub fn created(mut self, column: impl Into<String>) -> Self {
+        self.created_column = column.into();
+        self
+    }
+
+    /// Override the updated-timestamp column name.
+    pub fn updated(mut self, column: impl Into<String>) -> Self {
+        self.updated_column = column.into();
+        self
+    }
+}
+
+impl<T: TableSource, E: Entity<T::Value>> Table<T, E>
+where
+    T::Value: InvariantValue + From<String>,
+{
+    /// Stamp `created_at` on insert and `updated_at` on every write, using the
+    /// default column names.
+    ///
+    /// `created_at` is set only when the inserted record carries none (a
+    /// caller-supplied value is kept, so a backfilled import keeps its real
+    /// timestamps); `updated_at` is always (re)written. Both are RFC 3339 UTC
+    /// strings. The columns need only be nullable `TEXT`.
+    pub fn with_timestamps(self) -> Self {
+        self.with_audit(Timestamps::default())
+    }
+
+    /// [`Self::with_timestamps`] with custom column names.
+    pub fn with_audit(self, columns: Timestamps) -> Self {
+        self.with_hook(Hook::BeforeInsert(
+            Phase::Populate,
+            created_hook::<T>(columns.created_column),
+        ))
+        .with_hook(Hook::BeforeSave(
+            Phase::Populate,
+            updated_hook::<T>(columns.updated_column),
+        ))
+    }
+}
+
+/// Before-insert hook: set `column` to the current time only if it is absent or
+/// null (an explicit value survives).
+fn created_hook<T: TableSource>(column: String) -> BeforeFn<T>
+where
+    T::Value: InvariantValue + From<String>,
+{
+    Arc::new(
+        move |rec: &mut Record<T::Value>,
+              _table: &Table<T, EmptyEntity>|
+              -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            let column = column.clone();
+            Box::pin(async move {
+                let absent_or_null = match rec.get(column.as_str()) {
+                    None => true,
+                    Some(v) => v.is_null(),
+                };
+                if absent_or_null {
+                    rec.insert(column, T::Value::from(now_rfc3339()));
+                }
+                Ok(())
+            })
+        },
+    )
+}
+
+/// Before-save hook (insert + update): always set `column` to the current time.
+fn updated_hook<T: TableSource>(column: String) -> BeforeFn<T>
+where
+    T::Value: InvariantValue + From<String>,
+{
+    Arc::new(
+        move |rec: &mut Record<T::Value>,
+              _table: &Table<T, EmptyEntity>|
+              -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            let column = column.clone();
+            Box::pin(async move {
+                rec.insert(column, T::Value::from(now_rfc3339()));
+                Ok(())
+            })
+        },
+    )
+}
+
+/// Current UTC time as a second-precision RFC 3339 string (`…Z`).
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::mock_table_source::MockTableSource;
+    use serde_json::json;
+    use vantage_dataset::prelude::{
+        InsertableValueSet, ReadableValueSet, WritableValueSet,
+    };
+
+    type MockTable = Table<MockTableSource, EmptyEntity>;
+
+    fn looks_like_timestamp(v: &serde_json::Value) -> bool {
+        v.as_str()
+            .is_some_and(|s| s.len() >= 20 && s.ends_with('Z') && s.contains('T'))
+    }
+
+    #[tokio::test]
+    async fn stamps_created_and_updated_on_insert() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src).with_timestamps();
+
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"id": "1", "name": "a"})))
+            .await
+            .unwrap();
+        let row = table.get_value(id).await.unwrap().unwrap();
+        assert!(looks_like_timestamp(&row["created_at"]), "{row:?}");
+        assert!(looks_like_timestamp(&row["updated_at"]), "{row:?}");
+    }
+
+    #[tokio::test]
+    async fn keeps_caller_supplied_created_at() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src).with_timestamps();
+
+        let id = table
+            .insert_return_id_value(&Record::from(
+                json!({"id": "1", "name": "a", "created_at": "2000-01-01T00:00:00Z"}),
+            ))
+            .await
+            .unwrap();
+        let row = table.get_value(id).await.unwrap().unwrap();
+        // The explicit created_at survives; updated_at is still stamped fresh.
+        assert_eq!(row["created_at"], json!("2000-01-01T00:00:00Z"));
+        assert!(looks_like_timestamp(&row["updated_at"]));
+    }
+
+    #[tokio::test]
+    async fn updates_only_updated_at_on_patch() {
+        let src = MockTableSource::new()
+            .with_data(
+                "t",
+                vec![json!({"id": "1", "name": "a", "created_at": "2000-01-01T00:00:00Z"})],
+            )
+            .await;
+        let table = MockTable::new("t", src).with_timestamps();
+
+        table
+            .patch_value("1", &Record::from(json!({"name": "b"})))
+            .await
+            .unwrap();
+        let row = table.get_value("1".to_string()).await.unwrap().unwrap();
+        // created_at untouched by the update; updated_at freshly stamped.
+        assert_eq!(row["created_at"], json!("2000-01-01T00:00:00Z"));
+        assert!(looks_like_timestamp(&row["updated_at"]));
+        assert_eq!(row["name"], json!("b"));
+    }
+
+    #[tokio::test]
+    async fn custom_column_names() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src)
+            .with_audit(Timestamps::new().created("inserted").updated("touched"));
+
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"id": "1"})))
+            .await
+            .unwrap();
+        let row = table.get_value(id).await.unwrap().unwrap();
+        assert!(looks_like_timestamp(&row["inserted"]));
+        assert!(looks_like_timestamp(&row["touched"]));
+    }
+}

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -50,7 +50,7 @@ where
     /// left null/absent is filled, a matching value is kept, and a conflicting
     /// value is rejected.
     pub(super) invariants: IndexMap<String, T::Value>,
-    /// Lifecycle hooks (see [`Hook`]). Registered via [`Self::with_hook`].
+    /// Lifecycle hooks (see [`Hook`](super::Hook)). Registered via [`Self::with_hook`].
     pub(super) hooks: Hooks<T>,
 }
 

--- a/vantage-table/src/table/id_generator.rs
+++ b/vantage-table/src/table/id_generator.rs
@@ -1,0 +1,209 @@
+//! Auto-generation of record ids on insert.
+//!
+//! Some backends supply a primary key themselves (a SQL `DEFAULT`/sequence, an
+//! in-memory store's own uuid). When the backend does not — a bare
+//! `TEXT PRIMARY KEY`, a REST resource that expects the client to mint the id —
+//! [`Table::with_generated_id`] fills the id column on insert using the existing
+//! before-write hook machinery (see [`crate::table::hooks`]).
+//!
+//! It fills the id only when the inserted record carries none (the field is
+//! absent or null), and only on insert: `patch`/`replace`/`update`/`upsert`
+//! never touch the id. Because a present id is always kept, an id the caller
+//! assigned once survives a retried insert — generation stays idempotent.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use vantage_core::Result;
+use vantage_types::{EmptyEntity, Entity, InvariantValue, Record};
+
+use crate::table::{BeforeFn, Hook, Phase, Table};
+use crate::traits::column_like::ColumnLike;
+use crate::traits::table_source::TableSource;
+
+/// How a missing id is minted when a new record is inserted.
+///
+/// `UuidV7` is the recommended choice: it is time-ordered (RFC 9562), so ids
+/// sort by creation time and cluster together in a primary-key index instead of
+/// scattering it the way the purely-random `UuidV4` does.
+#[derive(Clone)]
+pub enum IdGenerator {
+    /// Time-ordered UUID (v7). Sortable and index-friendly — the recommended
+    /// default for new tables.
+    UuidV7,
+    /// Random UUID (v4).
+    UuidV4,
+    /// Any caller-supplied scheme (ULID, nanoid, a counter, …).
+    Custom(Arc<dyn Fn() -> String + Send + Sync>),
+}
+
+impl IdGenerator {
+    /// A custom generator from a closure.
+    pub fn custom(f: impl Fn() -> String + Send + Sync + 'static) -> Self {
+        IdGenerator::Custom(Arc::new(f))
+    }
+
+    /// Produce one fresh id string.
+    pub fn generate(&self) -> String {
+        match self {
+            IdGenerator::UuidV7 => uuid::Uuid::now_v7().to_string(),
+            IdGenerator::UuidV4 => uuid::Uuid::new_v4().to_string(),
+            IdGenerator::Custom(f) => f(),
+        }
+    }
+}
+
+impl std::fmt::Debug for IdGenerator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            IdGenerator::UuidV7 => "UuidV7",
+            IdGenerator::UuidV4 => "UuidV4",
+            IdGenerator::Custom(_) => "Custom",
+        };
+        f.debug_tuple("IdGenerator").field(&name).finish()
+    }
+}
+
+impl<T: TableSource, E: Entity<T::Value>> Table<T, E>
+where
+    T::Value: InvariantValue + From<String>,
+{
+    /// Fill the id column with a generated value whenever a new row is inserted
+    /// without one.
+    ///
+    /// Only insert is affected, and only when the record's id field is absent or
+    /// null — a caller-supplied id is always kept, so a retried insert that
+    /// carries the same id stays idempotent. `patch`/`replace`/`update`/`upsert`
+    /// never touch the id. Backends that mint their own id (e.g. the in-memory
+    /// store, a SQL column with a `DEFAULT`) ignore the filled value and need no
+    /// generator.
+    pub fn with_generated_id(self, generator: IdGenerator) -> Self {
+        self.with_hook(Hook::BeforeInsert(
+            Phase::Populate,
+            id_fill_hook::<T>(generator),
+        ))
+    }
+
+    /// Mutable form of [`Self::with_generated_id`].
+    pub fn add_generated_id(&mut self, generator: IdGenerator) {
+        self.add_hook(Hook::BeforeInsert(
+            Phase::Populate,
+            id_fill_hook::<T>(generator),
+        ));
+    }
+}
+
+/// Build the before-insert hook that fills an absent/null id from `generator`.
+/// The id column name is resolved from the table at fire time (falling back to
+/// `"id"`), so the column need not exist when the generator is registered.
+fn id_fill_hook<T: TableSource>(generator: IdGenerator) -> BeforeFn<T>
+where
+    T::Value: InvariantValue + From<String>,
+{
+    Arc::new(
+        move |rec: &mut Record<T::Value>,
+              table: &Table<T, EmptyEntity>|
+              -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+            let id_field = table
+                .id_field()
+                .map(|c| c.name().to_string())
+                .unwrap_or_else(|| "id".to_string());
+            let generator = generator.clone();
+            Box::pin(async move {
+                let absent_or_null = match rec.get(id_field.as_str()) {
+                    None => true,
+                    Some(v) => v.is_null(),
+                };
+                if absent_or_null {
+                    rec.insert(id_field, T::Value::from(generator.generate()));
+                }
+                Ok(())
+            })
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mocks::mock_table_source::MockTableSource;
+    use serde_json::json;
+    use vantage_dataset::prelude::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+
+    type MockTable = Table<MockTableSource, EmptyEntity>;
+
+    #[tokio::test]
+    async fn fills_missing_id_on_insert() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src).with_generated_id(IdGenerator::UuidV7);
+
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"name": "a"})))
+            .await
+            .unwrap();
+        // A v7 uuid is a non-empty, hyphenated string and is now the row's key.
+        assert!(id.contains('-'));
+        assert_eq!(
+            table.get_value(id).await.unwrap().unwrap()["name"],
+            json!("a")
+        );
+    }
+
+    #[tokio::test]
+    async fn keeps_caller_supplied_id() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src).with_generated_id(IdGenerator::UuidV7);
+
+        // A present id is preserved — the generator never overwrites it.
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"id": "fixed-1", "name": "a"})))
+            .await
+            .unwrap();
+        assert_eq!(id, "fixed-1");
+    }
+
+    #[tokio::test]
+    async fn fills_when_id_is_null() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table = MockTable::new("t", src).with_generated_id(IdGenerator::UuidV4);
+
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"id": null, "name": "a"})))
+            .await
+            .unwrap();
+        assert!(!id.is_empty() && id != "null");
+    }
+
+    #[tokio::test]
+    async fn custom_generator_is_used() {
+        let src = MockTableSource::new().with_data("t", vec![]).await;
+        let table =
+            MockTable::new("t", src).with_generated_id(IdGenerator::custom(|| "made-up".into()));
+
+        let id = table
+            .insert_return_id_value(&Record::from(json!({"name": "a"})))
+            .await
+            .unwrap();
+        assert_eq!(id, "made-up");
+    }
+
+    #[tokio::test]
+    async fn patch_does_not_touch_id() {
+        let src = MockTableSource::new()
+            .with_data("t", vec![json!({"id": "1", "name": "a"})])
+            .await;
+        let table =
+            MockTable::new("t", src).with_generated_id(IdGenerator::custom(|| "made-up".into()));
+
+        // patch fires before_update, not before_insert — the generator is a
+        // before_insert hook, so the id is left alone.
+        table
+            .patch_value("1", &Record::from(json!({"name": "b"})))
+            .await
+            .unwrap();
+        let row = table.get_value("1".to_string()).await.unwrap().unwrap();
+        assert_eq!(row["id"], json!("1"));
+        assert_eq!(row["name"], json!("b"));
+    }
+}

--- a/vantage-table/src/table/mod.rs
+++ b/vantage-table/src/table/mod.rs
@@ -21,6 +21,12 @@ pub use base::*;
 pub mod hooks;
 pub use hooks::*;
 
+pub mod audit;
+pub use audit::*;
+
+pub mod id_generator;
+pub use id_generator::*;
+
 pub mod impls;
 pub use impls::*;
 


### PR DESCRIPTION
Releases four crates consumed by vantage-ui's launch-control example.

## vantage-table 0.6.8
- `Table::with_generated_id(IdGenerator)` — mint a record's id on insert when the backend doesn't (bare `PRIMARY KEY`, client-keyed REST). `UuidV7`/`UuidV4`/`Custom`. Fills only an absent/null id, only on insert; a caller-supplied id is always kept (idempotent).
- `Table::with_timestamps()` / `with_audit(Timestamps)` — stamp `created_at` (once, if empty) and `updated_at` (every write) as RFC 3339 UTC strings; column names overridable.

## vantage-sql 0.6.4
- A NULL id read back is no longer coerced to the literal `"Null"`: NULL-id rows are skipped on read, and an insert whose `RETURNING` id comes back NULL fails with an explanatory error. Applies to SQLite, Postgres, MySQL.
- Explicit-id insert/replace applies the caller's id after the record, so a generator hook can't clobber it.

## vantage-diorama 0.6.5
- Refresh-on-open uses `force_load` so a cache-seeded grid is ordered by the server without a manual refresh.
- A chunk load bumps the generation only when a visible row actually changes (no repaint on byte-identical refresh).
- Short-page total derivation: a short page sets the grand `total` from the fetch itself, self-correcting a list opened before its rows existed; `set_search` drops the stale total.
- (Folds in the previously-unreleased 0.6.4 surface: diagnostics, activity signal, no-flicker reload, titles_only, optimistic writes, dedup registry.)

## vantage-api-client 0.6.4
- REST: with `.debug(true)`, each GET logs the resolved request URL.

All new unit tests pass (`vantage-table` audit/id_generator, `vantage-sql` sqlite NULL-id + generated-id). On merge, the publish-on-merge workflow ships all four to crates.io.