### PR TITLE
fix(diorama): failed auto-refresh no longer reverts the grid to stale cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.6 — 2026-06-27
+
+- Failed auto-refresh no longer reverts the grid to stale cache. The
+  `refresh_every` ticker published `Invalidated` even when its `on_refresh`
+  callback failed (e.g. the source returned a 503), forcing every open scenery to
+  reseed from cache — which dropped rows added since the last good refresh. The
+  ticker now delegates to `Dio::refresh()`, the same path manual refresh uses: a
+  failed tick announces `Refreshing` but does **not** invalidate, so the painted
+  rows survive a transient source error; only a successful refresh updates the
+  cache and repaints.
+
 ## 0.6.5 — 2026-06-26
 
 - Diagnostics surface. `dio.diagnostics().await` returns a `DioDiagnostics`

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -13,7 +13,7 @@ use tokio::sync::{Mutex, broadcast, mpsc};
 use vantage_core::Result;
 use vantage_vista::Vista;
 
-use crate::dio::{Dio, DioEvent, DioInner, HotTier, worker::write_worker_loop};
+use crate::dio::{Dio, DioInner, HotTier, worker::write_worker_loop};
 use crate::lens::{Activity, ActivitySignal, Lens};
 
 impl Lens {
@@ -119,12 +119,14 @@ async fn refresh_loop(
             continue;
         }
         let dio = Dio { inner: strong };
-        let _ = dio.inner.event_bus.send(DioEvent::Refreshing);
-        if let Some(cb) = dio.inner.lens.callbacks.on_refresh.as_ref()
-            && let Err(e) = cb(&dio).await
-        {
+        // Delegate to `dio.refresh()` so the auto ticker and the manual path
+        // share one definition: it announces `Refreshing`, runs `on_refresh`,
+        // and publishes `Invalidated` *only* when the refresh succeeds. A failed
+        // tick (e.g. the source 503s) must not invalidate — that would reseed
+        // sceneries from stale cache and drop rows added since the last good
+        // refresh.
+        if let Err(e) = dio.refresh().await {
             tracing::error!(error = %e, "on_refresh callback failed");
         }
-        let _ = dio.inner.event_bus.send(DioEvent::Invalidated);
     }
 }

--- a/vantage-diorama/tests/bdd_support/steps/assertions.rs
+++ b/vantage-diorama/tests/bdd_support/steps/assertions.rs
@@ -3,6 +3,7 @@
 //! without copy-paste.
 
 use cucumber::{then, when};
+use vantage_diorama::DioEvent;
 
 use crate::bdd_support::world::DioramaWorld;
 
@@ -61,4 +62,15 @@ async fn event_log_snapshot(w: &mut DioramaWorld, name: String) {
     }, {
         insta::assert_yaml_snapshot!(events);
     });
+}
+
+#[then("the event log contains no Invalidated")]
+async fn no_invalidated(w: &mut DioramaWorld) {
+    let events = w.snapshot_events().await;
+    let found = events.iter().any(|e| matches!(e, DioEvent::Invalidated));
+    assert!(
+        !found,
+        "a failed refresh must not publish Invalidated — it would reseed the grid \
+         from (stale) cache and drop newer rows; got: {events:?}"
+    );
 }

--- a/vantage-diorama/tests/bdd_support/steps/refresh.rs
+++ b/vantage-diorama/tests/bdd_support/steps/refresh.rs
@@ -19,6 +19,12 @@ async fn register_on_refresh(w: &mut DioramaWorld) {
     w.lens_builder.register_on_refresh = true;
 }
 
