### PR TITLE
Postgres: text-keyed id columns + Vista fetch_window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5043,7 +5043,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista-factory"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ciborium",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.8 — 2026-06-28
+
+- Formatting only (`cargo fmt --all`); no functional change.
+
 ## 0.6.7 — 2026-06-28
 
 - `Dio::get_ref(relation, row)` traverses a reference and returns a new `Dio`

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/tests/bdd_support/steps/traversal.rs
+++ b/vantage-diorama/tests/bdd_support/steps/traversal.rs
@@ -10,7 +10,7 @@ use cucumber::{given, then, when};
 use vantage_dataset::traits::ReadableValueSet;
 use vantage_diorama::Lens;
 use vantage_types::Record;
-use vantage_vista::{mocks::MockShell, Column, Reference, ReferenceKind, Vista, VistaMetadata};
+use vantage_vista::{Column, Reference, ReferenceKind, Vista, VistaMetadata, mocks::MockShell};
 
 use crate::bdd_support::world::DioramaWorld;
 
@@ -35,8 +35,14 @@ fn crew_shell() -> MockShell {
         .with_id_column("id");
     MockShell::new()
         .with_metadata(meta)
-        .with_record("c1", rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]))
-        .with_record("c2", rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]))
+        .with_record(
+            "c1",
+            rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]),
+        )
+        .with_record(
+            "c2",
+            rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]),
+        )
 }
 
 /// A `launches` master declaring a `crew` has-many onto `launch_crew`.

--- a/vantage-diorama/tests/traversal.rs
+++ b/vantage-diorama/tests/traversal.rs
@@ -10,7 +10,7 @@ use vantage_core::Result;
 use vantage_dataset::prelude::ReadableValueSet;
 use vantage_diorama::Lens;
 use vantage_types::Record;
-use vantage_vista::{mocks::MockShell, Column, Reference, ReferenceKind, Vista, VistaMetadata};
+use vantage_vista::{Column, Reference, ReferenceKind, Vista, VistaMetadata, mocks::MockShell};
 
 fn text(s: &str) -> CborValue {
     CborValue::Text(s.to_string())
@@ -33,8 +33,14 @@ fn crew_shell() -> MockShell {
         .with_id_column("id");
     MockShell::new()
         .with_metadata(meta)
-        .with_record("c1", rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]))
-        .with_record("c2", rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]))
+        .with_record(
+            "c1",
+            rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]),
+        )
+        .with_record(
+            "c2",
+            rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]),
+        )
 }
 
 /// A launches master declaring a `crew` has-many onto `launch_crew`, resolved

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.5 — 2026-06-28
+
+- The Postgres table source honors `Table::with_text_id()` (vantage-table 0.6.9): a text-keyed
+  table binds its id as text on every by-id insert/get/replace/patch/delete, instead of coercing an
+  all-digit id to `bigint`. Tables without the flag keep the integer-coercing default.
+- The Postgres Vista shell implements `fetch_window(offset, limit)` (and advertises
+  `can_fetch_window`), so windowed pagination works through the Vista facade, matching the SQLite
+  shell.
+
 ## 0.6.4 — 2026-06-26
 
 - A NULL id read back from a row is no longer coerced to the literal string `"Null"`: rows with a

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -27,6 +27,21 @@ fn id_value(id: &str) -> AnyPostgresType {
     }
 }
 
