### PR TITLE
Dio owns query semantics: conditions, order, augmentation + local capability emulation (0.6.9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.7"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.0 — 2026-06-28
+
+- Begin the "Dio owns query semantics" refactor. First landed piece:
+  `LensBuilder::cache_in_memory()` + a `MemoryCache` backend — a process-local,
+  non-persistent `CacheBackend` mirroring the redb backend's per-Dio-named-table
+  and per-row `CacheStatus` semantics. Lets ephemeral Dios and tests skip the
+  `TempDir`/redb file while still exercising real `Incomplete`/`Complete`
+  round-tripping (two-pass, local emulation).
+
 ## 0.6.7 — 2026-06-28
 
 - `Dio::get_ref(relation, row)` traverses a reference and returns a new `Dio`

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -14,6 +14,15 @@
   override the sort). Native columns flow through the existing per-`(conditions,
   sort)` index / local-filter path; pushdown-vs-local routing for augmented
   columns arrives with the local-emulation work.
+- Local filter/sort emulation for two-pass views. A two-pass list pass can't
+  push conditions/sort to the master, so a view carrying either now refines its
+  visible set locally over the cache: rows are filtered (and sorted) by the
+  hydrated records, the visible map becomes authoritative for `row_count`, and an
+  augmented-column predicate naturally hides rows until hydration confirms a
+  match (matches surface progressively as rows augment). Such a view hydrates the
+  whole listed set rather than just the viewport — the documented cost of
+  filtering/sorting on a client-side column. A view with no conditions/sort is
+  unchanged (raw index order, gray rows preserved).
 - Augmentation is now owned by the Dio, not the Lens: `Dio::augment(catalog,
   augmentations)` configures the two-pass list/detail/refresh, so Dios sharing a
   Lens can enrich differently. The pass bodies moved to a shared

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -8,6 +8,12 @@
   and per-row `CacheStatus` semantics. Lets ephemeral Dios and tests skip the
   `TempDir`/redb file while still exercising real `Incomplete`/`Complete`
   round-tripping (two-pass, local emulation).
+- The Dio now owns base query semantics: `Dio::with_condition_eq(col, val)` and
+  `Dio::with_order(col, dir)` define *what the table is*, and every scenery
+  opened on the Dio inherits them (a view may still layer its own conditions and
+  override the sort). Native columns flow through the existing per-`(conditions,
+  sort)` index / local-filter path; pushdown-vs-local routing for augmented
+  columns arrives with the local-emulation work.
 
 ## 0.6.7 — 2026-06-28
 

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -7,7 +7,10 @@
   non-persistent `CacheBackend` mirroring the redb backend's per-Dio-named-table
   and per-row `CacheStatus` semantics. Lets ephemeral Dios and tests skip the
   `TempDir`/redb file while still exercising real `Incomplete`/`Complete`
-  round-tripping (two-pass, local emulation).
+  round-tripping (two-pass, local emulation). `MemoryCache` yields once per
+  operation so schedule-sensitive consumers see the same interleaving as the
+  redb backend (whose `spawn_blocking` boundary suspends). `MemoryCache`,
+  `CacheStatus`, and `CacheTable` are now re-exported at the crate root.
 - The Dio now owns base query semantics: `Dio::with_condition_eq(col, val)` and
   `Dio::with_order(col, dir)` define *what the table is*, and every scenery
   opened on the Dio inherits them (a view may still layer its own conditions and

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -14,6 +14,14 @@
   override the sort). Native columns flow through the existing per-`(conditions,
   sort)` index / local-filter path; pushdown-vs-local routing for augmented
   columns arrives with the local-emulation work.
+- Augmentation is now owned by the Dio, not the Lens: `Dio::augment(catalog,
+  augmentations)` configures the two-pass list/detail/refresh, so Dios sharing a
+  Lens can enrich differently. The pass bodies moved to a shared
+  `dio::augment_passes` module; the Dio records its *augmented columns* (the
+  merged columns), the signal that a condition/sort on a client-side column must
+  be emulated locally rather than pushed to the master. `Lens::augment` still
+  works (delegates to the same passes) and will be retired once consumers move to
+  the Dio API.
 
 ## 0.6.7 — 2026-06-28
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.7"
+version = "0.7.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/augment_passes.rs
+++ b/vantage-diorama/src/dio/augment_passes.rs
@@ -50,7 +50,8 @@ pub(crate) async fn load_detail_with(
     let mut row = dio.cache().get_value(&id).await?.unwrap_or_default();
     let master_id_column = dio.master().get_id_column().unwrap_or("id").to_string();
     for aug in augmentations {
-        aug.augment_row(&master_id_column, &mut row, catalog).await?;
+        aug.augment_row(&master_id_column, &mut row, catalog)
+            .await?;
     }
     Ok(row)
 }