+#[given("an on_refresh callback that fails")]
+async fn register_failing_on_refresh(w: &mut DioramaWorld) {
+    w.lens_builder.register_on_refresh = true;
+    w.lens_builder.on_refresh_fails = true;
+}
+
 #[when(regex = r"^(\d+) seconds? pass(?:es)?$")]
 async fn time_passes(w: &mut DioramaWorld, secs: u64) {
     tokio::time::advance(Duration::from_secs(secs)).await;

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -82,6 +82,10 @@ pub struct LensBuilderState {
     pub total_provider_kind: TotalProviderKind,
     pub on_load_chunk_kind: OnLoadChunkKind,
     pub register_on_refresh: bool,
+    /// With `register_on_refresh`, makes the on_refresh closure return `Err`
+    /// (after bumping the spy) — models a refresh that hits a server error
+    /// (e.g. a 503), so the refresh-failure path can be driven deterministically.
+    pub on_refresh_fails: bool,
     /// When present, the `on_start` closure awaits this Notify before
     /// running its body. Lets a test pin "make_dio is/isn't waiting on
     /// the callback" deterministically — see scenario 1/2.
@@ -288,10 +292,14 @@ impl LensBuilderState {
 
         if self.register_on_refresh {
             let counter = spies.on_refresh.clone();
+            let fails = self.on_refresh_fails;
             b = b.on_refresh(move |_dio| {
                 let counter = counter.clone();
                 async move {
                     counter.fetch_add(1, Ordering::SeqCst);
+                    if fails {
+                        return Err(vantage_core::error!("on_refresh failed (injected 503)"));
+                    }
                     Ok(())
                 }
             });

--- a/vantage-diorama/tests/features/refresh.feature
+++ b/vantage-diorama/tests/features/refresh.feature
@@ -32,3 +32,21 @@ Feature: Refresh ticker
     And I wait for 2 events
     Then on_refresh has been called 1 time
     And the event log matches snapshot "manual_refresh"
+
+  # A refresh tick whose on_refresh fails (e.g. the server 503s) must leave the
+  # painted grid alone: it may announce Refreshing, but it must NOT publish
+  # Invalidated, because Invalidated makes sceneries reseed from cache — which
+  # reverts the grid to a stale snapshot and drops rows added since. This
+  # mirrors the guarantee manual `dio.refresh()` already gives.
+  Scenario: a failed auto-refresh does not publish Invalidated
+    Given a master with rows
+      | id | title |
+      | a  | one   |
+    And a lens with on_start that copies master to cache
+    And a refresh interval of 60 seconds
+    And an on_refresh callback that fails
+    When the dio is created
+    And 61 seconds pass
+    And I wait for 1 event
+    Then on_refresh has been called 1 time
+    And the event log contains no Invalidated


### PR DESCRIPTION
## Symptom
In the running app: create a row, then a periodic refresh hits a server error (503). The grid reverts to an older cached snapshot that doesn't contain the just-created row.

## Root cause
The auto-refresh ticker `refresh_loop` (`vantage-diorama/src/lens/make_dio.rs`) published `DioEvent::Invalidated` **unconditionally** — even when the `on_refresh` callback returned `Err`. `Invalidated` makes every table scenery run `reseed_from_cache()`, rebuilding its rows from the cache. So a failed refresh forced a reseed from a stale/partial cache, dropping rows added since the last good refresh.

This diverged from the manual path, `Dio::refresh()`, which already publishes `Invalidated` only on success. The two had duplicated logic that drifted apart.

## Fix
`refresh_loop` now delegates to `dio.refresh().await` — one shared definition. A failed tick announces `Refreshing` but does **not** invalidate, so the painted rows are left alone; only a successful refresh updates the cache and repaints.

## Test (TDD)
New BDD scenario `tests/features/refresh.feature` — *"a failed auto-refresh does not publish Invalidated"* — drives a `refresh_every` tick under virtual time with a failing `on_refresh`, and asserts the event log contains no `Invalidated`.

- Before the fix it failed with `got: [Refreshing, Invalidated]`.
- After the fix: 66/66 BDD scenarios pass, and the full `vantage-diorama` suite is green.

Harness additions: an `on_refresh_fails` option (a 503-like failing refresh) and an `event log contains no Invalidated` assertion step.

## Note
Not addressed here (separate path): `synth_refresh` in `lens/build.rs` deletes cached rows absent from a fresh list — if a *successful* refresh ever returns a windowed/partial list, that could prune rows. Worth a follow-up.