### PR TITLE
diorama: finish Lens = pure caching — retire legacy augment API + dead seams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.11 — 2026-06-28
+
+**Lens reduced to pure caching**
+
+- The legacy `Lens::augment` / `LensBuilder::catalog` builder API is removed;
+  configure two-pass augmentation on the Dio with `Dio::augment(catalog, augs)`.
+  The Lens now owns only caching strategy and explicitly-registered callbacks
+  (`on_start` / `on_refresh` / `on_load_chunk` / hand-rolled `on_list_page` +
+  `on_load_detail`).
+- Removed the unwired `Lens::on_query` seam and the no-op
+  `TableSceneryBuilder::eager()` v1 compatibility stub.
+
 ## 0.6.10 — 2026-06-28
 
 - Local emulation only forces full-set hydration when a condition/sort actually

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/examples/augmentation.rs
+++ b/vantage-diorama/examples/augmentation.rs
@@ -100,19 +100,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Lens::new()
             .cache_at(&cache)
             .viewport_debounce(Duration::from_millis(1))
-            .catalog(Arc::new(catalog))
-            .augment(vec![Augmentation {
-                table: "tfstate-detail".into(), // catalog name of the detail Vista
-                source: Source::Id,             // master.id -> detail.id
-                fetch: Fetch::PerRow,           // one detail record per master row
-                merge: MergeRule {
-                    columns: vec!["resources".into(), "serial".into()],
-                },
-            }])
             .build()?,
     );
 
-    let dio = lens.make_dio(master()).await?;
+    // Augmentation is a property of the Dio, not the Lens: configure it after
+    // make_dio, before opening any scenery.
+    let dio = lens.make_dio(master()).await?.augment(
+        Arc::new(catalog),
+        vec![Augmentation {
+            table: "tfstate-detail".into(), // catalog name of the detail Vista
+            source: Source::Id,             // master.id -> detail.id
+            fetch: Fetch::PerRow,           // one detail record per master row
+            merge: MergeRule {
+                columns: vec!["resources".into(), "serial".into()],
+            },
+        }],
+    );
     let scenery = dio.table_scenery().page_size(10).open().await?;
     let n = scenery.row_count();
 

--- a/vantage-diorama/src/dio/augment_passes.rs
+++ b/vantage-diorama/src/dio/augment_passes.rs
@@ -1,11 +1,10 @@
 //! The two-pass augmentation passes, owned by the Dio.
 //!
 //! A Dio configured with [`Dio::augment`](crate::Dio::augment) drives its own
-//! list / detail / refresh passes from the augmentation config it holds, instead
-//! of the Lens carrying them. These free functions are the shared bodies: the
-//! Dio path calls them reading config off `DioInner`, and the legacy
-//! `Lens::augment` synthesis (`lens::build`) delegates here too, so there's one
-//! definition of each pass.
+//! list / detail / refresh passes from the augmentation config it holds. These
+//! free functions are the shared bodies, read off `DioInner` — distinct from a
+//! Lens that registers explicit `on_list_page`/`on_load_detail` callbacks for
+//! hand-rolled two-pass.
 
 use ciborium::Value as CborValue;
 use vantage_core::Result;

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -132,7 +132,8 @@ impl DioInner {
     }
 
     /// Whether this Dio engages two-pass loading — either it owns augmentation
-    /// or its Lens registers a detail callback (legacy `Lens::augment` path).
+    /// or its Lens registers an explicit `on_load_detail` callback (hand-rolled
+    /// two-pass).
     pub(crate) fn is_two_pass(&self) -> bool {
         self.has_dio_augment() || self.lens.callbacks.on_load_detail.is_some()
     }
@@ -302,7 +303,7 @@ impl Dio {
     }
 
     /// Configure two-pass augmentation on this Dio: a cheap master list pass plus