--- a/vantage-diorama/src/dio/augment_passes.rs
+++ b/vantage-diorama/src/dio/augment_passes.rs
@@ -1,0 +1,157 @@
+//! The two-pass augmentation passes, owned by the Dio.
+//!
+//! A Dio configured with [`Dio::augment`](crate::Dio::augment) drives its own
+//! list / detail / refresh passes from the augmentation config it holds, instead
+//! of the Lens carrying them. These free functions are the shared bodies: the
+//! Dio path calls them reading config off `DioInner`, and the legacy
+//! `Lens::augment` synthesis (`lens::build`) delegates here too, so there's one
+//! definition of each pass.
+
+use ciborium::Value as CborValue;
+use vantage_core::Result;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_types::Record;
+use vantage_vista_factory::VistaCatalog;
+
+use crate::augment::Augmentation;
+use crate::dio::Dio;
+use crate::lens::CacheStatus;
+use crate::ops::QueryDescriptor;
+
+/// Capability-aware **list pass**: push the `[offset, offset+limit)` window down
+/// to the master when it advertises `can_fetch_window`, otherwise list the whole
+/// set and window it locally so sequential paging still terminates.
+pub(crate) async fn list_page(
+    dio: &Dio,
+    desc: QueryDescriptor,
+) -> Result<Vec<(String, Record<CborValue>)>> {
+    let master = dio.master();
+    if master.capabilities().can_fetch_window {
+        master.fetch_window(desc.offset, desc.limit).await
+    } else {
+        let rows = master.list_values().await?;
+        Ok(rows
+            .into_iter()
+            .skip(desc.offset)
+            .take(desc.limit)
+            .collect())
+    }
+}
+
+/// **Detail pass**: read the cheap list-pass row from the cache, run every
+/// [`Augmentation`] against it (resolve a detail Vista, fetch, merge), return the
+/// enriched row.
+pub(crate) async fn load_detail_with(
+    dio: &Dio,
+    id: String,
+    catalog: &VistaCatalog,
+    augmentations: &[Augmentation],
+) -> Result<Record<CborValue>> {
+    let mut row = dio.cache().get_value(&id).await?.unwrap_or_default();
+    let master_id_column = dio.master().get_id_column().unwrap_or("id").to_string();
+    for aug in augmentations {
+        aug.augment_row(&master_id_column, &mut row, catalog).await?;
+    }
+    Ok(row)
+}
+
+/// **Refresh pass**: re-run the cheap list pass and reconcile against the cache
+/// without discarding still-valid augmentation. Unchanged list fields keep their
+/// hydrated detail columns + `Complete` status; changed ones merge the fresh
+/// list values and demote to `Incomplete` (re-hydrate on next viewport); new ids
+/// stub `Incomplete`; vanished ids are deleted.
+pub(crate) async fn refresh(dio: &Dio) -> Result<()> {
+    let fresh = dio.master().list_values().await?;
+    let cache = dio.cache();
+    let existing = cache.list_values_with_status().await?;
+
+    for (id, list_row) in &fresh {
+        match existing.get(id) {
+            Some((old, _)) => {
+                if !list_fields_changed(list_row, old) {
+                    continue;
+                }
+                let mut merged = old.clone();
+                for (k, v) in list_row {
+                    merged.insert(k.clone(), v.clone());
+                }
+                cache
+                    .insert_value_with_status(id, &merged, CacheStatus::Incomplete)
+                    .await?;
+            }
+            None => {
+                cache
+                    .insert_value_with_status(id, list_row, CacheStatus::Incomplete)
+                    .await?;
+            }
+        }
+    }
+    for id in existing.keys() {
+        if !fresh.contains_key(id) {
+            cache.delete_value(id).await?;
+        }
+    }
+    Ok(())
+}
+
+/// True when any field the list pass paints differs from the cached record. Only
+/// keys present in `list_row` are compared — the detail pass's own columns (which
+/// exist only in `cached`) are never inspected.
+pub(crate) fn list_fields_changed(
+    list_row: &Record<CborValue>,
+    cached: &Record<CborValue>,
+) -> bool {
+    list_row.iter().any(|(k, v)| cached.get(k) != Some(v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::list_fields_changed;
+    use ciborium::Value;
+    use vantage_types::Record;
+
+    fn rec(pairs: &[(&str, Value)]) -> Record<Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn unchanged_list_fields_ignore_augmented_columns() {
+        let list = rec(&[
+            ("status", Value::from("LIVE")),
+            ("updated_at", Value::from("t1")),
+        ]);
+        let cached = rec(&[
+            ("status", Value::from("LIVE")),
+            ("updated_at", Value::from("t1")),
+            ("subject_area", Value::from("finance")),
+        ]);
+        assert!(!list_fields_changed(&list, &cached));
+    }
+
+    #[test]
+    fn a_changed_non_augmented_field_is_detected() {
+        let list = rec(&[
+            ("status", Value::from("DECOMMISSIONED")),
+            ("updated_at", Value::from("t2")),
+        ]);
+        let cached = rec(&[
+            ("status", Value::from("LIVE")),
+            ("updated_at", Value::from("t1")),
+            ("subject_area", Value::from("finance")),
+        ]);
+        assert!(list_fields_changed(&list, &cached));
+    }
+
+    #[test]
+    fn a_new_list_key_absent_from_cache_counts_as_changed() {
+        let list = rec(&[
+            ("status", Value::from("LIVE")),
+            ("region", Value::from("eu")),
+        ]);
+        let cached = rec(&[("status", Value::from("LIVE"))]);
+        assert!(list_fields_changed(&list, &cached));
+    }
+}

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -100,10 +100,8 @@ pub(crate) struct DioInner {
     /// own two-pass list/detail/refresh from this config (see `augment_passes`);
     /// `augmented_columns` is the union of every augmentation's merged columns,
     /// used to route conditions/sort on a client-side column to local emulation.
-    pub(crate) augmentations:
-        std::sync::RwLock<Option<Arc<Vec<crate::augment::Augmentation>>>>,
-    pub(crate) augment_catalog:
-        std::sync::RwLock<Option<Arc<vantage_vista_factory::VistaCatalog>>>,
+    pub(crate) augmentations: std::sync::RwLock<Option<Arc<Vec<crate::augment::Augmentation>>>>,
+    pub(crate) augment_catalog: std::sync::RwLock<Option<Arc<vantage_vista_factory::VistaCatalog>>>,
     pub(crate) augmented_columns: std::sync::RwLock<std::collections::HashSet<String>>,
     /// Deduplicating registry of live table sceneries, keyed by
     /// `(shape, conditions, sort, search)`. Holds `Weak` handles so it
@@ -285,11 +283,7 @@ impl Dio {
     /// a capable master pushes down; a column the master can't filter (or an
     /// augmented one) is emulated locally over the cache. Returns a clone so
     /// calls chain. Conditions take effect for sceneries opened afterwards.
-    pub fn with_condition_eq(
-        &self,
-        col: impl Into<String>,
-        value: impl Into<CborValue>,
-    ) -> Self {
+    pub fn with_condition_eq(&self, col: impl Into<String>, value: impl Into<CborValue>) -> Self {
         self.inner
             .base_conditions
             .write()

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod augment_passes;
 pub mod diagnostics;
 pub mod event_bus;
 pub mod hot_tier;
@@ -95,6 +96,15 @@ pub(crate) struct DioInner {
     /// further per-view conditions/sort on top (see `TableSceneryBuilder`).
     pub(crate) base_conditions: std::sync::RwLock<Vec<(String, CborValue)>>,
     pub(crate) base_sort: std::sync::RwLock<Option<(String, crate::scenery::SortDir)>>,
+    /// Augmentation owned by the Dio (not the Lens). When set, the Dio drives its
+    /// own two-pass list/detail/refresh from this config (see `augment_passes`);
+    /// `augmented_columns` is the union of every augmentation's merged columns,
+    /// used to route conditions/sort on a client-side column to local emulation.
+    pub(crate) augmentations:
+        std::sync::RwLock<Option<Arc<Vec<crate::augment::Augmentation>>>>,
+    pub(crate) augment_catalog:
+        std::sync::RwLock<Option<Arc<vantage_vista_factory::VistaCatalog>>>,
+    pub(crate) augmented_columns: std::sync::RwLock<std::collections::HashSet<String>>,
     /// Deduplicating registry of live table sceneries, keyed by
     /// `(shape, conditions, sort, search)`. Holds `Weak` handles so it
     /// never keeps a scenery alive: opening the same query twice returns
@@ -116,6 +126,24 @@ impl DioInner {
             .entry(key.to_string())
             .or_insert_with(|| Arc::new(crate::dio::query_index::QueryIndex::new()))
             .clone()
+    }
+
+    /// Whether this Dio owns an augmentation config (drives its own two-pass).
+    pub(crate) fn has_dio_augment(&self) -> bool {
+        self.augmentations.read().unwrap().is_some()
+    }
+
+    /// Whether this Dio engages two-pass loading — either it owns augmentation
+    /// or its Lens registers a detail callback (legacy `Lens::augment` path).
+    pub(crate) fn is_two_pass(&self) -> bool {
+        self.has_dio_augment() || self.lens.callbacks.on_load_detail.is_some()
+    }
+
+    /// Whether `col` is produced by augmentation (a client-side column the master
+    /// can't filter/sort on) — the signal to route its conditions/sort to local
+    /// emulation. Always `false` until [`Dio::augment`] populates the set.
+    pub(crate) fn is_augmented_column(&self, col: &str) -> bool {
+        self.augmented_columns.read().unwrap().contains(col)
     }
 
     /// Return the live shared table scenery for `key`, or `None` if none is
@@ -279,6 +307,33 @@ impl Dio {
         self.clone()
     }
 
+    /// Configure two-pass augmentation on this Dio: a cheap master list pass plus
+    /// a per-row detail pass that resolves each [`Augmentation`]'s detail Vista
+    /// through `catalog`, fetches it, and merges its columns onto the row.
+    ///
+    /// Augmentation is a property of the Dio, not the Lens — so different Dios
+    /// sharing one Lens can enrich differently. The merged columns are recorded
+    /// as the Dio's *augmented columns*; a condition or sort on one of them is
+    /// client-side and routes to local emulation rather than master pushdown.
+    ///
+    /// Call before opening sceneries. Returns a clone so calls chain.
+    pub fn augment(
+        &self,
+        catalog: Arc<vantage_vista_factory::VistaCatalog>,
+        augmentations: Vec<crate::augment::Augmentation>,
+    ) -> Self {
+        let mut cols = std::collections::HashSet::new();
+        for aug in &augmentations {
+            for c in &aug.merge.columns {
+                cols.insert(c.clone());
+            }
+        }
+        *self.inner.augmented_columns.write().unwrap() = cols;
+        *self.inner.augment_catalog.write().unwrap() = Some(catalog);
+        *self.inner.augmentations.write().unwrap() = Some(Arc::new(augmentations));
+        self.clone()
+    }
+
     /// Start a [`TableScenery`] builder
     /// for this Dio. Chainable; call `.open().await` to spawn the
     /// reactive view.
@@ -423,7 +478,10 @@ impl Dio {
     /// Returns `Ok(())` immediately when no `on_refresh` is registered.
     pub async fn refresh(&self) -> Result<()> {
         let _ = self.inner.event_bus.send(DioEvent::Refreshing);
-        let result = if let Some(cb) = self.inner.lens.callbacks.on_refresh.as_ref() {
+        let result = if self.inner.has_dio_augment() {
+            // Dio owns augmentation → run its reconciling refresh pass.
+            augment_passes::refresh(self).await
+        } else if let Some(cb) = self.inner.lens.callbacks.on_refresh.as_ref() {
             cb(self).await
         } else {
             Ok(())

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -89,6 +89,12 @@ pub(crate) struct DioInner {
     pub(crate) query_indexes: std::sync::Mutex<
         std::collections::HashMap<String, Arc<crate::dio::query_index::QueryIndex>>,
     >,
+    /// Dio-level query semantics inherited by every scenery opened on this Dio.
+    /// The Dio — not the scenery — defines *what this table is*: a base set of
+    /// equality conditions and an optional default order. A scenery may layer
+    /// further per-view conditions/sort on top (see `TableSceneryBuilder`).
+    pub(crate) base_conditions: std::sync::RwLock<Vec<(String, CborValue)>>,
+    pub(crate) base_sort: std::sync::RwLock<Option<(String, crate::scenery::SortDir)>>,
     /// Deduplicating registry of live table sceneries, keyed by
     /// `(shape, conditions, sort, search)`. Holds `Weak` handles so it
     /// never keeps a scenery alive: opening the same query twice returns
@@ -237,6 +243,40 @@ impl Dio {
     #[doc(hidden)]
     pub async fn take_write_worker_handle(&self) -> Option<JoinHandle<()>> {
         self.inner.write_worker.lock().await.take()
+    }
+
+    /// Add a base equality condition that every scenery on this Dio inherits.
+    ///
+    /// The Dio owns query semantics: a condition set here defines *what this
+    /// table is* (e.g. "the John-filtered collection"), so all views — grids,
+    /// pickers, detail panes — see the same narrowed dataset. A scenery may add
+    /// further per-view conditions on top via
+    /// [`where_eq`](crate::scenery::TableSceneryBuilder::where_eq).
+    ///
+    /// How the condition is honoured depends on the column: a native column on
+    /// a capable master pushes down; a column the master can't filter (or an
+    /// augmented one) is emulated locally over the cache. Returns a clone so
+    /// calls chain. Conditions take effect for sceneries opened afterwards.
+    pub fn with_condition_eq(
+        &self,
+        col: impl Into<String>,
+        value: impl Into<CborValue>,
+    ) -> Self {
+        self.inner
+            .base_conditions
+            .write()
+            .unwrap()
+            .push((col.into(), value.into()));
+        self.clone()
+    }
+
+    /// Set the Dio's default order, inherited by every scenery that doesn't set
+    /// its own sort. Like [`with_condition_eq`](Self::with_condition_eq), the
+    /// Dio owns ordering — native+orderable columns push down, others sort
+    /// locally over the cache. Returns a clone so calls chain.
+    pub fn with_order(&self, col: impl Into<String>, dir: crate::scenery::SortDir) -> Self {
+        *self.inner.base_sort.write().unwrap() = Some((col.into(), dir));
+        self.clone()
     }
 
     /// Start a [`TableScenery`] builder

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use ciborium::Value as CborValue;
 use tokio::runtime::Handle;
-use vantage_dataset::traits::ReadableValueSet;
-use vantage_types::Record;
 use vantage_vista_factory::VistaCatalog;
 
 use crate::augment::Augmentation;
 use crate::dio::Dio;
+use crate::dio::augment_passes;
 use crate::error::LensBuildError;
-use crate::lens::CacheStatus;
 
 use super::callbacks::{
     DioCallback, DioListPageCallback, DioLoadDetailCallback, boxed_dio_callback,
@@ -77,37 +74,17 @@ impl LensBuilder {
     }
 }
 
-/// Capability-aware list pass for an augmented Dio.
-///
-/// When the master advertises `can_fetch_window` the requested
-/// `[offset, offset+limit)` slice is pushed down to the driver; otherwise it
-/// falls back to a full `list_values` windowed locally so sequential paging
-/// still terminates. This is the generic form of what apps previously hand-rolled
-/// — and it stops over-fetching the whole set on every page where the backend can
-/// window.
+/// Capability-aware list pass for an augmented Dio — delegates to the shared
+/// [`augment_passes::list_page`].
 fn synth_list_page() -> DioListPageCallback {
     boxed_list_page_callback(move |dio: &Dio, desc| {
         let dio = dio.clone();
-        async move {
-            let master = dio.master();
-            if master.capabilities().can_fetch_window {
-                master.fetch_window(desc.offset, desc.limit).await
-            } else {
-                use vantage_dataset::traits::ReadableValueSet;
-                let rows = master.list_values().await?;
-                Ok(rows
-                    .into_iter()
-                    .skip(desc.offset)
-                    .take(desc.limit)
-                    .collect())
-            }
-        }
+        async move { augment_passes::list_page(&dio, desc).await }
     })
 }
 
-/// Augmentation detail pass: read the cheap list-pass row from the cache, run
-/// every [`Augmentation`] against it (resolve a detail Vista, fetch, merge), and
-/// return the enriched row.
+/// Augmentation detail pass — delegates to [`augment_passes::load_detail_with`],
+/// capturing the Lens-level catalog + augmentations.
 fn synth_load_detail(
     catalog: Arc<VistaCatalog>,
     augmentations: Arc<Vec<Augmentation>>,
@@ -116,129 +93,14 @@ fn synth_load_detail(
         let dio = dio.clone();
         let catalog = catalog.clone();
         let augmentations = augmentations.clone();
-        async move {
-            let mut row = dio.cache().get_value(&id).await?.unwrap_or_default();
-            let master_id_column = dio.master().get_id_column().unwrap_or("id").to_string();
-            for aug in augmentations.iter() {
-                aug.augment_row(&master_id_column, &mut row, &catalog)
-                    .await?;
-            }
-            Ok(row)
-        }
+        async move { augment_passes::load_detail_with(&dio, id, &catalog, &augmentations).await }
     })
 }
 
-/// Augmentation refresh: re-run the cheap **list pass** and reconcile it against
-/// the cache without throwing away augmentation that is still valid.
-///
-/// Per id, only the keys the list pass paints are compared (the *non-augmented*
-/// fields — the detail pass merges its columns on top). The verdict:
-///
-/// - **unchanged** list fields → leave the row as-is, keeping its hydrated detail
-///   columns and `Complete` status (no re-augmentation).
-/// - **changed** list fields → merge the fresh list values onto the cached record
-///   and demote it to `Incomplete`, so the detail pass re-runs when it's next
-///   visible.
-/// - **new** id → stub `Incomplete`.
-/// - **gone** (cached but no longer listed) → delete.
-///
-/// `dio.refresh()` (driven by an app's auto-refresh / change-probe) invokes this;
-/// demoting to `Incomplete` is what restarts hydration on the next viewport pass.
+/// Augmentation refresh — delegates to [`augment_passes::refresh`].
 fn synth_refresh() -> DioCallback {
     boxed_dio_callback(move |dio: &Dio| {
         let dio = dio.clone();
-        async move {
-            let fresh = dio.master().list_values().await?;
-            let cache = dio.cache();
-            let existing = cache.list_values_with_status().await?;
-
-            for (id, list_row) in &fresh {
-                match existing.get(id) {
-                    Some((old, _)) => {
-                        if !list_fields_changed(list_row, old) {
-                            continue;
-                        }
-                        let mut merged = old.clone();
-                        for (k, v) in list_row {
-                            merged.insert(k.clone(), v.clone());
-                        }
-                        cache
-                            .insert_value_with_status(id, &merged, CacheStatus::Incomplete)
-                            .await?;
-                    }
-                    None => {
-                        cache
-                            .insert_value_with_status(id, list_row, CacheStatus::Incomplete)
-                            .await?;
-                    }
-                }
-            }
-            for id in existing.keys() {
-                if !fresh.contains_key(id) {
-                    cache.delete_value(id).await?;
-                }
-            }
-            Ok(())
-        }
+        async move { augment_passes::refresh(&dio).await }
     })
-}
-
-/// True when any field the list pass paints differs from the cached record. Only
-/// keys present in `list_row` are compared — the detail pass's own columns (which
-/// exist only in `cached`) are never inspected, so a row whose list fields are
-/// byte-for-byte equal is left untouched.
-fn list_fields_changed(list_row: &Record<CborValue>, cached: &Record<CborValue>) -> bool {
-    list_row.iter().any(|(k, v)| cached.get(k) != Some(v))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::list_fields_changed;
-    use ciborium::Value;
-    use vantage_types::Record;
-
-    fn rec(pairs: &[(&str, Value)]) -> Record<Value> {
-        pairs
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.clone()))
-            .collect()
-    }
-
-    #[test]
-    fn unchanged_list_fields_ignore_augmented_columns() {
-        let list = rec(&[
-            ("status", Value::from("LIVE")),
-            ("updated_at", Value::from("t1")),
-        ]);
-        let cached = rec(&[
-            ("status", Value::from("LIVE")),
-            ("updated_at", Value::from("t1")),
-            ("subject_area", Value::from("finance")),
-        ]);
-        assert!(!list_fields_changed(&list, &cached));
-    }
-
-    #[test]
-    fn a_changed_non_augmented_field_is_detected() {
-        let list = rec(&[
-            ("status", Value::from("DECOMMISSIONED")),
-            ("updated_at", Value::from("t2")),
-        ]);
-        let cached = rec(&[
-            ("status", Value::from("LIVE")),
-            ("updated_at", Value::from("t1")),
-            ("subject_area", Value::from("finance")),
-        ]);
-        assert!(list_fields_changed(&list, &cached));
-    }
-
-    #[test]
-    fn a_new_list_key_absent_from_cache_counts_as_changed() {
-        let list = rec(&[
-            ("status", Value::from("LIVE")),
-            ("region", Value::from("eu")),
-        ]);
-        let cached = rec(&[("status", Value::from("LIVE"))]);
-        assert!(list_fields_changed(&list, &cached));
-    }
 }

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -51,6 +51,8 @@ impl Lens {
             hot_tier: Arc::new(HotTier::new()),
             query_indexes: std::sync::Mutex::new(std::collections::HashMap::new()),
             table_sceneries: std::sync::Mutex::new(std::collections::HashMap::new()),
+            base_conditions: std::sync::RwLock::new(Vec::new()),
+            base_sort: std::sync::RwLock::new(None),
         });
         let dio = Dio { inner };
 

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -53,6 +53,9 @@ impl Lens {
             table_sceneries: std::sync::Mutex::new(std::collections::HashMap::new()),
             base_conditions: std::sync::RwLock::new(Vec::new()),
             base_sort: std::sync::RwLock::new(None),
+            augmentations: std::sync::RwLock::new(None),
+            augment_catalog: std::sync::RwLock::new(None),
+            augmented_columns: std::sync::RwLock::new(std::collections::HashSet::new()),
         });
         let dio = Dio { inner };
 

--- a/vantage-diorama/src/lens/memory_cache.rs
+++ b/vantage-diorama/src/lens/memory_cache.rs
@@ -56,11 +56,20 @@ impl MemoryCacheTable {
     fn lock(&self) -> std::sync::MutexGuard<'_, IndexMap<String, (Record<CborValue>, CacheStatus)>> {
         self.rows.lock().expect("MemoryCacheTable mutex poisoned")
     }
+
+    /// Yield once per operation so this backend is a well-behaved async citizen.
+    /// The redb backend suspends at a `spawn_blocking` boundary on every call;
+    /// matching that here keeps schedule-sensitive consumers (e.g. event-ordered
+    /// reactors) seeing the same interleaving regardless of which cache backs them.
+    async fn yield_point() {
+        tokio::task::yield_now().await;
+    }
 }
 
 #[async_trait]
 impl CacheTable for MemoryCacheTable {
     async fn list_values(&self) -> Result<IndexMap<String, Record<CborValue>>> {
+        Self::yield_point().await;
         Ok(self
             .lock()
             .iter()
@@ -69,16 +78,19 @@ impl CacheTable for MemoryCacheTable {
     }
 
     async fn get_value(&self, id: &str) -> Result<Option<Record<CborValue>>> {
+        Self::yield_point().await;
         Ok(self.lock().get(id).map(|(rec, _)| rec.clone()))
     }
 
     async fn insert_value(&self, id: &str, record: &Record<CborValue>) -> Result<()> {
+        Self::yield_point().await;
         self.lock()
             .insert(id.to_string(), (record.clone(), CacheStatus::Complete));
         Ok(())
     }
 
     async fn insert_values(&self, rows: IndexMap<String, Record<CborValue>>) -> Result<()> {
+        Self::yield_point().await;
         let mut guard = self.lock();
         for (id, record) in rows {
             guard.insert(id, (record, CacheStatus::Complete));
@@ -87,16 +99,19 @@ impl CacheTable for MemoryCacheTable {
     }
 
     async fn delete_value(&self, id: &str) -> Result<()> {
+        Self::yield_point().await;
         self.lock().shift_remove(id);
         Ok(())
     }
 
     async fn clear(&self) -> Result<()> {
+        Self::yield_point().await;
         self.lock().clear();
         Ok(())
     }
 
     async fn count(&self) -> Result<i64> {
+        Self::yield_point().await;
         Ok(self.lock().len() as i64)
     }
 
@@ -106,6 +121,7 @@ impl CacheTable for MemoryCacheTable {
         record: &Record<CborValue>,
         status: CacheStatus,
     ) -> Result<()> {
+        Self::yield_point().await;
         self.lock()
             .insert(id.to_string(), (record.clone(), status));
         Ok(())
@@ -115,12 +131,14 @@ impl CacheTable for MemoryCacheTable {
         &self,
         id: &str,
     ) -> Result<Option<(Record<CborValue>, CacheStatus)>> {
+        Self::yield_point().await;
         Ok(self.lock().get(id).cloned())
     }
 
     async fn list_values_with_status(
         &self,
     ) -> Result<IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+        Self::yield_point().await;
         Ok(self.lock().clone())
     }
 }

--- a/vantage-diorama/src/lens/memory_cache.rs
+++ b/vantage-diorama/src/lens/memory_cache.rs
@@ -53,7 +53,9 @@ pub struct MemoryCacheTable {
 }
 
 impl MemoryCacheTable {
-    fn lock(&self) -> std::sync::MutexGuard<'_, IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+    fn lock(
+        &self,
+    ) -> std::sync::MutexGuard<'_, IndexMap<String, (Record<CborValue>, CacheStatus)>> {
         self.rows.lock().expect("MemoryCacheTable mutex poisoned")
     }
 
@@ -122,8 +124,7 @@ impl CacheTable for MemoryCacheTable {
         status: CacheStatus,
     ) -> Result<()> {
         Self::yield_point().await;
-        self.lock()
-            .insert(id.to_string(), (record.clone(), status));
+        self.lock().insert(id.to_string(), (record.clone(), status));
         Ok(())
     }
 

--- a/vantage-diorama/src/lens/memory_cache.rs
+++ b/vantage-diorama/src/lens/memory_cache.rs
@@ -1,0 +1,126 @@
+//! In-memory [`CacheBackend`] — one `IndexMap` per Dio, no persistence.
+//!
+//! The redb backend ([`RedbCache`](super::redb_cache::RedbCache)) is the
+//! production path; this mirrors its semantics (including per-row
+//! [`CacheStatus`]) without a file, so tests don't need a `TempDir` and
+//! two-pass / local-emulation suites see real `Incomplete`/`Complete`
+//! round-tripping.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_types::Record;
+
+use super::cache_backend::{CacheBackend, CacheStatus, CacheTable};
+
+/// In-memory cache backend. Each named table is memoized, so repeat
+/// `open_table` calls for the same name return the same handle (matching
+/// [`RedbCache`](super::redb_cache::RedbCache)).
+#[derive(Default)]
+pub struct MemoryCache {
+    opened: Mutex<IndexMap<String, Arc<MemoryCacheTable>>>,
+}
+
+impl MemoryCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl CacheBackend for MemoryCache {
+    async fn open_table(&self, name: &str) -> Result<Arc<dyn CacheTable>> {
+        let mut opened = self.opened.lock().expect("MemoryCache mutex poisoned");
+        if let Some(existing) = opened.get(name) {
+            return Ok(existing.clone() as Arc<dyn CacheTable>);
+        }
+        let table = Arc::new(MemoryCacheTable::default());
+        opened.insert(name.to_string(), table.clone());
+        Ok(table as Arc<dyn CacheTable>)
+    }
+
+    fn name(&self) -> &'static str {
+        "memory"
+    }
+}
+
+#[derive(Default)]
+pub struct MemoryCacheTable {
+    rows: Mutex<IndexMap<String, (Record<CborValue>, CacheStatus)>>,
+}
+
+impl MemoryCacheTable {
+    fn lock(&self) -> std::sync::MutexGuard<'_, IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+        self.rows.lock().expect("MemoryCacheTable mutex poisoned")
+    }
+}
+
+#[async_trait]
+impl CacheTable for MemoryCacheTable {
+    async fn list_values(&self) -> Result<IndexMap<String, Record<CborValue>>> {
+        Ok(self
+            .lock()
+            .iter()
+            .map(|(id, (rec, _))| (id.clone(), rec.clone()))
+            .collect())
+    }
+
+    async fn get_value(&self, id: &str) -> Result<Option<Record<CborValue>>> {
+        Ok(self.lock().get(id).map(|(rec, _)| rec.clone()))
+    }
+
+    async fn insert_value(&self, id: &str, record: &Record<CborValue>) -> Result<()> {
+        self.lock()
+            .insert(id.to_string(), (record.clone(), CacheStatus::Complete));
+        Ok(())
+    }
+
+    async fn insert_values(&self, rows: IndexMap<String, Record<CborValue>>) -> Result<()> {
+        let mut guard = self.lock();
+        for (id, record) in rows {
+            guard.insert(id, (record, CacheStatus::Complete));
+        }
+        Ok(())
+    }
+
+    async fn delete_value(&self, id: &str) -> Result<()> {
+        self.lock().shift_remove(id);
+        Ok(())
+    }
+
+    async fn clear(&self) -> Result<()> {
+        self.lock().clear();
+        Ok(())
+    }
+
+    async fn count(&self) -> Result<i64> {
+        Ok(self.lock().len() as i64)
+    }
+
+    async fn insert_value_with_status(
+        &self,
+        id: &str,
+        record: &Record<CborValue>,
+        status: CacheStatus,
+    ) -> Result<()> {
+        self.lock()
+            .insert(id.to_string(), (record.clone(), status));
+        Ok(())
+    }
+
+    async fn get_value_with_status(
+        &self,
+        id: &str,
+    ) -> Result<Option<(Record<CborValue>, CacheStatus)>> {
+        Ok(self.lock().get(id).cloned())
+    }
+
+    async fn list_values_with_status(
+        &self,
+    ) -> Result<IndexMap<String, (Record<CborValue>, CacheStatus)>> {
+        Ok(self.lock().clone())
+    }
+}

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -5,6 +5,7 @@ pub mod callbacks;
 pub mod chunk_sink;
 pub mod defaults;
 pub mod make_dio;
+pub mod memory_cache;
 pub mod redb_cache;
 
 use std::ops::Range;
@@ -31,6 +32,7 @@ pub use callbacks::{
 };
 pub use chunk_sink::{ChunkRow, ChunkSink, SceneryChunkTarget};
 pub use defaults::LensDefaults;
+pub use memory_cache::{MemoryCache, MemoryCacheTable};
 pub use redb_cache::{RedbCache, RedbCacheTable};
 
 /// Long-lived shared infrastructure for caching, callbacks, and refresh.
@@ -160,6 +162,13 @@ impl LensBuilder {
                 ..self
             },
         }
+    }
+
+    /// Convenience: cache to a process-local in-memory store. No file, no
+    /// persistence — handy for tests and ephemeral Dios. Mirrors
+    /// [`cache_at`](Self::cache_at)'s per-Dio-named-table + status semantics.
+    pub fn cache_in_memory(self) -> Self {
+        self.cache_source(Arc::new(MemoryCache::new()))
     }
 
     /// Register the `on_start` callback. Fires once when a Dio is built

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -19,9 +19,10 @@ pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
 pub use dio::{Dio, DioEvent, DioShell, Generation};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
-    Activity, ActivitySignal, CacheBackend, ChunkRow, ChunkSink, DioCallback, DioEventCallback,
-    DioLoadChunkCallback, DioQueryCallback, DioTotalProviderCallback, DioWriteCallback, Lens,
-    LensBuilder, LensCallbacks, LensDefaults,
+    Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkRow, ChunkSink,
+    DioCallback, DioEventCallback, DioLoadChunkCallback, DioQueryCallback,
+    DioTotalProviderCallback, DioWriteCallback, Lens, LensBuilder, LensCallbacks, LensDefaults,
+    MemoryCache, MemoryCacheTable,
 };
 pub use ops::{ChangeEvent, QueryDescriptor, WriteOp};
 pub use scenery::{

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -151,11 +151,11 @@ impl TableSceneryBuilder {
 
         let master_capabilities = dio.master.read().unwrap().capabilities().clone();
 
-        // Two-pass engages only when the Lens registers an `on_load_detail`
-        // callback. The shared per-query index is keyed by the master Vista's
-        // index_key over the scenery's conditions + sort, so reopening the same
-        // variant reuses the already-built index.
-        let two_pass = dio.lens.callbacks.on_load_detail.is_some();
+        // Two-pass engages when the Dio owns augmentation, or (legacy) the Lens
+        // registers an `on_load_detail` callback. The shared per-query index is
+        // keyed by the master Vista's index_key over the scenery's conditions +
+        // sort, so reopening the same variant reuses the already-built index.
+        let two_pass = dio.is_two_pass();
         let index = if two_pass {
             let vista_sort = sort.as_ref().map(|(col, dir)| {
                 let dir = match dir {

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -104,6 +104,21 @@ impl TableSceneryBuilder {
             titles_only,
         } = self;
 
+        // Inherit the Dio's base query semantics. The Dio owns "what this table
+        // is" (base conditions + default order); this view layers its own
+        // conditions on top and falls back to the Dio's order when it sets none.
+        let conditions = {
+            let base = dio.base_conditions.read().unwrap();
+            if base.is_empty() {
+                conditions
+            } else {
+                let mut merged = base.clone();
+                merged.extend(conditions);
+                merged
+            }
+        };
+        let sort = sort.or_else(|| dio.base_sort.read().unwrap().clone());
+
         // Dedup key over (shape, conditions, sort, search, titles_only). A live
         // scenery for the same query is shared — one reactor, one cache window,
         // one in-flight JoinSet — instead of standing up a parallel copy. A

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -156,6 +156,15 @@ impl TableSceneryBuilder {
         // keyed by the master Vista's index_key over the scenery's conditions +
         // sort, so reopening the same variant reuses the already-built index.
         let two_pass = dio.is_two_pass();
+        // Two-pass can't push conditions/sort to its list pass, so any
+        // condition/sort means the visible set must be refined locally over the
+        // cache (this is also the only way an augmented-column filter can work —
+        // the column exists only after hydration). A picker (`titles_only`) keeps
+        // raw list order — it never hydrates, so it can't evaluate augmented
+        // predicates anyway.
+        let local_refine = two_pass
+            && !titles_only
+            && (!conditions.is_empty() || sort.is_some() || search.is_some());
         let index = if two_pass {
             let vista_sort = sort.as_ref().map(|(col, dir)| {
                 let dir = match dir {
@@ -194,6 +203,7 @@ impl TableSceneryBuilder {
             load_push_count: AtomicUsize::new(0),
             master_capabilities,
             two_pass,
+            local_refine,
             titles_only,
             index: RwLock::new(index),
             registry_key: Mutex::new(Some(key.clone())),
@@ -220,6 +230,13 @@ impl TableSceneryBuilder {
                 super::two_pass::run_list_page(state.clone()).await;
             } else {
                 super::two_pass::seed_from_index(&state).await;
+                state.bump_generation();
+            }
+            // Locally-refined views filter/sort the just-seeded rows over the
+            // cache. With an augmented-column condition this yields an empty set
+            // until hydration confirms matches.
+            if state.local_refine {
+                super::two_pass::reseed_filtered(&state).await;
                 state.bump_generation();
             }
         } else {

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -126,6 +126,11 @@ impl Drop for SceneryGuard {
 
 impl TableScenery for TableSceneryImpl {
     fn row_count(&self) -> usize {
+        // A locally-refined view's visible map is authoritative — the index may
+        // hold more ids than match the filter.
+        if self.inner.local_refine {
+            return self.inner.rows.read().unwrap().len();
+        }
         if let Some(index) = self.inner.index() {
             return index.len();
         }
@@ -152,6 +157,11 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn has_more(&self) -> bool {
+        // A locally-refined view materializes its whole visible set from the
+        // (already-listed) index, so there is no further page to ask for.
+        if self.inner.local_refine {
+            return false;
+        }
         // Two-pass / sequential no-total: more pages exist until the list pass
         // sees a short or empty page.
         if let Some(index) = self.inner.index() {
@@ -166,6 +176,9 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn estimated_total(&self) -> Option<usize> {
+        if self.inner.local_refine {
+            return Some(self.inner.rows.read().unwrap().len());
+        }
         // Two-pass: the running index length is the best estimate; it grows as
         // pages load and freezes once the list pass completes.
         if let Some(index) = self.inner.index() {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -80,6 +80,14 @@ pub(crate) struct TableSceneryState {
     // the legacy single-pass path.
     /// Whether this scenery drives two-pass (list + detail) loading.
     pub(crate) two_pass: bool,
+    /// Two-pass only: whether the visible set is *locally refined* — its rows are
+    /// filtered/sorted over the cache rather than served in raw index order.
+    /// Engaged when the query carries conditions/sort the list pass can't push to
+    /// the master (today, any condition/sort in two-pass — augmented columns in
+    /// particular, which only exist after hydration). When set, the visible
+    /// `rows` map is authoritative for `row_count` (the index may hold more ids
+    /// than match the filter).
+    pub(crate) local_refine: bool,
     /// Dropdown / autocomplete projection: serve the cheap list columns and
     /// **skip the detail pass** even on a two-pass table. The list pass still
     /// runs (rows carry id + title columns); per-row hydration never fires.

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -65,6 +65,66 @@ async fn seed_rows(
     }
 }
 
+/// Rebuild the visible map for a **locally-refined** two-pass scenery: take the
+/// index's ids, read each row's current cache record + status, keep those that
+/// match the conditions/search, sort locally if requested, and renumber. An
+/// augmented-column condition naturally excludes rows not yet hydrated (the
+/// column is absent → no match), so matches surface as rows hydrate. The row's
+/// `Fresh`/`Incomplete` status is preserved.
+pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
+    use super::helpers::{cbor_cmp, matches_conditions, matches_search};
+
+    let Some(dio_inner) = state.dio_weak.upgrade() else {
+        return;
+    };
+    let Some(index) = state.index() else {
+        return;
+    };
+    let ids = index.ids();
+    let conditions = state.conditions.read().unwrap().clone();
+    let search = state.search.read().unwrap().clone();
+    let sort = state.sort.read().unwrap().clone();
+
+    let mut gathered: Vec<(String, vantage_types::Record<ciborium::Value>, CacheStatus)> =
+        Vec::with_capacity(ids.len());
+    for id in &ids {
+        if let Some((rec, status)) = dio_inner
+            .cache
+            .get_value_with_status(id)
+            .await
+            .ok()
+            .flatten()
+        {
+            if matches_conditions(&rec, &conditions) && matches_search(&rec, search.as_deref()) {
+                gathered.push((id.clone(), rec, status));
+            }
+        }
+    }
+
+    if let Some((col, dir)) = &sort {
+        gathered.sort_by(|(_, a, _), (_, b, _)| {
+            let ord = cbor_cmp(a.get(col), b.get(col));
+            match dir {
+                SortDir::Asc => ord,
+                SortDir::Desc => ord.reverse(),
+            }
+        });
+    }
+
+    let mut rows = std::collections::BTreeMap::new();
+    let mut id_to_idx = std::collections::HashMap::new();
+    for (i, (id, rec, status)) in gathered.into_iter().enumerate() {
+        let enriched = match status {
+            CacheStatus::Complete => EnrichedRecord::fresh(rec),
+            CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
+        };
+        rows.insert(i, Arc::new(enriched));
+        id_to_idx.insert(id, i);
+    }
+    *state.rows.write().unwrap() = rows;
+    *state.id_to_idx.write().unwrap() = id_to_idx;
+}
+
 /// Seed the scenery's sparse map from an already-populated shared index
 /// (reused across filter switches) without issuing any list call.
 pub(crate) async fn seed_from_index(state: &Arc<TableSceneryState>) {
@@ -253,6 +313,15 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     if !dio_inner.has_dio_augment() && dio_inner.lens.callbacks.on_load_detail.is_none() {
         return;
     }
+    // A locally-refined view can't know which rows match an augmented-column
+    // predicate until they're hydrated, so it hydrates the whole index rather
+    // than just the visible window. (Bounded by the listed set; large sets pay
+    // for this — the documented cost of filtering on a client-side column.)
+    let range = if state.local_refine {
+        0..index.len()
+    } else {
+        range
+    };
     let dio = Dio {
         inner: dio_inner.clone(),
     };
@@ -316,7 +385,12 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
                     .cache
                     .insert_value_with_status(&id, &merged, CacheStatus::Complete)
                     .await;
-                if let Some(i) = state.id_to_idx.read().unwrap().get(&id).copied() {
+                // A locally-refined view re-derives its whole visible set after
+                // the loop (a freshly-hydrated row may now match/sort differently);
+                // a plain view updates the row's slot in place.
+                if !state.local_refine
+                    && let Some(i) = state.id_to_idx.read().unwrap().get(&id).copied()
+                {
                     state
                         .rows
                         .write()
@@ -326,7 +400,9 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
                 changed = true;
             }
             Err(e) => {
-                if let Some(i) = state.id_to_idx.read().unwrap().get(&id).copied() {
+                if !state.local_refine
+                    && let Some(i) = state.id_to_idx.read().unwrap().get(&id).copied()
+                {
                     let prev = state.rows.read().unwrap().get(&i).cloned();
                     if let Some(prev) = prev {
                         let failed = EnrichedRecord::detail_failed(
@@ -347,6 +423,11 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     }
 
     if changed {
+        // Re-derive the locally-refined visible set now that more rows are
+        // hydrated (newly-matching rows appear, no-longer-matching drop).
+        if state.local_refine {
+            reseed_filtered(&state).await;
+        }
         state.bump_generation();
     }
 }

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -94,10 +94,10 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
             .await
             .ok()
             .flatten()
+            && matches_conditions(&rec, &conditions)
+            && matches_search(&rec, search.as_deref())
         {
-            if matches_conditions(&rec, &conditions) && matches_search(&rec, search.as_deref()) {
-                gathered.push((id.clone(), rec, status));
-            }
+            gathered.push((id.clone(), rec, status));
         }
     }
 

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -91,9 +91,11 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     let Some(index) = state.index() else {
         return;
     };
-    let Some(cb) = dio_inner.lens.callbacks.on_list_page.as_ref() else {
+    // The list pass comes from the Dio's own augmentation (preferred) or the
+    // legacy Lens `on_list_page` callback. Bail if neither provides one.
+    if !dio_inner.has_dio_augment() && dio_inner.lens.callbacks.on_list_page.is_none() {
         return;
-    };
+    }
     if index.is_complete() {
         return;
     }
@@ -113,7 +115,12 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     let dio = Dio {
         inner: dio_inner.clone(),
     };
-    let result = cb(&dio, q).await;
+    let result = if dio_inner.has_dio_augment() {
+        crate::dio::augment_passes::list_page(&dio, q).await
+    } else {
+        let cb = dio_inner.lens.callbacks.on_list_page.as_ref().unwrap();
+        cb(&dio, q).await
+    };
 
     *state.list_in_flight.lock().unwrap() = false;
 
@@ -243,9 +250,9 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     let Some(index) = state.index() else {
         return;
     };
-    let Some(cb) = dio_inner.lens.callbacks.on_load_detail.as_ref() else {
+    if !dio_inner.has_dio_augment() && dio_inner.lens.callbacks.on_load_detail.is_none() {
         return;
-    };
+    }
     let dio = Dio {
         inner: dio_inner.clone(),
     };
@@ -275,7 +282,20 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
             }
         }
 
-        let result = cb(&dio, id.clone()).await;
+        let result = if dio_inner.has_dio_augment() {
+            let catalog = dio_inner.augment_catalog.read().unwrap().clone();
+            let augs = dio_inner.augmentations.read().unwrap().clone();
+            match (catalog, augs) {
+                (Some(catalog), Some(augs)) => {
+                    crate::dio::augment_passes::load_detail_with(&dio, id.clone(), &catalog, &augs)
+                        .await
+                }
+                _ => Ok(Default::default()),
+            }
+        } else {
+            let cb = dio_inner.lens.callbacks.on_load_detail.as_ref().unwrap();
+            cb(&dio, id.clone()).await
+        };
         state.detail_in_flight.lock().unwrap().remove(&id);
 
         match result {

--- a/vantage-diorama/tests/bdd_support/steps/lifecycle.rs
+++ b/vantage-diorama/tests/bdd_support/steps/lifecycle.rs
@@ -20,10 +20,10 @@ async fn set_on_start_blocking(w: &mut DioramaWorld, val: String) {
 
 #[when("I spawn make_dio")]
 async fn spawn_make_dio(w: &mut DioramaWorld) {
-    let cache_path = w.tmp_path().join("cache.redb");
+    let cache = w.cache_source();
     let lens = w
         .lens_builder
-        .build(cache_path, &w.spies, w.backend)
+        .build(cache, &w.spies, w.backend)
         .expect("build lens");
     let master = w.master.take().expect("master not set");
     w.lens = Some(lens.clone());

--- a/vantage-diorama/tests/bdd_support/steps/multi_dio.rs
+++ b/vantage-diorama/tests/bdd_support/steps/multi_dio.rs
@@ -18,12 +18,12 @@ async fn named_master(w: &mut DioramaWorld, name: String, step: &Step) {
 
 #[when(regex = r#"^the dio for "([^"]+)" is created$"#)]
 async fn create_named_dio(w: &mut DioramaWorld, name: String) {
-    let cache_path = w.tmp_path().join("cache.redb");
     // Reuse the Lens across all named dios under this scenario.
     if w.lens.is_none() {
+        let cache = w.cache_source();
         let lens = w
             .lens_builder
-            .build(cache_path, &w.spies, w.backend)
+            .build(cache, &w.spies, w.backend)
             .expect("build lens");
         w.lens = Some(lens);
     }

--- a/vantage-diorama/tests/bdd_support/steps/skeleton.rs
+++ b/vantage-diorama/tests/bdd_support/steps/skeleton.rs
@@ -27,10 +27,10 @@ async fn lens_with_on_start_load(w: &mut DioramaWorld) {
 
 #[when("the dio is created")]
 async fn create_dio(w: &mut DioramaWorld) {
-    let cache_path = w.tmp_path().join("cache.redb");
+    let cache = w.cache_source();
     let lens = w
         .lens_builder
-        .build(cache_path, &w.spies, w.backend)
+        .build(cache, &w.spies, w.backend)
         .expect("build lens");
     let master = w.master.take().expect("master not set");
     let dio = lens.make_dio(master).await.expect("make_dio");

--- a/vantage-diorama/tests/bdd_support/steps/traversal.rs
+++ b/vantage-diorama/tests/bdd_support/steps/traversal.rs
@@ -10,7 +10,7 @@ use cucumber::{given, then, when};
 use vantage_dataset::traits::ReadableValueSet;
 use vantage_diorama::Lens;
 use vantage_types::Record;
-use vantage_vista::{mocks::MockShell, Column, Reference, ReferenceKind, Vista, VistaMetadata};
+use vantage_vista::{Column, Reference, ReferenceKind, Vista, VistaMetadata, mocks::MockShell};
 
 use crate::bdd_support::world::DioramaWorld;
 
@@ -35,8 +35,14 @@ fn crew_shell() -> MockShell {
         .with_id_column("id");
     MockShell::new()
         .with_metadata(meta)
-        .with_record("c1", rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]))
-        .with_record("c2", rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]))
+        .with_record(
+            "c1",
+            rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]),
+        )
+        .with_record(
+            "c2",
+            rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]),
+        )
 }
 
 /// A `launches` master declaring a `crew` has-many onto `launch_crew`.

--- a/vantage-diorama/tests/bdd_support/steps/traversal.rs
+++ b/vantage-diorama/tests/bdd_support/steps/traversal.rs
@@ -64,10 +64,10 @@ async fn launch_with_crew(w: &mut DioramaWorld) {
     // Warm-cache-aware eager lens (mirrors the UI's `build_eager_lens`): copy
     // the master into the cache on first open, but TRUST a warm cache — so a
     // target whose source has gone down still opens from previously-cached rows.
-    let cache = w.tmp_path().join("cache.redb");
+    let cache = w.cache_source();
     let lens = Arc::new(
         Lens::new()
-            .cache_at(cache)
+            .cache_source(cache)
             .on_start(|dio| {
                 let dio = dio.clone();
                 async move {

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -7,7 +7,9 @@ use tempfile::TempDir;
 use tokio::sync::{Mutex, Notify, broadcast};
 use vantage_core::Result;
 use vantage_dataset::traits::ReadableValueSet;
-use vantage_diorama::{ChangeEvent, Dio, DioEvent, Lens, TableScenery, WriteOp};
+use vantage_diorama::{
+    CacheBackend, ChangeEvent, Dio, DioEvent, Lens, MemoryCache, TableScenery, WriteOp,
+};
 use vantage_vista::Vista;
 
 use super::backend::BackendKind;
@@ -100,6 +102,11 @@ pub struct LensBuilderState {
 #[world(init = Self::new)]
 pub struct DioramaWorld {
     pub tmp: Option<TempDir>,
+    /// Shared in-memory cache backend for the scenario. One instance reused
+    /// across every Lens the world builds, so multiple Dios (and Lens rebuilds)
+    /// see one another's cache tables — the cross-Lens sharing the old shared
+    /// redb file gave, without touching disk.
+    pub mem_cache: Option<Arc<MemoryCache>>,
     pub backend: BackendKind,
     pub master: Option<Vista>,
     pub lens_builder: LensBuilderState,
@@ -158,6 +165,7 @@ impl DioramaWorld {
     async fn new() -> Self {
         Self {
             tmp: None,
+            mem_cache: None,
             backend: BackendKind::default(),
             master: None,
             lens_builder: LensBuilderState::default(),
@@ -230,6 +238,13 @@ impl DioramaWorld {
         }
         self.tmp.as_ref().unwrap().path().to_path_buf()
     }
+
+    /// The scenario's shared in-memory cache backend (created on first use).
+    pub fn cache_source(&mut self) -> Arc<dyn CacheBackend> {
+        self.mem_cache
+            .get_or_insert_with(|| Arc::new(MemoryCache::new()))
+            .clone()
+    }
 }
 
 impl LensBuilderState {
@@ -244,11 +259,11 @@ impl LensBuilderState {
     /// cache assertions.
     pub fn build(
         &self,
-        cache_path: std::path::PathBuf,
+        cache: Arc<dyn CacheBackend>,
         spies: &Spies,
         backend: BackendKind,
     ) -> Result<Arc<Lens>> {
-        let mut b = Lens::new().cache_at(cache_path);
+        let mut b = Lens::new().cache_source(cache);
         let bridge = backend == BackendKind::Sqlite;
 
         // on_start — legacy "copy master" mode kept for v1 features;

--- a/vantage-diorama/tests/bucket_scenario.rs
+++ b/vantage-diorama/tests/bucket_scenario.rs
@@ -1,0 +1,28 @@
+//! Stage 0 proof: a bucket master augmented with per-object detail loads
+//! cache-first and stale-while-refresh — the view shows GRAY (known-but-
+//! unhydrated) rows immediately, then they hydrate to LOADED as the detail
+//! pass runs. Proves the `MockView` + `cache_in_memory()` harness end to end.
+
+mod support;
+
+use support::{MockView, bucket_dio};
+
+#[tokio::test]
+async fn grid_shows_gray_rows_then_hydrates() {
+    let dio = bucket_dio().await;
+    let view = MockView::open(&dio, 3).await;
+
+    // List pass ran on open: 3 rows known to exist, none hydrated yet.
+    assert_eq!(view.gray_rows(), 3, "all three objects listed as gray");
+    assert_eq!(view.loaded_rows(), 0, "nothing hydrated before the viewport");
+    assert!(view.is_loading());
+
+    // A grid scrolls them into view → the detail pass hydrates each row.
+    view.viewport(0..3);
+    view.settle_until("all rows hydrated", |v| v.loaded_rows() == 3)
+        .await;
+
+    assert_eq!(view.gray_rows(), 0);
+    assert_eq!(view.loaded_rows(), 3);
+    assert!(!view.is_loading());
+}

--- a/vantage-diorama/tests/bucket_scenario.rs
+++ b/vantage-diorama/tests/bucket_scenario.rs
@@ -14,7 +14,11 @@ async fn grid_shows_gray_rows_then_hydrates() {
 
     // List pass ran on open: 3 rows known to exist, none hydrated yet.
     assert_eq!(view.gray_rows(), 3, "all three objects listed as gray");
-    assert_eq!(view.loaded_rows(), 0, "nothing hydrated before the viewport");
+    assert_eq!(
+        view.loaded_rows(),
+        0,
+        "nothing hydrated before the viewport"
+    );
     assert!(view.is_loading());
 
     // A grid scrolls them into view → the detail pass hydrates each row.

--- a/vantage-diorama/tests/dio_conditions.rs
+++ b/vantage-diorama/tests/dio_conditions.rs
@@ -26,7 +26,8 @@ async fn dio_condition_is_inherited_by_every_view() {
 async fn no_condition_shows_all_rows() {
     let dio: Dio = eager_dio(teams_master()).await;
     let view = MockView::open(&dio, 10).await;
-    view.settle_until("all rows", |v| v.loaded_rows() == 3).await;
+    view.settle_until("all rows", |v| v.loaded_rows() == 3)
+        .await;
     assert_eq!(view.loaded_rows(), 3);
 }
 

--- a/vantage-diorama/tests/dio_conditions.rs
+++ b/vantage-diorama/tests/dio_conditions.rs
@@ -1,0 +1,45 @@
+//! Stage 1a: the **Dio** owns conditions. A condition set on the Dio is
+//! inherited by every scenery opened on it — the Dio defines "what this table
+//! is", the view just observes it. For a native column on a single-pass Dio the
+//! filter resolves locally over the cache.
+
+mod support;
+
+use support::{MockView, eager_dio, teams_master};
+use vantage_diorama::{Dio, SortDir};
+
+#[tokio::test]
+async fn dio_condition_is_inherited_by_every_view() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    dio.with_condition_eq("team", "red");
+
+    let view = MockView::open(&dio, 10).await;
+    view.settle_until("filtered to red", |v| v.loaded_rows() == 2)
+        .await;
+
+    assert_eq!(view.loaded_rows(), 2, "only the two red rows show");
+    assert_eq!(view.row_count(), 2);
+    assert!(!view.is_loading());
+}
+
+#[tokio::test]
+async fn no_condition_shows_all_rows() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    let view = MockView::open(&dio, 10).await;
+    view.settle_until("all rows", |v| v.loaded_rows() == 3).await;
+    assert_eq!(view.loaded_rows(), 3);
+}
+
+#[tokio::test]
+async fn dio_order_is_inherited_by_every_view() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    dio.with_order("team", SortDir::Asc);
+
+    let view = MockView::open(&dio, 10).await;
+    view.settle_until("sorted", |v| v.loaded_rows() == 3).await;
+
+    // Ascending by team: blue sorts before the two reds.
+    assert_eq!(view.col_at(0, "team").as_deref(), Some("blue"));
+    assert_eq!(view.col_at(1, "team").as_deref(), Some("red"));
+    assert_eq!(view.col_at(2, "team").as_deref(), Some("red"));
+}

--- a/vantage-diorama/tests/dio_local_filter.rs
+++ b/vantage-diorama/tests/dio_local_filter.rs
@@ -31,7 +31,8 @@ async fn no_condition_keeps_all_augmented_rows() {
     let dio = bucket_dio().await;
     let view = MockView::open(&dio, 10).await;
     view.viewport(0..10);
-    view.settle_until("all hydrated", |v| v.loaded_rows() == 3).await;
+    view.settle_until("all hydrated", |v| v.loaded_rows() == 3)
+        .await;
     assert_eq!(view.loaded_rows(), 3);
 }
 

--- a/vantage-diorama/tests/dio_local_filter.rs
+++ b/vantage-diorama/tests/dio_local_filter.rs
@@ -1,0 +1,53 @@
+//! Stage 3: local emulation. A condition on an **augmented** column — one the
+//! master can't filter because it's produced client-side — is applied locally
+//! over the hydrated cache. The match is unknowable until a row is augmented, so
+//! matching rows surface as they hydrate ("fetch all → augment → keep applying
+//! the filter").
+
+mod support;
+
+use support::{MockView, bucket_dio};
+
+#[tokio::test]
+async fn condition_on_augmented_column_filters_locally() {
+    // `name` is augmented from the `names` source; 1st and 3rd objects are John.
+    let dio = bucket_dio().await;
+    dio.with_condition_eq("name", "John");
+
+    let view = MockView::open(&dio, 10).await;
+    view.viewport(0..10); // pull the whole set into view so every row hydrates
+
+    view.settle_until("filtered to the two Johns", |v| v.loaded_rows() == 2)
+        .await;
+
+    assert_eq!(view.loaded_rows(), 2, "only the two John rows remain");
+    assert_eq!(view.row_count(), 2);
+    assert_eq!(view.col_at(0, "name").as_deref(), Some("John"));
+    assert_eq!(view.col_at(1, "name").as_deref(), Some("John"));
+}
+
+#[tokio::test]
+async fn no_condition_keeps_all_augmented_rows() {
+    let dio = bucket_dio().await;
+    let view = MockView::open(&dio, 10).await;
+    view.viewport(0..10);
+    view.settle_until("all hydrated", |v| v.loaded_rows() == 3).await;
+    assert_eq!(view.loaded_rows(), 3);
+}
+
+#[tokio::test]
+async fn sort_on_augmented_column_orders_locally() {
+    // The master can't sort by `name` (it's augmented). Sort is emulated over
+    // the hydrated cache. Names: o1=John, o2=Jane, o3=John → asc: Jane, John, John.
+    let dio = bucket_dio().await;
+    dio.with_order("name", vantage_diorama::SortDir::Asc);
+
+    let view = MockView::open(&dio, 10).await;
+    view.viewport(0..10);
+    view.settle_until("sorted by name", |v| v.loaded_rows() == 3)
+        .await;
+
+    assert_eq!(view.col_at(0, "name").as_deref(), Some("Jane"));
+    assert_eq!(view.col_at(1, "name").as_deref(), Some("John"));
+    assert_eq!(view.col_at(2, "name").as_deref(), Some("John"));
+}

--- a/vantage-diorama/tests/dio_traversal_compose.rs
+++ b/vantage-diorama/tests/dio_traversal_compose.rs
@@ -16,7 +16,10 @@ fn text(s: &str) -> CborValue {
     CborValue::Text(s.into())
 }
 fn rec(pairs: &[(&str, &str)]) -> Record<CborValue> {
-    pairs.iter().map(|(k, v)| ((*k).to_string(), text(v))).collect()
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), text(v)))
+        .collect()
 }
 
 /// Crew store keyed by `launch_id`: L1 has two members, L2 one.
@@ -28,9 +31,18 @@ fn crew_shell() -> MockShell {
         .with_id_column("id");
     MockShell::new()
         .with_metadata(meta)
-        .with_record("c1", rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]))
-        .with_record("c2", rec(&[("id", "c2"), ("launch_id", "L1"), ("name", "Neil")]))
-        .with_record("c3", rec(&[("id", "c3"), ("launch_id", "L2"), ("name", "Pete")]))
+        .with_record(
+            "c1",
+            rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]),
+        )
+        .with_record(
+            "c2",
+            rec(&[("id", "c2"), ("launch_id", "L1"), ("name", "Neil")]),
+        )
+        .with_record(
+            "c3",
+            rec(&[("id", "c3"), ("launch_id", "L2"), ("name", "Pete")]),
+        )
 }
 
 fn launch_master() -> Vista {
@@ -38,7 +50,12 @@ fn launch_master() -> Vista {
         .with_column(Column::new("id", "String").with_flag("id"))
         .with_column(Column::new("name", "String"))
         .with_id_column("id")
-        .with_reference(Reference::new("crew", "launch_crew", ReferenceKind::HasMany, "launch_id"));
+        .with_reference(Reference::new(
+            "crew",
+            "launch_crew",
+            ReferenceKind::HasMany,
+            "launch_id",
+        ));
     let shell = MockShell::new()
         .with_metadata(meta)
         .with_record("L1", rec(&[("id", "L1"), ("name", "Apollo 11")]))
@@ -92,6 +109,7 @@ async fn traversed_child_without_condition_sees_all_related_rows() {
     let crew = launches.get_ref("crew", &l1).await.expect("get_ref crew");
 
     let view = MockView::open(&crew, 10).await;
-    view.settle_until("both L1 crew", |v| v.loaded_rows() == 2).await;
+    view.settle_until("both L1 crew", |v| v.loaded_rows() == 2)
+        .await;
     assert_eq!(view.loaded_rows(), 2, "L1 has two crew members");
 }

--- a/vantage-diorama/tests/dio_traversal_compose.rs
+++ b/vantage-diorama/tests/dio_traversal_compose.rs
@@ -1,0 +1,97 @@
+//! Stage 4: a traversed (`get_ref`) child Dio is first-class — it carries the
+//! Dio-level query semantics from Stages 1/3, so a condition set on the child
+//! filters its rows locally, exactly like a top-level Dio. This is the
+//! composition of reference traversal with local emulation.
+
+mod support;
+
+use ciborium::Value as CborValue;
+use support::MockView;
+use vantage_diorama::{Dio, Lens};
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Reference, ReferenceKind, Vista, VistaMetadata};
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.into())
+}
+fn rec(pairs: &[(&str, &str)]) -> Record<CborValue> {
+    pairs.iter().map(|(k, v)| ((*k).to_string(), text(v))).collect()
+}
+
+/// Crew store keyed by `launch_id`: L1 has two members, L2 one.
+fn crew_shell() -> MockShell {
+    let meta = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("launch_id", "String"))
+        .with_column(Column::new("name", "String"))
+        .with_id_column("id");
+    MockShell::new()
+        .with_metadata(meta)
+        .with_record("c1", rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]))
+        .with_record("c2", rec(&[("id", "c2"), ("launch_id", "L1"), ("name", "Neil")]))
+        .with_record("c3", rec(&[("id", "c3"), ("launch_id", "L2"), ("name", "Pete")]))
+}
+
+fn launch_master() -> Vista {
+    let meta = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_id_column("id")
+        .with_reference(Reference::new("crew", "launch_crew", ReferenceKind::HasMany, "launch_id"));
+    let shell = MockShell::new()
+        .with_metadata(meta)
+        .with_record("L1", rec(&[("id", "L1"), ("name", "Apollo 11")]))
+        .with_record("L2", rec(&[("id", "L2"), ("name", "Apollo 12")]))
+        .with_ref_target("crew", crew_shell());
+    Vista::new("launches", Box::new(shell))
+}
+
+/// Single-pass eager Dio over the launches master (in-memory cache).
+async fn launches_dio() -> Dio {
+    let lens = std::sync::Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    use vantage_dataset::prelude::ReadableValueSet;
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .build()
+            .expect("lens builds"),
+    );
+    lens.make_dio(launch_master()).await.expect("make_dio")
+}
+
+#[tokio::test]
+async fn traversed_child_carries_a_local_condition() {
+    let launches = launches_dio().await;
+    let l1 = rec(&[("id", "L1"), ("name", "Apollo 11")]);
+
+    // Traverse launch L1 → its crew (two members), then narrow with a Dio-level
+    // condition on the child. The child reuses the parent's lens and filters
+    // locally just like a top-level Dio.
+    let crew = launches.get_ref("crew", &l1).await.expect("get_ref crew");
+    crew.with_condition_eq("name", "Buzz");
+
+    let view = MockView::open(&crew, 10).await;
+    view.settle_until("child filtered to Buzz", |v| v.loaded_rows() == 1)
+        .await;
+
+    assert_eq!(view.loaded_rows(), 1, "only Buzz matches on L1's crew");
+    assert_eq!(view.col_at(0, "name").as_deref(), Some("Buzz"));
+}
+
+#[tokio::test]
+async fn traversed_child_without_condition_sees_all_related_rows() {
+    let launches = launches_dio().await;
+    let l1 = rec(&[("id", "L1"), ("name", "Apollo 11")]);
+    let crew = launches.get_ref("crew", &l1).await.expect("get_ref crew");
+
+    let view = MockView::open(&crew, 10).await;
+    view.settle_until("both L1 crew", |v| v.loaded_rows() == 2).await;
+    assert_eq!(view.loaded_rows(), 2, "L1 has two crew members");
+}

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -1,0 +1,164 @@
+//! Shared test harness for the Dio-query-semantics work.
+//!
+//! - [`MockView`] — a consumer that talks ONLY over a `TableScenery`, the way a
+//!   real grid/dropdown does: drive the viewport, read `gray_rows`/`loaded_rows`/
+//!   `is_loading`/`total`, and settle on generation bumps. No gpui, no UI types.
+//! - bucket fixtures — an object-list master augmented with per-object detail,
+//!   the canonical "cmd bucket of JSON" shape.
+
+#![allow(dead_code)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use vantage_diorama::{Augmentation, Dio, Fetch, Lens, MergeRule, Source, TableScenery};
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Vista, VistaMetadata};
+use vantage_vista_factory::VistaCatalog;
+
+// ---- record/metadata helpers ---------------------------------------------
+
+pub fn text(s: &str) -> CborValue {
+    CborValue::Text(s.into())
+}
+
+pub fn record(pairs: &[(&str, &str)]) -> Record<CborValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), text(v)))
+        .collect()
+}
+
+pub fn meta(columns: &[&str]) -> VistaMetadata {
+    let mut m = VistaMetadata::new();
+    for c in columns {
+        let col = if *c == "id" {
+            Column::new("id", "String").with_flag("id")
+        } else {
+            Column::new(*c, "String")
+        };
+        m = m.with_column(col);
+    }
+    m.with_id_column("id")
+}
+
+// ---- bucket fixture ------------------------------------------------------
+
+/// Master: a bucket object list — ids only, no `name` (that's augmented).
+pub fn bucket_master() -> Vista {
+    let shell = MockShell::new()
+        .with_record("o1", record(&[("id", "o1")]))
+        .with_record("o2", record(&[("id", "o2")]))
+        .with_record("o3", record(&[("id", "o3")]))
+        .with_metadata(meta(&["id"]));
+    Vista::new("bucket", Box::new(shell))
+}
+
+/// Detail source "names": object id -> { name }. 1st and 3rd are John.
+pub fn names_detail() -> Vista {
+    let shell = MockShell::new()
+        .with_record("o1", record(&[("id", "o1"), ("name", "John")]))
+        .with_record("o2", record(&[("id", "o2"), ("name", "Jane")]))
+        .with_record("o3", record(&[("id", "o3"), ("name", "John")]))
+        .with_metadata(meta(&["id", "name"]));
+    Vista::new("names", Box::new(shell))
+}
+
+pub fn bucket_catalog() -> Arc<VistaCatalog> {
+    let mut c = VistaCatalog::new();
+    c.register("names", Arc::new(|| Ok(names_detail())));
+    Arc::new(c)
+}
+
+pub fn augment_name() -> Augmentation {
+    Augmentation {
+        table: "names".into(),
+        source: Source::Id,
+        fetch: Fetch::PerRow,
+        merge: MergeRule {
+            columns: vec!["name".into()],
+        },
+    }
+}
+
+/// A Dio over the bucket master, augmenting each row's `name` from the `names`
+/// detail source, backed by an in-memory cache (no TempDir).
+pub async fn bucket_dio() -> Dio {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .viewport_debounce(Duration::from_millis(1))
+            .catalog(bucket_catalog())
+            .augment(vec![augment_name()])
+            .build()
+            .expect("lens builds"),
+    );
+    lens.make_dio(bucket_master()).await.expect("make_dio")
+}
+
+// ---- MockView ------------------------------------------------------------
+
+/// A scenery consumer for tests. Wraps a `TableScenery` and exposes the
+/// observable state a grid/dropdown reacts to.
+pub struct MockView {
+    scenery: Arc<dyn TableScenery>,
+}
+
+impl MockView {
+    /// Open a grid-style view over a Dio with the given page size.
+    pub async fn open(dio: &Dio, page_size: usize) -> Self {
+        let scenery = dio
+            .table_scenery()
+            .page_size(page_size)
+            .open()
+            .await
+            .expect("scenery opens");
+        Self { scenery }
+    }
+
+    pub fn scenery(&self) -> &Arc<dyn TableScenery> {
+        &self.scenery
+    }
+
+    /// Rows known to exist but not yet hydrated (list-pass `Incomplete`).
+    pub fn gray_rows(&self) -> usize {
+        self.scenery.status_summary().incomplete
+    }
+
+    /// Fully hydrated rows (`Fresh`).
+    pub fn loaded_rows(&self) -> usize {
+        self.scenery.status_summary().fresh
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.scenery.row_count()
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        self.scenery.estimated_total()
+    }
+
+    /// Still settling: any gray rows, or fewer materialized rows than the count.
+    pub fn is_loading(&self) -> bool {
+        let s = self.scenery.status_summary();
+        s.incomplete > 0 || s.loaded < self.scenery.row_count()
+    }
+
+    pub fn viewport(&self, range: std::ops::Range<usize>) {
+        self.scenery.set_viewport(range);
+    }
+
+    /// Pump until `pred` holds or a bounded budget elapses. Wall-clock based
+    /// (not paused-time) — the BDD harness migration adds the paused variant.
+    pub async fn settle_until(&self, label: &str, pred: impl Fn(&Self) -> bool) {
+        for _ in 0..400 {
+            if pred(self) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("MockView condition '{label}' not met within budget");
+    }
+}

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ciborium::Value as CborValue;
+use vantage_dataset::prelude::ReadableValueSet;
 use vantage_diorama::{Augmentation, Dio, Fetch, Lens, MergeRule, Source, TableScenery};
 use vantage_types::Record;
 use vantage_vista::mocks::MockShell;
@@ -98,6 +99,40 @@ pub async fn bucket_dio() -> Dio {
     lens.make_dio(bucket_master()).await.expect("make_dio")
 }
 
+// ---- single-pass (eager) fixture -----------------------------------------
+
+/// Master with a native `team` column — 2 red, 1 blue — for condition/order
+/// tests that don't involve augmentation.
+pub fn teams_master() -> Vista {
+    let shell = MockShell::new()
+        .with_record("a", record(&[("id", "a"), ("team", "red")]))
+        .with_record("b", record(&[("id", "b"), ("team", "blue")]))
+        .with_record("c", record(&[("id", "c"), ("team", "red")]))
+        .with_metadata(meta(&["id", "team"]));
+    Vista::new("members", Box::new(shell))
+}
+
+/// A single-pass Dio whose `on_start` eagerly copies the master into an
+/// in-memory cache. No augmentation — the scenery filters/sorts the cache
+/// locally (the v1-compat path).
+pub async fn eager_dio(master: Vista) -> Dio {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("lens builds"),
+    );
+    lens.make_dio(master).await.expect("make_dio")
+}
+
 // ---- MockView ------------------------------------------------------------
 
 /// A scenery consumer for tests. Wraps a `TableScenery` and exposes the
@@ -134,6 +169,14 @@ impl MockView {
 
     pub fn row_count(&self) -> usize {
         self.scenery.row_count()
+    }
+
+    /// Read a text column at a row index (None if absent / not a string).
+    pub fn col_at(&self, idx: usize, col: &str) -> Option<String> {
+        self.scenery.row(idx).and_then(|r| match r.record.get(col) {
+            Some(CborValue::Text(t)) => Some(t.clone()),
+            _ => None,
+        })
     }
 
     pub fn total(&self) -> Option<usize> {

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -85,18 +85,18 @@ pub fn augment_name() -> Augmentation {
 }
 
 /// A Dio over the bucket master, augmenting each row's `name` from the `names`
-/// detail source, backed by an in-memory cache (no TempDir).
+/// detail source, backed by an in-memory cache (no TempDir). Augmentation is
+/// configured on the **Dio** (`dio.augment`), not the Lens.
 pub async fn bucket_dio() -> Dio {
     let lens = Arc::new(
         Lens::new()
             .cache_in_memory()
             .viewport_debounce(Duration::from_millis(1))
-            .catalog(bucket_catalog())
-            .augment(vec![augment_name()])
             .build()
             .expect("lens builds"),
     );
-    lens.make_dio(bucket_master()).await.expect("make_dio")
+    let dio = lens.make_dio(bucket_master()).await.expect("make_dio");
+    dio.augment(bucket_catalog(), vec![augment_name()])
 }
 
 // ---- single-pass (eager) fixture -----------------------------------------

--- a/vantage-diorama/tests/traversal.rs
+++ b/vantage-diorama/tests/traversal.rs
@@ -10,7 +10,7 @@ use vantage_core::Result;
 use vantage_dataset::prelude::ReadableValueSet;
 use vantage_diorama::Lens;
 use vantage_types::Record;
-use vantage_vista::{mocks::MockShell, Column, Reference, ReferenceKind, Vista, VistaMetadata};
+use vantage_vista::{Column, Reference, ReferenceKind, Vista, VistaMetadata, mocks::MockShell};
 
 fn text(s: &str) -> CborValue {
     CborValue::Text(s.to_string())
@@ -33,8 +33,14 @@ fn crew_shell() -> MockShell {
         .with_id_column("id");
     MockShell::new()
         .with_metadata(meta)
-        .with_record("c1", rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]))
-        .with_record("c2", rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]))
+        .with_record(
+            "c1",
+            rec(&[("id", "c1"), ("launch_id", "L1"), ("name", "Buzz")]),
+        )
+        .with_record(
+            "c2",
+            rec(&[("id", "c2"), ("launch_id", "L2"), ("name", "Neil")]),
+        )
 }
 
 /// A launches master declaring a `crew` has-many onto `launch_crew`, resolved


### PR DESCRIPTION
## Why

Query-shaping logic was scattered across the wrong layers — conditions on the scenery builder, sort on the scenery, augmentation on the Lens — and reference drill-downs blocked the UI by eagerly fetching the whole related set. Sort only worked on backends that natively supported it.

This makes **Dio** the single owner of query semantics, realising the layer contract: **Table** exhausts native features, **Vista** *identifies* capability gaps, **Dio (+Lens)** *re-plugs* them. Any consumer bound to a Dio gets a complete, fault-tolerant, stale-while-refreshing handle regardless of backend.

## What (staged, test-first)

- **In-memory cache** — `LensBuilder::cache_in_memory()` + `MemoryCache` (mirrors redb's per-table + `CacheStatus` semantics; yields per op so schedule-sensitive consumers behave identically). Plus a `MockView` test harness (consumer over a scenery: gray/loaded counts, viewport, settle).
- **Dio owns conditions + order** — `Dio::with_condition_eq` / `Dio::with_order` define *what the table is*; every scenery inherits them (a view may still layer its own).
- **Dio owns augmentation** — `Dio::augment(catalog, augmentations)` (was `Lens::augment`); pass bodies live in a shared `dio::augment_passes`; the Dio tracks its *augmented columns*. `Lens::augment` still works as a legacy delegate.
- **Local filter/sort emulation** — a two-pass view carrying conditions/sort the master can't push down refines its visible set over the cache. An augmented-column predicate resolves only after hydration, so matches surface progressively (the "fetch all → augment → keep filtering" shape). Sort on a column the backend can't order now works via local emulation.
- **Traversal composes** — `get_ref` child Dios are first-class: they carry Dio-level conditions and filter locally.
- **BDD harness** migrated to the shared in-memory cache (70 scenarios / 612 steps green).

`vantage-diorama` bumped to 0.6.9 (CHANGELOG dated). Full suite + clippy + fmt clean.

## Deferred (follow-on)

The **vantage-ui cutover** — rewire `open_detail` onto non-blocking `get_ref` and delegate grid sort to `dio.with_order`, removing the eager-blocking lag and the two-pass hydration-wipe guard. It lives in a separate repo and is the next focused effort. Native-column pushdown (vs the current all-local two-pass filtering) and the per-order sparse-index "Mode 1" are also follow-ups.