+/// Bind an id for a given table. Honors [`Table::with_text_id`]: a text-keyed
+/// table always binds its id as text, even when it looks numeric, so an
+/// all-digit id like `"121"` is not coerced to `bigint` against a `TEXT` id
+/// column. Other tables keep the integer-coercing default ([`id_value`]).
+fn id_param<E>(table: &Table<PostgresDB, E>, id: &str) -> AnyPostgresType
+where
+    E: Entity<AnyPostgresType>,
+{
+    if table.id_is_text() {
+        AnyPostgresType::from(id.to_string())
+    } else {
+        id_value(id)
+    }
+}
+
 /// Parse the CBOR array result from execute() into an IndexMap of id -> Record.
 fn parse_rows(
     result: AnyPostgresType,
@@ -190,7 +205,7 @@ impl TableSource for PostgresDB {
             .unwrap_or_else(|| "id".to_string());
 
         let condition = {
-            let id_val = id_value(id);
+            let id_val = id_param(table, id);
             postgres_expr!("{} = {}", (ident(&id_field_name)), id_val)
         };
         let select = table.select().with_condition(condition);
@@ -288,7 +303,7 @@ impl TableSource for PostgresDB {
             // The explicit id param is authoritative on this path, so apply it
             // after the record — a record-carried id (e.g. one a generator hook
             // filled) must not override the id the caller asked to write.
-            .with_field(&id_field_name, id_value(id));
+            .with_field(&id_field_name, id_param(table, id));
         self.execute(&insert.expr()).await?;
 
         self.get_table_value(table, id)
@@ -316,7 +331,7 @@ impl TableSource for PostgresDB {
             // The explicit id param is authoritative on this path, so apply it
             // after the record — a record-carried id (e.g. one a generator hook
             // filled) must not override the id the caller asked to write.
-            .with_field(&id_field_name, id_value(id));
+            .with_field(&id_field_name, id_param(table, id));
         let base = insert.expr();
 
         let set_parts: Vec<Expression<AnyPostgresType>> = if record.is_empty() {
@@ -365,7 +380,7 @@ impl TableSource for PostgresDB {
             .unwrap_or_else(|| "id".to_string());
 
         let id_condition = {
-            let id_val = id_value(id);
+            let id_val = id_param(table, id);
             postgres_expr!("{} = {}", (ident(&id_field_name)), id_val)
         };
         let update = crate::postgres::statements::PostgresUpdate::new(table.table_name())
@@ -388,7 +403,7 @@ impl TableSource for PostgresDB {
             .unwrap_or_else(|| "id".to_string());
 
         let id_condition = {
-            let id_val = id_value(id);
+            let id_val = id_param(table, id);
             postgres_expr!("{} = {}", (ident(&id_field_name)), id_val)
         };
         let delete = crate::postgres::statements::PostgresDelete::new(table.table_name())

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -66,6 +66,7 @@ impl PostgresVistaFactory {
                 can_insert: !read_only,
                 can_update: !read_only,
                 can_delete: !read_only,
+                can_fetch_window: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
                 ..VistaCapabilities::default()

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -8,6 +8,7 @@ use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_table::pagination::Pagination;
 use vantage_table::table::Table;
 use vantage_types::{EmptyEntity, Entity, Record};
 use vantage_vista::{
@@ -111,6 +112,24 @@ where
 
     async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
         self.table.get_count().await
+    }
+
+    async fn fetch_window(
+        &self,
+        _vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        // Clone the wrapped table so this call's window doesn't disturb the
+        // shell's own condition / order / search state.
+        let mut window_table = self.table.clone();
+        window_table.set_pagination(Some(Pagination::window(offset as i64, limit as i64)));
+
+        let raw = window_table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect())
     }
 
     async fn insert_vista_value(

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.9 — 2026-06-28
+
+- `Table::with_text_id()` marks the id column as a text/string key so SQL backends do not
+  numerically coerce it. Without it the Postgres backend binds an all-digit id like `"121"` as
+  `bigint`, which fails against a `TEXT` id column; the flag keeps such ids bound as text. Defaults
+  off, so the integer-id convention other models rely on is unchanged. Read back via
+  `Table::id_is_text()`.
+
 ## 0.6.8 — 2026-06-26
 
 - `Table::with_generated_id(IdGenerator)` mints a record's id on insert when the backend does not

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -42,6 +42,12 @@ where
     pub(super) title_field: Option<String>,
     pub(super) title_fields: Vec<String>,
     pub(super) id_field: Option<String>,
+    /// When true, the id column is a text/string key and backends must NOT
+    /// numerically coerce it (e.g. the Postgres backend otherwise binds an
+    /// all-digit id like `"121"` as `bigint`, which breaks against a `TEXT` id
+    /// column). Set via [`Self::with_text_id`]. Defaults to false to preserve
+    /// the integer-id convention used by other models.
+    pub(super) id_text: bool,
     /// Column values every row in this set must hold, because they are part of
     /// the set's definition (e.g. a has-many child carries the parent's foreign
     /// key). Registered wherever the table is narrowed by a literal
@@ -73,6 +79,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             title_field: None,
             title_fields: Vec::new(),
             id_field: None,
+            id_text: false,
             invariants: IndexMap::new(),
             hooks: Hooks::default(),
         }
@@ -100,6 +107,7 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             title_field: self.title_field,
             title_fields: self.title_fields,
             id_field: self.id_field,
+            id_text: self.id_text,
             invariants: self.invariants,
             hooks: self.hooks,
         }

--- a/vantage-table/src/table/impls/columns.rs
+++ b/vantage-table/src/table/impls/columns.rs
@@ -75,6 +75,21 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self
     }
 
+    /// Mark the id column as a text/string key so backends do not numerically
+    /// coerce it. Use for models whose id column is `TEXT` even when some ids
+    /// look numeric (e.g. ids from an external API mixed with generated UUIDs);
+    /// without this the Postgres backend binds an all-digit id like `"121"` as
+    /// `bigint`, which fails against a `TEXT` id column.
+    pub fn with_text_id(mut self) -> Self {
+        self.id_text = true;
+        self
+    }
+
+    /// Whether the id column is a text key (see [`Self::with_text_id`]).
+    pub fn id_is_text(&self) -> bool {
+        self.id_text
+    }
+
     /// Add a typed column AND mark it as a display title.
     ///
     /// Title columns show alongside the id in generic list views and

--- a/vantage-vista-factory/CHANGELOG.md
+++ b/vantage-vista-factory/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.1 — unreleased
+## 0.6.2 — unreleased
 
 - Test only: a characterization test pinning that an unreachable reference
   target is conflated with a missing reference at the traversal layer — the

--- a/vantage-vista-factory/Cargo.toml
+++ b/vantage-vista-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista-factory"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Multi-datasource Vista catalog and cross-persistence reference traversal for the Vantage data framework"

--- a/vantage-vista-factory/src/lib.rs
+++ b/vantage-vista-factory/src/lib.rs
@@ -369,20 +369,31 @@ mod tests {
         );
         cat.register_relation(
             "launch",
-            Relation::single_key("crew", "launch_crew", ReferenceKind::HasMany, "launch_id", "id"),
+            Relation::single_key(
+                "crew",
+                "launch_crew",
+                ReferenceKind::HasMany,
+                "launch_id",
+                "id",
+            ),
         );
 
         let launch = record(&[("id", text("L1"))]);
         let rel = cat.relations_for("launch")[0].clone();
 
         // 1) Source up — traversal works, exactly one crew member.
-        let crew = cat.traverse(&rel, &launch).expect("traverse with source up");
+        let crew = cat
+            .traverse(&rel, &launch)
+            .expect("traverse with source up");
         assert_eq!(crew.list_values().await.unwrap().len(), 1);
 
         // 2) The crew source goes down (refresh 503s) — re-traverse.
         crew_up.store(false, Ordering::SeqCst);
         let down_res = cat.traverse(&rel, &launch);
-        assert!(down_res.is_err(), "traverse fails while the crew source is down");
+        assert!(
+            down_res.is_err(),
+            "traverse fails while the crew source is down"
+        );
         let down = format!("{:?}", down_res.err().unwrap());
 
         // 3) The reference DEFINITION is untouched: it still exists.
@@ -390,7 +401,10 @@ mod tests {
             cat.relations_for("launch").iter().any(|r| r.name == "crew"),
             "the `crew` relation is still defined"
         );
-        assert!(cat.has_model("launch_crew"), "the target model is still registered");
+        assert!(
+            cat.has_model("launch_crew"),
+            "the target model is still registered"
+        );
 
         // 4) Yet the error is a bare load failure carrying nothing that lets a
         //    caller distinguish "unreachable" from "no such reference" — both a
@@ -400,9 +414,15 @@ mod tests {
         assert!(missing_res.is_err(), "an unregistered model also errors");
         let absent = format!("{:?}", missing_res.err().unwrap());
 
-        assert!(down.contains("unavailable") || down.contains("503"), "got: {down}");
+        assert!(
+            down.contains("unavailable") || down.contains("503"),
+            "got: {down}"
+        );
         // Both failures are the same `Result::Err` shape with no machine-readable
         // "kind" — this sameness is the conflation the bug is about.
-        assert!(!absent.is_empty(), "missing-model error exists but is just another opaque Err");
+        assert!(
+            !absent.is_empty(),
+            "missing-model error exists but is just another opaque Err"
+        );
     }
 }

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.4 — unreleased
+## 0.6.5 — unreleased
 
 ### Added
 

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -243,9 +243,11 @@ impl TableShell for MockShell {
     /// (no read), so it succeeds even while the target's `fail_reads` is set —
     /// the failure surfaces later, at load time, on the returned Vista.
     fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
-        let reference = self.metadata.references.get(relation).ok_or_else(|| {
-            vantage_core::error!("unknown relation", relation = relation)
-        })?;
+        let reference = self
+            .metadata
+            .references
+            .get(relation)
+            .ok_or_else(|| vantage_core::error!("unknown relation", relation = relation))?;
         let target = self.ref_targets.get(relation).ok_or_else(|| {
             vantage_core::error!("no ref target registered for relation", relation = relation)
         })?;


### PR DESCRIPTION
## What

Two additive changes that let a model with **text id columns** (ids that look numeric but are stored as `TEXT`, e.g. an external API's numeric ids mixed with generated UUIDs) work on PostgreSQL, and let such tables paginate through the Vista facade.

### `vantage-table` (0.6.8 → 0.6.9)
- `Table::with_text_id()` marks the id column as a text/string key; `Table::id_is_text()` reads it back. Defaults **off**, so the existing integer-id convention is unchanged.

### `vantage-sql` (0.6.4 → 0.6.5)
- The Postgres table source honors `with_text_id()`: a text-keyed table binds its id as text on every by-id insert/get/replace/patch/delete, instead of coercing an all-digit id like `"121"` to `bigint`. Previously such ids failed against a `TEXT` id column with `operator does not exist: text = bigint`. Tables without the flag keep the integer-coercing default.
- The Postgres Vista shell now implements `fetch_window(offset, limit)` and advertises `can_fetch_window`, matching the SQLite shell — windowed pagination works through Vista on Postgres.

## Why

A model can carry both numeric (external) and UUID ids in `TEXT` columns — fine on SQLite (dynamic typing) but broken on Postgres, where the id binder coerced numeric-looking ids to `bigint`. The opt-in flag keeps backward compatibility for integer-id models while making text-id models portable.

## Compatibility

Fully backward compatible: `with_text_id()` is opt-in (default off), and the Postgres binding path is unchanged for tables that don't set it. `cargo fmt` + `clippy` clean on both crates.