-    /// a per-row detail pass that resolves each [`Augmentation`]'s detail Vista
+    /// a per-row detail pass that resolves each [`Augmentation`](crate::Augmentation)'s detail Vista
     /// through `catalog`, fetches it, and merges its columns onto the row.
     ///
     /// Augmentation is a property of the Dio, not the Lens — so different Dios
@@ -355,8 +356,7 @@ impl Dio {
     /// - cache miss → `RecordStatus::NotFound`, record = `None`
     ///
     /// No master fetch on miss (the cache is the source of truth in
-    /// v1). Use [`Dio::patched`](Self::patched) — from an `on_query`
-    /// callback or your own code — to seed the row.
+    /// v1). Use [`Dio::patched`](Self::patched) to seed the row.
     pub async fn record_scenery(&self, id: impl Into<String>) -> Result<Arc<dyn RecordScenery>> {
         let id = id.into();
         let (initial_record, initial_status) = match self.inner.cache.get_value(&id).await? {

--- a/vantage-diorama/src/error.rs
+++ b/vantage-diorama/src/error.rs
@@ -6,9 +6,6 @@ pub enum LensBuildError {
     #[error("cache backend is required (call .cache_at(...) or .cache_source(...))")]
     MissingCacheSource,
 
-    #[error("augmentations were registered but no catalog was provided (call .catalog(...))")]
-    MissingCatalog,
-
     #[error(transparent)]
     Other(#[from] VantageError),
 }

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -1,27 +1,17 @@
 use std::sync::Arc;
 
 use tokio::runtime::Handle;
-use vantage_vista_factory::VistaCatalog;
 
-use crate::augment::Augmentation;
-use crate::dio::Dio;
-use crate::dio::augment_passes;
 use crate::error::LensBuildError;
 
-use super::callbacks::{
-    DioCallback, DioListPageCallback, DioLoadDetailCallback, boxed_dio_callback,
-    boxed_list_page_callback, boxed_load_detail_callback,
-};
 use super::{Lens, LensBuilder, LensCallbacks};
 
 impl LensBuilder {
     /// Validate required state and produce the built [`Lens`].
     ///
-    /// When [`augment`](Self::augment) registered any augmentations and no
-    /// explicit two-pass callbacks were supplied, this synthesizes them: a
-    /// capability-aware list pass and an augmentation detail pass
-    /// (`synth_list_page` / `synth_load_detail`). Registering the detail pass
-    /// is what engages two-pass loading downstream.
+    /// The Lens carries caching strategy and any explicitly-registered
+    /// callbacks; two-pass augmentation is configured on the Dio via
+    /// [`Dio::augment`](crate::Dio::augment), not here.
     pub fn build(self) -> Result<Lens, LensBuildError> {
         if let Some(err) = self.deferred_cache_error {
             return Err(err);
@@ -33,35 +23,15 @@ impl LensBuilder {
             .runtime
             .unwrap_or_else(|| Handle::try_current().expect("LensBuilder::build called outside a tokio runtime; supply one with .runtime(handle)"));
 
-        let mut on_list_page = self.on_list_page;
-        let mut on_load_detail = self.on_load_detail;
-        let mut on_refresh = self.on_refresh;
-
-        if !self.augmentations.is_empty() && on_load_detail.is_none() {
-            let catalog = self.catalog.ok_or(LensBuildError::MissingCatalog)?;
-            let augmentations = Arc::new(self.augmentations);
-
-            // Each pass is synthesized only if the caller didn't supply one, so an
-            // app can still hand-roll any single pass while reusing the rest.
-            if on_list_page.is_none() {
-                on_list_page = Some(synth_list_page());
-            }
-            if on_refresh.is_none() {
-                on_refresh = Some(synth_refresh());
-            }
-            on_load_detail = Some(synth_load_detail(catalog, augmentations));
-        }
-
         let callbacks = LensCallbacks {
             on_start: self.on_start,
-            on_refresh,
+            on_refresh: self.on_refresh,
             on_write: self.on_write,
             on_event: self.on_event,
-            on_query: self.on_query,
             total_provider: self.total_provider,
             on_load_chunk: self.on_load_chunk,
-            on_list_page,
-            on_load_detail,
+            on_list_page: self.on_list_page,
+            on_load_detail: self.on_load_detail,
         };
 
         Ok(Lens {
@@ -72,35 +42,4 @@ impl LensBuilder {
             activity: self.activity,
         })
     }
-}
-
-/// Capability-aware list pass for an augmented Dio — delegates to the shared
-/// [`augment_passes::list_page`].
-fn synth_list_page() -> DioListPageCallback {
-    boxed_list_page_callback(move |dio: &Dio, desc| {
-        let dio = dio.clone();
-        async move { augment_passes::list_page(&dio, desc).await }
-    })
-}
-
-/// Augmentation detail pass — delegates to [`augment_passes::load_detail_with`],
-/// capturing the Lens-level catalog + augmentations.
-fn synth_load_detail(
-    catalog: Arc<VistaCatalog>,
-    augmentations: Arc<Vec<Augmentation>>,
-) -> DioLoadDetailCallback {
-    boxed_load_detail_callback(move |dio: &Dio, id| {
-        let dio = dio.clone();
-        let catalog = catalog.clone();
-        let augmentations = augmentations.clone();
-        async move { augment_passes::load_detail_with(&dio, id, &catalog, &augmentations).await }
-    })
-}
-
-/// Augmentation refresh — delegates to [`augment_passes::refresh`].
-fn synth_refresh() -> DioCallback {
-    boxed_dio_callback(move |dio: &Dio| {
-        let dio = dio.clone();
-        async move { augment_passes::refresh(&dio).await }
-    })
 }

--- a/vantage-diorama/src/lens/callbacks.rs
+++ b/vantage-diorama/src/lens/callbacks.rs
@@ -25,9 +25,6 @@ pub type DioWriteCallback =
 pub type DioEventCallback =
     Box<dyn for<'a> Fn(&'a Dio, ChangeEvent) -> DioCallbackFuture<'a> + Send + Sync + 'static>;
 
-pub type DioQueryCallback =
-    Box<dyn for<'a> Fn(&'a Dio, QueryDescriptor) -> DioCallbackFuture<'a> + Send + Sync + 'static>;
-
 /// Future returned by a [`DioTotalProviderCallback`]. Carries a row
 /// count back to the Scenery; runs once per scenery open and is
 /// cached for the scenery's lifetime.
@@ -81,7 +78,6 @@ pub struct LensCallbacks {
     pub on_refresh: Option<DioCallback>,
     pub on_write: Option<DioWriteCallback>,
     pub on_event: Option<DioEventCallback>,
-    pub on_query: Option<DioQueryCallback>,
     pub total_provider: Option<DioTotalProviderCallback>,
     pub on_load_chunk: Option<DioLoadChunkCallback>,
     pub on_list_page: Option<DioListPageCallback>,
@@ -119,15 +115,6 @@ where
     Fut: Future<Output = Result<()>> + Send + 'static,
 {
     Box::new(move |dio, ev| Box::pin(f(dio, ev)))
-}
-
-/// Wrap a user closure into a [`DioQueryCallback`].
-pub fn boxed_dio_query_callback<F, Fut>(f: F) -> DioQueryCallback
-where
-    F: for<'a> Fn(&'a Dio, QueryDescriptor) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<()>> + Send + 'static,
-{
-    Box::new(move |dio, q| Box::pin(f(dio, q)))
 }
 
 /// Wrap a user closure into a [`DioTotalProviderCallback`].

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -25,10 +25,10 @@ pub use activity::{Activity, ActivitySignal};
 pub use cache_backend::{CacheBackend, CacheStatus, CacheTable};
 pub use callbacks::{
     DioCallback, DioEventCallback, DioListPageCallback, DioLoadChunkCallback,
-    DioLoadDetailCallback, DioQueryCallback, DioTotalProviderCallback, DioWriteCallback,
-    LensCallbacks, boxed_dio_callback, boxed_dio_event_callback, boxed_dio_query_callback,
-    boxed_dio_write_callback, boxed_list_page_callback, boxed_load_chunk_callback,
-    boxed_load_detail_callback, boxed_total_provider_callback,
+    DioLoadDetailCallback, DioTotalProviderCallback, DioWriteCallback, LensCallbacks,
+    boxed_dio_callback, boxed_dio_event_callback, boxed_dio_write_callback,
+    boxed_list_page_callback, boxed_load_chunk_callback, boxed_load_detail_callback,
+    boxed_total_provider_callback,
 };
 pub use chunk_sink::{ChunkRow, ChunkSink, SceneryChunkTarget};
 pub use defaults::LensDefaults;
@@ -85,13 +85,10 @@ pub struct LensBuilder {
     pub(crate) on_refresh: Option<DioCallback>,
     pub(crate) on_write: Option<DioWriteCallback>,
     pub(crate) on_event: Option<DioEventCallback>,
-    pub(crate) on_query: Option<DioQueryCallback>,
     pub(crate) total_provider: Option<DioTotalProviderCallback>,
     pub(crate) on_load_chunk: Option<DioLoadChunkCallback>,
     pub(crate) on_list_page: Option<DioListPageCallback>,
     pub(crate) on_load_detail: Option<DioLoadDetailCallback>,
-    pub(crate) augmentations: Vec<crate::augment::Augmentation>,
-    pub(crate) catalog: Option<std::sync::Arc<vantage_vista_factory::VistaCatalog>>,
     pub(crate) defaults: LensDefaults,
     pub(crate) runtime: Option<Handle>,
     pub(crate) activity: ActivitySignal,
@@ -112,13 +109,10 @@ impl LensBuilder {
             on_refresh: None,
             on_write: None,
             on_event: None,
-            on_query: None,
             total_provider: None,
             on_load_chunk: None,
             on_list_page: None,
             on_load_detail: None,
-            augmentations: Vec::new(),
-            catalog: None,
             defaults: LensDefaults::default(),
             runtime: None,
             activity: ActivitySignal::new(),
@@ -221,17 +215,6 @@ impl LensBuilder {
         self
     }
 
-    /// Register the `on_query` callback. Stage 5b will wire this up;
-    /// stage 3 only stores the registration.
-    pub fn on_query<F, Fut>(mut self, f: F) -> Self
-    where
-        F: for<'a> Fn(&'a Dio, QueryDescriptor) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<()>> + Send + 'static,
-    {
-        self.on_query = Some(boxed_dio_query_callback(f));
-        self
-    }
-
     /// Register the `total_provider` callback. Fires once per
     /// [`TableScenery`](crate::scenery::TableScenery) open; the result
     /// drives `row_count()` and `estimated_total()` for that scenery's
@@ -329,30 +312,6 @@ impl LensBuilder {
 
     pub fn runtime(mut self, handle: Handle) -> Self {
         self.runtime = Some(handle);
-        self
-    }
-
-    /// Provide the cross-persistence [`VistaCatalog`](vantage_vista_factory::VistaCatalog)
-    /// used to resolve augmentation `table:` names into base detail Vistas.
-    /// Required whenever [`augment`](Self::augment) is used.
-    pub fn catalog(mut self, catalog: std::sync::Arc<vantage_vista_factory::VistaCatalog>) -> Self {
-        self.catalog = Some(catalog);
-        self
-    }
-
-    /// Register augmentations — detail sources merged onto each master row.
-    ///
-    /// Registering at least one engages two-pass loading: the master is listed
-    /// cheaply, then each visible row is augmented one at a time from its detail
-    /// source (the same Vista or a different backend, resolved via the
-    /// [`catalog`](Self::catalog)). [`build`](Self::build) synthesizes the list
-    /// and detail passes unless explicit `on_list_page`/`on_load_detail`
-    /// callbacks were supplied.
-    ///
-    /// Lower [`AugmentSpec`](crate::augment::AugmentSpec)s with
-    /// [`lower_augment`](crate::augment::lower_augment) first.
-    pub fn augment(mut self, augmentations: Vec<crate::augment::Augmentation>) -> Self {
-        self.augmentations = augmentations;
         self
     }
 }

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -20,9 +20,9 @@ pub use dio::{Dio, DioEvent, DioShell, Generation};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
     Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkRow, ChunkSink,
-    DioCallback, DioEventCallback, DioLoadChunkCallback, DioQueryCallback,
-    DioTotalProviderCallback, DioWriteCallback, Lens, LensBuilder, LensCallbacks, LensDefaults,
-    MemoryCache, MemoryCacheTable,
+    DioCallback, DioEventCallback, DioLoadChunkCallback, DioTotalProviderCallback,
+    DioWriteCallback, Lens, LensBuilder, LensCallbacks, LensDefaults, MemoryCache,
+    MemoryCacheTable,
 };
 pub use ops::{ChangeEvent, QueryDescriptor, WriteOp};
 pub use scenery::{

--- a/vantage-diorama/src/scenery/record.rs
+++ b/vantage-diorama/src/scenery/record.rs
@@ -15,8 +15,7 @@
 //! Deliberately *not* in v1:
 //!
 //! - **Master fetch on cache miss** — the cache is the source of
-//!   truth. Use [`Dio::patched`](crate::Dio::patched) (e.g. from an
-//!   `on_query` callback once that lands in stage 5b) to seed the row.
+//!   truth. Use [`Dio::patched`](crate::Dio::patched) to seed the row.
 //! - **`PendingWrite` status + `mark_pending_write`** — optimistic
 //!   write tracking lands when the UI adapter (stage 8) exercises it.
 //! - **`Stale` status** — no producer until refresh/TTL tracking

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -20,7 +20,6 @@ pub struct TableSceneryBuilder {
     pub(crate) sort: Option<(String, SortDir)>,
     pub(crate) search: Option<String>,
     pub(crate) page_size: usize,
-    pub(crate) eager: bool,
     pub(crate) initial_range: Option<std::ops::Range<usize>>,
     pub(crate) titles_only: bool,
 }
@@ -33,7 +32,6 @@ impl TableSceneryBuilder {
             sort: None,
             search: None,
             page_size: 100,
-            eager: false,
             initial_range: None,
             titles_only: false,
         }
@@ -58,13 +56,6 @@ impl TableSceneryBuilder {
     /// refresh-on-open initial fetch. Default 100.
     pub fn page_size(mut self, n: usize) -> Self {
         self.page_size = n;
-        self
-    }
-
-    /// Currently equivalent to the default — kept so caller code can
-    /// continue to target the v1 API shape.
-    pub fn eager(mut self) -> Self {
-        self.eager = true;
         self
     }
 
@@ -99,7 +90,6 @@ impl TableSceneryBuilder {
             sort,
             search,
             page_size,
-            eager: _,
             initial_range,
             titles_only,
         } = self;
@@ -151,8 +141,8 @@ impl TableSceneryBuilder {
 
         let master_capabilities = dio.master.read().unwrap().capabilities().clone();
 
-        // Two-pass engages when the Dio owns augmentation, or (legacy) the Lens
-        // registers an `on_load_detail` callback. The shared per-query index is
+        // Two-pass engages when the Dio owns augmentation, or the Lens registers
+        // an explicit `on_load_detail` callback. The shared per-query index is
         // keyed by the master Vista's index_key over the scenery's conditions +
         // sort, so reopening the same variant reuses the already-built index.
         let two_pass = dio.is_two_pass();

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -174,8 +174,9 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     let Some(index) = state.index() else {
         return;
     };
-    // The list pass comes from the Dio's own augmentation (preferred) or the
-    // legacy Lens `on_list_page` callback. Bail if neither provides one.
+    // The list pass comes from the Dio's own augmentation (preferred) or an
+    // explicitly-registered Lens `on_list_page` callback (hand-rolled two-pass).
+    // Bail if neither provides one.
     if !dio_inner.has_dio_augment() && dio_inner.lens.callbacks.on_list_page.is_none() {
         return;
     }

--- a/vantage-diorama/tests/augment.rs
+++ b/vantage-diorama/tests/augment.rs
@@ -93,12 +93,11 @@ async fn open(tmp: &TempDir, augmentations: Vec<Augmentation>) -> Dio {
         Lens::new()
             .cache_at(tmp.path().join("cache.redb"))
             .viewport_debounce(Duration::from_millis(1))
-            .catalog(catalog())
-            .augment(augmentations)
             .build()
             .expect("lens builds"),
     );
-    lens.make_dio(master_vista()).await.expect("make_dio")
+    let dio = lens.make_dio(master_vista()).await.expect("make_dio");
+    dio.augment(catalog(), augmentations)
 }
 
 fn status_of(s: &Arc<dyn TableScenery>, i: usize) -> Option<RowStatus> {
@@ -199,21 +198,6 @@ async fn multiple_augmentations_merge_independently() {
     assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
     assert_eq!(col_of(&scenery, 0, "extra").as_deref(), Some("x0"));
     assert_eq!(col_of(&scenery, 0, "branch").as_deref(), Some("main"));
-}
-
-/// Registering augmentations without a catalog is rejected at build time —
-/// honest failure, not a silent no-op.
-#[tokio::test]
-async fn augment_without_catalog_fails_to_build() {
-    let tmp = TempDir::new().unwrap();
-    let result = Lens::new()
-        .cache_at(tmp.path().join("cache.redb"))
-        .augment(vec![aug("runs-detail", Source::Id, &["detail"])])
-        .build();
-    assert!(matches!(
-        result,
-        Err(vantage_diorama::LensBuildError::MissingCatalog)
-    ));
 }
 
 /// A missing key field surfaces as a failed row — the detail pass error marks


### PR DESCRIPTION
Follows up the "Dio owns query semantics" work (#326, #328): conditions, order, and augmentation are owned by the Dio, and the Lens is now a pure caching strategy. This removes the transitional/dead surface that was left behind.

## Changes
- **`Lens::augment` / `LensBuilder::catalog` removed.** Two-pass augmentation is configured on the Dio via `Dio::augment(catalog, augmentations)`. The Lens owns only caching strategy and explicitly-registered callbacks (`on_start` / `on_refresh` / `on_load_chunk` / hand-rolled `on_list_page` + `on_load_detail`). The `synth_list_page`/`synth_load_detail`/`synth_refresh` synthesis and the `MissingCatalog` build error are gone; `dio::augment_passes` is the single home for the pass bodies.
- **Dead seams removed:** the unwired `Lens::on_query` (builder method, `LensCallbacks` slot, `DioQueryCallback`/`boxed_dio_query_callback`) and the no-op `TableSceneryBuilder::eager()` v1 stub.
- **Consumers migrated:** `tests/augment.rs` and `examples/augmentation.rs` now use `Dio::augment`. The `augment_without_catalog_fails_to_build` test is dropped — the catalog is now a required parameter, so that failure mode is structurally impossible (type-driven, not a runtime check).
- CHANGELOG `0.6.10` gains a "Lens reduced to pure caching" section.

## Verification
- `cargo test` (full suite) + `cargo test --test bdd` (70/70) green
- `cargo run --example augmentation` compiles/runs
- `cargo clippy --all-targets --features rhai` clean; `cargo fmt --check` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean (with and without `rhai`)