### PR TITLE
vantage-sql: TLS for Postgres/MySQL pools (tls-rustls)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,7 +1659,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ dependencies = [
  "tokio-util",
  "typed-builder 0.22.0",
  "uuid",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3071,7 +3071,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3696,6 +3696,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -3706,6 +3707,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4933,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5253,6 +5255,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.6 — 2026-06-28
+
+- TLS support for the Postgres and MySQL connection pools: sqlx is now built with the `tls-rustls`
+  feature (rustls + ring + webpki), so a `DATABASE_URL` with `sslmode=require` negotiates an
+  encrypted connection. This is required against servers that enforce SSL — e.g. Amazon RDS for
+  PostgreSQL 15+, whose default parameter group sets `rds.force_ssl = 1` and rejects unencrypted
+  sessions. No API change; existing non-SSL connections keep working (sqlx defaults to
+  `sslmode=prefer`).
+
 ## 0.6.5 — 2026-06-28
 
 - The Postgres table source honors `Table::with_text_id()` (vantage-table 0.6.9): a text-keyed

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -27,7 +27,7 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
-sqlx = { version = "0.8", features = ["runtime-tokio", "rust_decimal", "uuid", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
 uuid = "1"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Builds sqlx with the `tls-rustls` feature (rustls + ring + webpki) so the Postgres and MySQL connection pools can negotiate encrypted connections. Bumps vantage-sql to 0.6.6.

## Why
A `DATABASE_URL` with `sslmode=require` previously failed: sqlx was compiled with no TLS backend, so `PgPool::connect` could not negotiate TLS. Against a server that enforces SSL this means no connection at all — e.g. **Amazon RDS for PostgreSQL 15+**, whose default parameter group sets `rds.force_ssl = 1` and rejects unencrypted sessions:

```
no pg_hba.conf entry for host "...", user "...", database "...", no encryption
```

(Hit in production wiring the launch-control demo Lambda to an RDS instance.)

## Change
- `vantage-sql/Cargo.toml`: add `tls-rustls` to the sqlx features. Pure-Rust (ring + webpki) — no system OpenSSL needed, so it builds cleanly in slim containers.
- No API change. Existing non-SSL connections keep working (sqlx defaults to `sslmode=prefer`); `sslmode=require` now succeeds and stays encrypted.

## Verify
- `cargo build/clippy -p vantage-sql --features postgres,sqlite,mysql,vista` — clean.
- `cargo fmt --check` — clean.