### PR TITLE
diorama 0.6.12: chunk-loaded grid sort/refresh fixes

### DIFF
--- a/.rules
+++ b/.rules
@@ -316,6 +316,29 @@ the following rules:
   not need to be linear — a follow-up commit (`fix`, `fmt`, `clippy`, etc.) is
   always fine.
 
+### Final checks before asking for PR approval
+
+Run this sweep **once per PR**, right before you tell me the PR is ready — not on
+every intermediate commit. These mirror what CI enforces, so passing them locally
+means green checks. The point is to catch them in one pass instead of a
+push-fail-push loop.
+
+1. **Clippy on everything, warnings denied** — `cargo clippy --all-targets
+   -- -D warnings`. The `--all-targets` matters: CI lints test/example/bench code
+   too, so a plain `cargo clippy` will miss lints in `tests/` (e.g.
+   `collapsible_if`, unused imports) and the build will still fail.
+2. **Format** — `cargo fmt --check`.
+3. **Tests** — full suite plus BDD: `cargo test` and `cargo test --test bdd`.
+4. **Version + CHANGELOG bump for every changed crate.** The release `check` job
+   fails any crate that has a diff but the same version as base. For each crate
+   you touched (even a one-line log-level change), bump its `Cargo.toml` version
+   (patch is fine) and add a CHANGELOG entry. Don't forget to let the bump flow
+   into `Cargo.lock`.
+5. **No duplicated new code** (SonarCloud, ≤3% on new lines). Copy-pasted test
+   boilerplate is the usual offender — factor shared helpers into
+   `tests/support/` (include via `mod support;`) rather than repeating
+   `paged_lens` / `wait_for_gen` / fixture builders across files.
+
 ## List of sub-crates and very brief description for each:
 
 ### Core Framework Crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4633,7 +4633,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.5 — 2026-06-29
+
+- REST: the count probe is quieter under `.debug(true)`. The count query and its
+  `window (0, 1)` probe GET now log at `debug`, while real data fetches stay at
+  `info` — so the log shows the fetches that matter without the count-probe noise.
+
 ## 0.6.4 — 2026-06-26
 
 - REST: with `.debug(true)`, each GET now logs the resolved request URL

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.4"
+version = "0.6.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -332,7 +332,7 @@ impl RestApi {
                 )
             })?;
         if self.debug {
-            tracing::info!(target: "vantage_api_client::rest", total, "REST count");
+            tracing::debug!(target: "vantage_api_client::rest", total, "REST count");
         }
         Ok(Some(total))
     }
@@ -379,8 +379,14 @@ impl RestApi {
         let query = self.build_query_string(window, &conds, &query_consumed);
         let url = join_query(&endpoint, &query);
 
+        // The `(0, 1)` window is the count probe (reads only the envelope's
+        // total); log it at debug so it doesn't drown the real data fetches.
         if self.debug {
-            tracing::info!(target: "vantage_api_client::rest", table = table_name, url = %url, "REST GET");
+            if window == Some((0, 1)) {
+                tracing::debug!(target: "vantage_api_client::rest", table = table_name, url = %url, "REST GET (count probe)");
+            } else {
+                tracing::info!(target: "vantage_api_client::rest", table = table_name, url = %url, "REST GET");
+            }
         }
 
         let mut request = self.client.get(&url);

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 0.6.12 — 2026-06-29
+
+**Chunk-loaded grids: sort survives refresh, count stays live**
+
+- A client-side sort on a single-pass, chunk-loaded (paged) scenery is now
+  re-imposed after every chunk load and refresh. A paged master that can't order
+  server-side returns rows in its native order on each refetch; the scenery
+  re-sorts the freshly-cached rows instead of snapping back to native order, so a
+  user's column sort no longer flickers away on the next poll. (Orders the loaded
+  rows — the documented cost of sorting a lazily-paged, non-orderable source.)
+- A chunk-loaded refresh now re-invokes `total_provider`, so a row that appeared
+  (or vanished) server-side since open grows (or shrinks) the row count instead of
+  staying frozen at the open-time total.
+- **A refresh repaints once, atomically — no intermediate-frame flicker.** A
+  chunk-loaded refresh used to bump the generation twice: once when re-counting
+  (start of the refresh) and again after the in-place refetch + re-sort landed,
+  with a network round-trip in between. The grid repainted in that gap — a brief
+  flash of the new row count against not-yet-refreshed/re-sorted rows. Re-count is
+  now silent and the forced refetch carries the single repaint, so the new count
+  and the refreshed, re-sorted rows appear together.
+- **A reordering refresh no longer duplicates/drops rows.** A paged refresh used
+  to re-fetch only the last viewport by absolute offset; if the master's order had
+  shifted (e.g. a `-last_updated` order a live source keeps bumping), a row that
+  migrated into the viewport was left ALSO sitting at its old slot (a duplicate),
+  silently evicting another row. Refresh now re-fetches the whole contiguous
+  loaded block containing the viewport, so a reorder reshuffles cleanly.
+- **Sort / filter on a dotted (nested) column now works.** A condition or sort on
+  a column like `launch_service_provider.name` — whose value lives in a nested CBOR
+  `Map` (a REST `?mode=detailed` belongs-to object) — used to look up the literal
+  flat key, find nothing, and silently no-op. Dotted keys now resolve into the
+  nested map.
+- **A client-sorted refresh never flashes the master's native order.** While a
+  refresh's in-place refetch landed, each chunk row was stamped straight into the
+  *displayed* map at its absolute master offset — so for the window between the
+  pushes and the re-sort the grid (which repaints on its own timer, not just on
+  generation bumps) could repaint the rows in the master's native order, then snap
+  back to the client sort. On a paged scenery with an active sort the displayed map
+  is now a pure projection of the cache: the chunk loader fills the cache and the
+  post-load re-sort is the sole writer of the visible map, so the order only ever
+  transitions atomically between sorted states.
+
 ## 0.6.11 — 2026-06-28
 
 **Lens reduced to pure caching**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -229,7 +229,27 @@ impl TableSceneryBuilder {
                 super::two_pass::reseed_filtered(&state).await;
                 state.bump_generation();
             }
+        } else if dio.lens.callbacks.on_load_chunk.is_some()
+            && dio.lens.callbacks.on_start.is_none()
+        {
+            // Pure paged lens (lazy chunk loading, no eager `on_start` warm): the
+            // row ORDER is the master's, fetched a page at a time — NOT the cache's
+            // id-keyed iteration order. Seeding densely from the cache here would
+            // both show the wrong order and make the viewport loader treat every
+            // row as already-cached and skip the authoritative fetch, so a warm
+            // cache (the redb file surviving a restart) would pin the grid to a
+            // stale, mis-ordered set until a forced refresh. Leave the map empty;
+            // the first viewport load fills it in the master's order.
+            // `total_provider` (above) already sized the scrollbar, so the grid
+            // shows its loading state, not a blank count.
+            //
+            // A hybrid lens that DOES warm via `on_start` (cache seeded in the
+            // master's list order) still reseeds below, so its cache-aware
+            // "skip already-loaded ranges" optimisation is preserved.
+            state.bump_generation();
         } else {
+            // Eager single-pass (or `on_start`-warmed hybrid): the cache IS the
+            // row set; seed (and order) from it directly.
             state.reseed_from_cache().await?;
             state.bump_generation();
         }

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -1,11 +1,37 @@
 use ciborium::Value as CborValue;
 use vantage_types::Record;
 
+/// Resolve a column key against a record, walking dotted paths (`obj.field`)
+/// into nested CBOR `Map`s. A REST `?mode=detailed` response stores belongs-to
+/// objects as nested maps (e.g. `launch_service_provider: { name: … }`) and
+/// surfaces their leaves as dotted columns, so a flat `rec.get("a.b")` misses
+/// them. Tries the literal key first (covers flat columns and any key that
+/// genuinely contains a dot), then descends segment by segment.
+pub(crate) fn record_get_path<'a>(rec: &'a Record<CborValue>, path: &str) -> Option<&'a CborValue> {
+    if let Some(v) = rec.get(path) {
+        return Some(v);
+    }
+    let mut segments = path.split('.');
+    let mut current = rec.get(segments.next()?)?;
+    for segment in segments {
+        let CborValue::Map(entries) = current else {
+            return None;
+        };
+        current = entries.iter().find_map(|(k, v)| match k {
+            CborValue::Text(name) if name == segment => Some(v),
+            _ => None,
+        })?;
+    }
+    Some(current)
+}
+
 pub(crate) fn matches_conditions(rec: &Record<CborValue>, conds: &[(String, CborValue)]) -> bool {
-    conds.iter().all(|(col, expected)| match rec.get(col) {
-        Some(v) => cbor_eq(v, expected),
-        None => false,
-    })
+    conds
+        .iter()
+        .all(|(col, expected)| match record_get_path(rec, col) {
+            Some(v) => cbor_eq(v, expected),
+            None => false,
+        })
 }
 
 pub(crate) fn matches_search(rec: &Record<CborValue>, needle: Option<&str>) -> bool {

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -303,10 +303,32 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             } else {
                 false
             };
-            // Bump when a row changed (a refresh of byte-identical rows leaves
-            // the flag clear) or when the total moved (so `row_count` consumers
-            // — scrollbars, `ListDio` — repaint).
-            if state.take_load_dirty() || total_changed {
+            // A client-side sort can't push down to a paged, non-orderable
+            // master, so this load (a viewport fetch, a scroll, or a refresh's
+            // in-place refetch) lands rows in the master's native order. Re-impose
+            // the active sort over the freshly-cached rows so the order survives
+            // the refetch instead of snapping back to native order. It orders only
+            // the loaded rows — the documented cost of sorting a lazily-paged
+            // source that can't order server-side.
+            let resorted = if state.sort.read().unwrap().is_some() {
+                if let Err(e) = state.reseed_from_cache().await {
+                    tracing::error!(error = %e, "post-load resort failed");
+                    false
+                } else {
+                    true
+                }
+            } else {
+                false
+            };
+            // Drain the dirty flag regardless (so it doesn't leak into the next
+            // load). Bump when this was a forced refetch (a refresh or load-more —
+            // it carries the single repaint for the whole refresh, including a
+            // `refresh_total` that updated the count without bumping), when the
+            // order was re-imposed, when a row changed (a refresh of byte-identical
+            // rows leaves the flag clear), or when the total moved (so `row_count`
+            // consumers — scrollbars, `ListDio` — repaint).
+            let dirty = state.take_load_dirty();
+            if force_load || resorted || dirty || total_changed {
                 state.bump_generation();
             }
             tracing::debug!(

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -262,6 +262,13 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn set_sort(&self, column: Option<String>, dir: SortDir) {
+        tracing::debug!(
+            target: "vantage_diorama::sort",
+            column = ?column,
+            dir = ?dir,
+            two_pass = self.inner.two_pass,
+            "set_sort",
+        );
         self.inner.deregister();
         *self.inner.sort.write().unwrap() = column.map(|c| (c, dir));
         self.inner.reload_notify.notify_one();

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -46,10 +46,10 @@ pub(crate) async fn reload_loop(
                             reseed(&state).await;
                         }
                     }
-                    Ok(DioEvent::RecordChanged { .. })
-                    | Ok(DioEvent::RecordInserted { .. })
-                    | Ok(DioEvent::RecordRemoved { .. })
-                    | Ok(DioEvent::Invalidated) => {
+                    Ok(DioEvent::RecordChanged { .. }
+                    | DioEvent::RecordInserted { .. }
+                    | DioEvent::RecordRemoved { .. }
+                    | DioEvent::Invalidated) => {
                         refresh(&state).await;
                     }
                     // Optimistic-write affordance: stamp just the affected row
@@ -84,6 +84,10 @@ pub(crate) async fn reload_loop(
 /// `on_refresh` has already restaged).
 async fn refresh(state: &Arc<TableSceneryState>) {
     if state.is_chunk_loaded() {
+        // Re-count first: a chunk-loaded scenery caches its total at open and
+        // would otherwise never notice a row that appeared (or vanished)
+        // server-side. Then re-fetch the current viewport in place.
+        state.refresh_total().await;
         state.refresh_loaded_viewport();
     } else {
         reseed(state).await;

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -12,7 +12,7 @@ use crate::dio::{DioInner, Generation};
 use crate::lens::SceneryChunkTarget;
 use crate::scenery::enriched_record::{EnrichedRecord, RowStatus};
 
-use super::helpers::{cbor_cmp, matches_conditions, matches_search};
+use super::helpers::{cbor_cmp, matches_conditions, matches_search, record_get_path};
 use super::{SortDir, ViewportRequest};
 
 /// Internal state shared by the public scenery handle, the reactor
@@ -187,13 +187,25 @@ impl TableSceneryState {
             .collect();
 
         if let Some((col, dir)) = sort {
+            let missing = filtered
+                .iter()
+                .filter(|(_, r)| record_get_path(r, &col).is_none())
+                .count();
             filtered.sort_by(|(_, a), (_, b)| {
-                let ord = cbor_cmp(a.get(&col), b.get(&col));
+                let ord = cbor_cmp(record_get_path(a, &col), record_get_path(b, &col));
                 match dir {
                     SortDir::Asc => ord,
                     SortDir::Desc => ord.reverse(),
                 }
             });
+            tracing::debug!(
+                target: "vantage_diorama::sort",
+                col = %col,
+                dir = ?dir,
+                rows = filtered.len(),
+                rows_missing_sort_value = missing,
+                "reseed_from_cache applied sort",
+            );
         }
 
         let mut rows = BTreeMap::new();
@@ -205,6 +217,35 @@ impl TableSceneryState {
         *self.rows.write().unwrap() = rows;
         *self.id_to_idx.write().unwrap() = id_to_idx;
         Ok(())
+    }
+
+    /// Re-invoke the lens `total_provider` and update the cached grand total, so
+    /// a row that appeared (or vanished) server-side since open grows (or shrinks)
+    /// the scrollbar instead of staying frozen at the open-time total. No-op when
+    /// no provider is registered (the total then self-corrects from short pages).
+    ///
+    /// Deliberately does NOT bump the generation: it runs at the *start* of a
+    /// refresh, before the in-place refetch repopulates the rows. Bumping here
+    /// would repaint an intermediate frame (new count, rows not yet refreshed /
+    /// re-sorted) — a visible flicker. The forced refetch that follows carries
+    /// the single repaint, so the new count and the refreshed+re-sorted rows land
+    /// together.
+    pub(crate) async fn refresh_total(&self) {
+        let Some(dio_inner) = self.dio_weak.upgrade() else {
+            return;
+        };
+        let Some(cb) = dio_inner.lens.callbacks.total_provider.as_ref() else {
+            return;
+        };
+        let dio = crate::Dio {
+            inner: dio_inner.clone(),
+        };
+        match cb(&dio).await {
+            Ok(total) => {
+                self.set_total(Some(total));
+            }
+            Err(e) => tracing::error!(error = %e, "refresh_total failed"),
+        }
     }
 
     /// React to `DioEvent::RecordChanged { id }`: if the id is in our
@@ -274,22 +315,42 @@ impl TableSceneryState {
             .unwrap_or(false)
     }
 
-    /// Re-fetch the last viewport in place so a refresh updates the visible
-    /// rows without blanking them: `force_load` overwrites each slot as the
-    /// fresh rows land, and a failed refetch leaves the existing rows
-    /// untouched (the loader never clears on error). No-op until a viewport
-    /// has been set.
+    /// Re-fetch the loaded rows in place so a refresh updates them without
+    /// blanking: `force_load` overwrites each slot as the fresh rows land, and a
+    /// failed refetch leaves the existing rows untouched (the loader never clears
+    /// on error). No-op until a viewport has been set.
+    ///
+    /// Re-fetches the whole **contiguous loaded block** that contains the
+    /// viewport, not just the viewport itself. The master serves rows by absolute
+    /// offset; if its order shifted since the last fetch — e.g. a `-last_updated`
+    /// order the live source keeps bumping — re-fetching only the viewport leaves
+    /// a row that migrated *into* it still sitting at its old slot, i.e. a
+    /// duplicate (and another row silently dropped). Overwriting the entire
+    /// contiguous block keeps every loaded slot consistent with the master's
+    /// current order, so a reorder reshuffles cleanly instead of scrambling.
     pub(crate) fn refresh_loaded_viewport(&self) {
-        let range = self.last_viewport.read().unwrap().clone();
-        if let Some(range) = range {
-            super::loader::enqueue_viewport(
-                self,
-                ViewportRequest {
-                    range,
-                    force_load: true,
-                },
-            );
-        }
+        let Some(viewport) = self.last_viewport.read().unwrap().clone() else {
+            return;
+        };
+        let range = {
+            let rows = self.rows.read().unwrap();
+            let mut start = viewport.start;
+            while start > 0 && rows.contains_key(&(start - 1)) {
+                start -= 1;
+            }
+            let mut end = viewport.end;
+            while rows.contains_key(&end) {
+                end += 1;
+            }
+            start..end
+        };
+        super::loader::enqueue_viewport(
+            self,
+            ViewportRequest {
+                range,
+                force_load: true,
+            },
+        );
     }
 
     /// Largest cached index, +1 — the natural start for the next
@@ -308,9 +369,19 @@ impl TableSceneryState {
 
 impl SceneryChunkTarget for TableSceneryState {
     fn write_chunk_row(&self, idx: usize, id: String, record: Record<CborValue>) {
-        // Count every received row (before the skip below), so the loader can
+        // Count every received row (before the skips below), so the loader can
         // tell a short page (end of set) from a full one.
         self.load_push_count.fetch_add(1, Ordering::SeqCst);
+        // With a client sort active, the displayed map is a pure projection of
+        // the cache, rebuilt by `reseed_from_cache` once the load finishes (the
+        // loader re-sorts whenever `sort` is set). The cache row was already
+        // written by `ChunkSink::push`, so there is nothing more to do here —
+        // and stamping this server-ordered row into the visible map would expose
+        // the master's native order in the window before the re-sort runs, a
+        // flicker the grid repaints on its own timer. Let reseed own the map.
+        if self.sort.read().unwrap().is_some() {
+            return;
+        }
         // Skip the write entirely when this slot already holds the same fresh
         // record: a refresh that re-fetches identical data must not look like a
         // change. Only a new/!Fresh slot or a different record is "dirty", and

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -95,7 +95,7 @@ fn references_augmented_column(
 /// column is absent → no match), so matches surface as rows hydrate. The row's
 /// `Fresh`/`Incomplete` status is preserved.
 pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
-    use super::helpers::{cbor_cmp, matches_conditions, matches_search};
+    use super::helpers::{cbor_cmp, matches_conditions, matches_search, record_get_path};
 
     let Some(dio_inner) = state.dio_weak.upgrade() else {
         return;
@@ -126,7 +126,7 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
 
     if let Some((col, dir)) = &sort {
         gathered.sort_by(|(_, a, _), (_, b, _)| {
-            let ord = cbor_cmp(a.get(col), b.get(col));
+            let ord = cbor_cmp(record_get_path(a, col), record_get_path(b, col));
             match dir {
                 SortDir::Asc => ord,
                 SortDir::Desc => ord.reverse(),

--- a/vantage-diorama/tests/chunk_refresh_no_transient.rs
+++ b/vantage-diorama/tests/chunk_refresh_no_transient.rs
@@ -1,0 +1,159 @@
+//! A client-sorted, chunk-loaded scenery must never expose the master's native
+//! order — not even for the brief window between a refresh's in-place refetch
+//! and the re-sort that follows it.
+//!
+//! The grid repaints on its own timer (independent of generation bumps), so any
+//! moment the displayed rows sit in master order is a visible flicker: the order
+//! jumps to the server's order while the chunk lands, then snaps back once the
+//! sort is re-imposed. The fix makes the displayed map a pure projection of the
+//! cache via the re-sort, so `push` fills the cache without ever stamping
+//! server-ordered rows into the visible map.
+//!
+//! This test observes the rows *from inside* `on_load_chunk`, right after the
+//! pushes and before the loader's re-sort — exactly the window the grid can
+//! repaint in.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Generation, Lens, SortDir, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn rec(v: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r
+}
+
+fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get("v") {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("v", "String"))
+        .with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+/// Master native order is (a=v3, b=v1, c=v2). Sorted ascending the view is
+/// (v1, v2, v3). On a refresh, `on_load_chunk` pushes in master order; the test
+/// reads `row(0)` straight after those pushes (before the loader re-sorts) and
+/// asserts it is still the sorted top — never the master top.
+#[tokio::test]
+async fn refresh_never_exposes_master_order_midload() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("v3")),
+        ("b".into(), rec("v1")),
+        ("c".into(), rec("v2")),
+    ]));
+
+    // Shared seams: the scenery handle (set after open) and the order observed
+    // from inside the refresh's chunk load.
+    let scenery_slot: Arc<Mutex<Option<Weak<dyn TableScenery>>>> = Arc::new(Mutex::new(None));
+    let observed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let load_count = Arc::new(AtomicUsize::new(0));
+
+    let lens = {
+        let backend = backend.clone();
+        let total = backend.clone();
+        let scenery_slot = scenery_slot.clone();
+        let observed = observed.clone();
+        let load_count = load_count.clone();
+        Arc::new(
+            Lens::new()
+                .cache_at(tmp.path().join("c.redb"))
+                .total_provider(move |_dio| {
+                    let b = total.clone();
+                    async move { Ok(b.lock().unwrap().len()) }
+                })
+                .on_load_chunk(move |_dio, range, sink| {
+                    let b = backend.clone();
+                    let scenery_slot = scenery_slot.clone();
+                    let observed = observed.clone();
+                    let load_count = load_count.clone();
+                    async move {
+                        let rows = b.lock().unwrap().clone();
+                        for idx in range {
+                            if let Some((id, r)) = rows.get(idx) {
+                                sink.push(idx, id.clone(), r.clone()).await?;
+                            }
+                        }
+                        // Second load == the refresh's in-place refetch. Snapshot
+                        // the visible order in the post-push / pre-resort window.
+                        if load_count.fetch_add(1, Ordering::SeqCst) == 1 {
+                            if let Some(scenery) = scenery_slot
+                                .lock()
+                                .unwrap()
+                                .as_ref()
+                                .and_then(Weak::upgrade)
+                            {
+                                let snap: Vec<String> =
+                                    (0..3).filter_map(|i| value(&scenery, i)).collect();
+                                *observed.lock().unwrap() = snap;
+                            }
+                        }
+                        Ok(())
+                    }
+                })
+                .build()
+                .expect("build paged lens"),
+        )
+    };
+
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    *scenery_slot.lock().unwrap() = Some(Arc::downgrade(&scenery));
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..3);
+    wait_for_gen(&mut gen_rx, g0).await;
+
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("v".to_string()), SortDir::Asc);
+    wait_for_gen(&mut gen_rx, g1).await;
+    assert_eq!(value(&scenery, 0).as_deref(), Some("v1"), "sorted top");
+
+    let g2 = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g2).await;
+
+    // What the grid could have repainted mid-refresh.
+    let observed = observed.lock().unwrap().clone();
+    assert_eq!(
+        observed,
+        vec!["v1".to_string(), "v2".to_string(), "v3".to_string()],
+        "mid-refresh the visible order must stay sorted, never the master's (v3,v1,v2)"
+    );
+
+    // And the settled order is sorted too.
+    assert_eq!(value(&scenery, 0).as_deref(), Some("v1"), "settled top");
+    assert_eq!(value(&scenery, 2).as_deref(), Some("v3"), "settled bottom");
+    Ok(())
+}

--- a/vantage-diorama/tests/chunk_refresh_no_transient.rs
+++ b/vantage-diorama/tests/chunk_refresh_no_transient.rs
@@ -15,14 +15,16 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_core::Result;
-use vantage_diorama::{Generation, Lens, SortDir, TableScenery};
+use vantage_diorama::{Lens, SortDir, TableScenery};
 use vantage_types::Record;
-use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+use vantage_vista::Vista;
+
+mod support;
+use support::chunk::{Backend, col_at, master as master_cols, wait_for_gen};
 
 fn rec(v: &str) -> Record<CborValue> {
     let mut r = Record::new();
@@ -31,33 +33,11 @@ fn rec(v: &str) -> Record<CborValue> {
 }
 
 fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
-    scenery.row(idx).and_then(|r| match r.record.get("v") {
-        Some(CborValue::Text(s)) => Some(s.clone()),
-        _ => None,
-    })
+    col_at(scenery, idx, "v")
 }
 
 fn master() -> Vista {
-    let metadata = VistaMetadata::new()
-        .with_column(Column::new("id", "String").with_flag("id"))
-        .with_column(Column::new("v", "String"))
-        .with_id_column("id");
-    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
-}
-
-type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
-
-async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
-    tokio::time::timeout(Duration::from_millis(500), async {
-        loop {
-            if u64::from(*rx.borrow_and_update()) > current {
-                return u64::from(*rx.borrow());
-            }
-            rx.changed().await.expect("watch channel closed");
-        }
-    })
-    .await
-    .expect("timed out waiting for generation bump")
+    master_cols(&[("v", "String")])
 }
 
 /// Master native order is (a=v3, b=v1, c=v2). Sorted ascending the view is

--- a/vantage-diorama/tests/chunk_refresh_no_transient.rs
+++ b/vantage-diorama/tests/chunk_refresh_no_transient.rs
@@ -106,17 +106,16 @@ async fn refresh_never_exposes_master_order_midload() -> Result<()> {
                         }
                         // Second load == the refresh's in-place refetch. Snapshot
                         // the visible order in the post-push / pre-resort window.
-                        if load_count.fetch_add(1, Ordering::SeqCst) == 1 {
-                            if let Some(scenery) = scenery_slot
+                        if load_count.fetch_add(1, Ordering::SeqCst) == 1
+                            && let Some(scenery) = scenery_slot
                                 .lock()
                                 .unwrap()
                                 .as_ref()
                                 .and_then(Weak::upgrade)
-                            {
-                                let snap: Vec<String> =
-                                    (0..3).filter_map(|i| value(&scenery, i)).collect();
-                                *observed.lock().unwrap() = snap;
-                            }
+                        {
+                            let snap: Vec<String> =
+                                (0..3).filter_map(|i| value(&scenery, i)).collect();
+                            *observed.lock().unwrap() = snap;
                         }
                         Ok(())
                     }

--- a/vantage-diorama/tests/chunk_refresh_reorder.rs
+++ b/vantage-diorama/tests/chunk_refresh_reorder.rs
@@ -6,14 +6,18 @@
 //! that scramble.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_core::Result;
-use vantage_diorama::{Generation, Lens, TableScenery};
+use vantage_diorama::TableScenery;
 use vantage_types::Record;
-use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+use vantage_vista::Vista;
+
+mod support;
+use support::chunk::{
+    Backend, col_at, master as master_cols, paged_lens_native_desc, settle, wait_for_gen,
+};
 
 fn rec(name: &str, lu: i64) -> Record<CborValue> {
     let mut r = Record::new();
@@ -23,74 +27,15 @@ fn rec(name: &str, lu: i64) -> Record<CborValue> {
 }
 
 fn name_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
-    scenery.row(idx).and_then(|r| match r.record.get("name") {
-        Some(CborValue::Text(s)) => Some(s.clone()),
-        _ => None,
-    })
+    col_at(scenery, idx, "name")
 }
 
 fn master() -> Vista {
-    let metadata = VistaMetadata::new()
-        .with_column(Column::new("id", "String").with_flag("id"))
-        .with_column(Column::new("name", "String"))
-        .with_column(Column::new("lu", "i64"))
-        .with_id_column("id");
-    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+    master_cols(&[("name", "String"), ("lu", "i64")])
 }
 
-type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
-
-fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
-    let total = backend.clone();
-    let lens = Lens::new()
-        .cache_at(cache)
-        .total_provider(move |_dio| {
-            let b = total.clone();
-            async move { Ok(b.lock().unwrap().len()) }
-        })
-        .on_load_chunk(move |_dio, range, sink| {
-            let b = backend.clone();
-            async move {
-                // Native order = lu DESC (mirrors ?ordering=-last_updated).
-                let mut rows = b.lock().unwrap().clone();
-                rows.sort_by(|a, b| {
-                    let la = a.1.get("lu");
-                    let lb = b.1.get("lu");
-                    match (la, lb) {
-                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
-                            i128::from(*y).cmp(&i128::from(*x))
-                        }
-                        _ => std::cmp::Ordering::Equal,
-                    }
-                });
-                for idx in range {
-                    if let Some((id, r)) = rows.get(idx) {
-                        sink.push(idx, id.clone(), r.clone()).await?;
-                    }
-                }
-                Ok(())
-            }
-        })
-        .build()
-        .expect("build paged lens");
-    Arc::new(lens)
-}
-
-async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
-    tokio::time::timeout(Duration::from_millis(500), async {
-        loop {
-            if u64::from(*rx.borrow_and_update()) > current {
-                return u64::from(*rx.borrow());
-            }
-            rx.changed().await.expect("watch channel closed");
-        }
-    })
-    .await
-    .expect("timed out waiting for generation bump")
-}
-
-async fn settle() {
-    tokio::time::sleep(Duration::from_millis(80)).await;
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<vantage_diorama::Lens> {
+    paged_lens_native_desc(cache, backend, "lu")
 }
 
 #[tokio::test]

--- a/vantage-diorama/tests/chunk_refresh_reorder.rs
+++ b/vantage-diorama/tests/chunk_refresh_reorder.rs
@@ -1,0 +1,145 @@
+//! A chunk-loaded grid with NO client sort, showing the master's native order
+//! (e.g. REST `?ordering=-last_updated`). When that native order SHIFTS between
+//! refreshes (the simulator bumps `last_updated`) and the refresh re-fetches only
+//! a partial viewport by absolute offset, a row that migrated into the refetched
+//! window can be left ALSO occupying its old slot — a duplicate. This reproduces
+//! that scramble.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Generation, Lens, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn rec(name: &str, lu: i64) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("name".to_string(), CborValue::Text(name.to_string()));
+    r.insert("lu".to_string(), CborValue::Integer(lu.into()));
+    r
+}
+
+fn name_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get("name") {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_column(Column::new("lu", "i64"))
+        .with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            async move {
+                // Native order = lu DESC (mirrors ?ordering=-last_updated).
+                let mut rows = b.lock().unwrap().clone();
+                rows.sort_by(|a, b| {
+                    let la = a.1.get("lu");
+                    let lb = b.1.get("lu");
+                    match (la, lb) {
+                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
+                            i128::from(*y).cmp(&i128::from(*x))
+                        }
+                        _ => std::cmp::Ordering::Equal,
+                    }
+                });
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(80)).await;
+}
+
+#[tokio::test]
+async fn refresh_after_reorder_does_not_duplicate_rows() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    // Native order lu desc: a,b,c,d (a newest).
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("a", 40)),
+        ("b".into(), rec("b", 30)),
+        ("c".into(), rec("c", 20)),
+        ("d".into(), rec("d", 10)),
+    ]));
+    let lens = paged_lens(tmp.path().join("c.redb"), backend.clone());
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    // Load the whole set, then narrow the live viewport to the top rows (the
+    // grid's visible window is smaller than what it has loaded).
+    let g = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..4);
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+    assert_eq!(name_at(&scenery, 0).as_deref(), Some("a"));
+    assert_eq!(name_at(&scenery, 3).as_deref(), Some("d"));
+
+    scenery.set_viewport(0..2); // visible window shrinks; last_viewport = 0..2
+    settle().await;
+
+    // Simulator bumps d to the top: native order becomes d,a,b,c.
+    backend.lock().unwrap()[3].1 = rec("d", 99);
+    let g = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+
+    // Collect the visible names across the full row_count and assert no id/name
+    // appears twice — a refetch of a shifted order must not duplicate rows.
+    let names: Vec<String> = (0..scenery.row_count())
+        .filter_map(|i| name_at(&scenery, i))
+        .collect();
+    let mut sorted = names.clone();
+    sorted.sort();
+    let before = sorted.len();
+    sorted.dedup();
+    assert_eq!(
+        sorted.len(),
+        before,
+        "rows must not be duplicated after a reordering refresh; saw {names:?}"
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/chunk_sort.rs
+++ b/vantage-diorama/tests/chunk_sort.rs
@@ -10,14 +10,15 @@
 //!      total is not frozen at its open-time value.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_core::Result;
-use vantage_diorama::{Generation, Lens, SortDir, TableScenery};
+use vantage_diorama::{SortDir, TableScenery};
 use vantage_types::Record;
-use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+mod support;
+use support::chunk::{Backend, col_at, master as master_cols, paged_lens, wait_for_gen};
 
 fn rec(v: &str) -> Record<CborValue> {
     let mut r = Record::new();
@@ -26,64 +27,11 @@ fn rec(v: &str) -> Record<CborValue> {
 }
 
 fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
-    scenery.row(idx).and_then(|r| match r.record.get("v") {
-        Some(CborValue::Text(s)) => Some(s.clone()),
-        _ => None,
-    })
+    col_at(scenery, idx, "v")
 }
 
-/// Master only supplies metadata + the (false) order capability; rows come from
-/// `backend` via `on_load_chunk`.
-fn master() -> Vista {
-    let metadata = VistaMetadata::new()
-        .with_column(Column::new("id", "String").with_flag("id"))
-        .with_column(Column::new("v", "String"))
-        .with_id_column("id");
-    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
-}
-
-type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
-
-/// Paged lens with NO `on_refresh` — refresh flows through the scenery's
-/// in-place viewport refetch. `on_load_chunk` pushes each row at its absolute
-/// `backend` index (the master's native order). `total_provider` reports the
-/// live `backend` length, so a re-count picks up appended rows.
-fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
-    let total = backend.clone();
-    let lens = Lens::new()
-        .cache_at(cache)
-        .total_provider(move |_dio| {
-            let b = total.clone();
-            async move { Ok(b.lock().unwrap().len()) }
-        })
-        .on_load_chunk(move |_dio, range, sink| {
-            let b = backend.clone();
-            async move {
-                let rows = b.lock().unwrap().clone();
-                for idx in range {
-                    if let Some((id, r)) = rows.get(idx) {
-                        sink.push(idx, id.clone(), r.clone()).await?;
-                    }
-                }
-                Ok(())
-            }
-        })
-        .build()
-        .expect("build paged lens");
-    Arc::new(lens)
-}
-
-async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
-    tokio::time::timeout(Duration::from_millis(500), async {
-        loop {
-            if u64::from(*rx.borrow_and_update()) > current {
-                return u64::from(*rx.borrow());
-            }
-            rx.changed().await.expect("watch channel closed");
-        }
-    })
-    .await
-    .expect("timed out waiting for generation bump")
+fn master() -> vantage_vista::Vista {
+    master_cols(&[("v", "String")])
 }
 
 /// Sort by `v` ascending, then refresh. The backend stays in its native order

--- a/vantage-diorama/tests/chunk_sort.rs
+++ b/vantage-diorama/tests/chunk_sort.rs
@@ -1,0 +1,172 @@
+//! Sort + count behaviour for single-pass, chunk-loaded (paged/lazy) sceneries
+//! whose master can't push order down (e.g. the generic api-client).
+//!
+//! Two guarantees:
+//!   1. A client-side sort survives a refresh. Refresh re-fetches the viewport
+//!      from the master in the master's *native* order; the scenery must
+//!      re-impose the active sort over the freshly-loaded rows instead of
+//!      leaving them server-ordered.
+//!   2. Refresh re-counts. A newly-appeared row grows `row_count` — the cached
+//!      total is not frozen at its open-time value.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Generation, Lens, SortDir, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn rec(v: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r
+}
+
+fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get("v") {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+/// Master only supplies metadata + the (false) order capability; rows come from
+/// `backend` via `on_load_chunk`.
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("v", "String"))
+        .with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+/// Paged lens with NO `on_refresh` — refresh flows through the scenery's
+/// in-place viewport refetch. `on_load_chunk` pushes each row at its absolute
+/// `backend` index (the master's native order). `total_provider` reports the
+/// live `backend` length, so a re-count picks up appended rows.
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            async move {
+                let rows = b.lock().unwrap().clone();
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+/// Sort by `v` ascending, then refresh. The backend stays in its native order
+/// (a=v3, b=v1, c=v2); the sorted view (v1, v2, v3) must survive the refresh's
+/// in-place refetch.
+#[tokio::test]
+async fn client_sort_survives_refresh() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("v3")),
+        ("b".into(), rec("v1")),
+        ("c".into(), rec("v2")),
+    ]));
+    let lens = paged_lens(tmp.path().join("c.redb"), backend.clone());
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..3);
+    wait_for_gen(&mut gen_rx, g0).await;
+    assert_eq!(value(&scenery, 0).as_deref(), Some("v3"), "native order");
+
+    // User sorts by `v` ascending → v1, v2, v3.
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("v".to_string()), SortDir::Asc);
+    wait_for_gen(&mut gen_rx, g1).await;
+    assert_eq!(value(&scenery, 0).as_deref(), Some("v1"), "sorted top");
+    assert_eq!(value(&scenery, 2).as_deref(), Some("v3"), "sorted bottom");
+
+    // A refresh (e.g. the page's live poll) refetches the viewport in the
+    // master's native order. The active sort must be re-imposed, not clobbered.
+    let g2 = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g2).await;
+
+    assert_eq!(
+        value(&scenery, 0).as_deref(),
+        Some("v1"),
+        "sort must survive refresh (top)"
+    );
+    assert_eq!(
+        value(&scenery, 1).as_deref(),
+        Some("v2"),
+        "sort must survive refresh (middle)"
+    );
+    assert_eq!(
+        value(&scenery, 2).as_deref(),
+        Some("v3"),
+        "sort must survive refresh (bottom)"
+    );
+    Ok(())
+}
+
+/// A row appended to the backend must grow `row_count` on the next refresh —
+/// the open-time total is not frozen.
+#[tokio::test]
+async fn refresh_recounts_appended_rows() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("v1")),
+        ("b".into(), rec("v2")),
+    ]));
+    let lens = paged_lens(tmp.path().join("c.redb"), backend.clone());
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..2);
+    wait_for_gen(&mut gen_rx, g0).await;
+    assert_eq!(scenery.row_count(), 2);
+
+    // A new launch appears server-side.
+    backend.lock().unwrap().push(("c".into(), rec("v3")));
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g1).await;
+
+    assert_eq!(
+        scenery.row_count(),
+        3,
+        "refresh must re-count and reflect the appended row"
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/chunk_sort_fidelity.rs
+++ b/vantage-diorama/tests/chunk_sort_fidelity.rs
@@ -8,14 +8,19 @@
 //! The user's client-side sort by `v` must hold through all of it.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_core::Result;
-use vantage_diorama::{Generation, Lens, SortDir, TableScenery};
+use vantage_diorama::{SortDir, TableScenery};
 use vantage_types::Record;
-use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+use vantage_vista::Vista;
+
+mod support;
+use support::chunk::{
+    Backend, master as master_cols, order as order_col, paged_lens_native_desc, settle,
+    wait_for_gen,
+};
 
 /// A backend row: a stable id, a sort value `v`, and a `last_updated` `lu` that
 /// the "simulator" bumps to reorder the native (server) order.
@@ -26,86 +31,18 @@ fn rec(v: &str, lu: i64) -> Record<CborValue> {
     r
 }
 
-fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
-    scenery.row(idx).and_then(|r| match r.record.get("v") {
-        Some(CborValue::Text(s)) => Some(s.clone()),
-        _ => None,
-    })
-}
-
 fn order(scenery: &Arc<dyn TableScenery>) -> Vec<String> {
-    (0..scenery.row_count())
-        .filter_map(|i| value(scenery, i))
-        .collect()
+    order_col(scenery, "v")
 }
 
 fn master() -> Vista {
-    let metadata = VistaMetadata::new()
-        .with_column(Column::new("id", "String").with_flag("id"))
-        .with_column(Column::new("v", "String"))
-        .with_column(Column::new("lu", "i64"))
-        .with_id_column("id");
-    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+    master_cols(&[("v", "String"), ("lu", "i64")])
 }
 
-type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
-
-/// Paged lens whose `on_load_chunk` serves rows in **native order** = `lu`
+/// Paged lens whose `on_load_chunk` serves rows in native order = `lu`
 /// descending (mirrors the launches URL `?ordering=-last_updated`), windowed.
-/// This is what a non-orderable paged master does: the client sort never
-/// reaches it.
-fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
-    let total = backend.clone();
-    let lens = Lens::new()
-        .cache_at(cache)
-        .total_provider(move |_dio| {
-            let b = total.clone();
-            async move { Ok(b.lock().unwrap().len()) }
-        })
-        .on_load_chunk(move |_dio, range, sink| {
-            let b = backend.clone();
-            async move {
-                // Native order: lu DESC, like the server's baked ordering.
-                let mut rows = b.lock().unwrap().clone();
-                rows.sort_by(|a, b| {
-                    let la = a.1.get("lu");
-                    let lb = b.1.get("lu");
-                    match (la, lb) {
-                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
-                            i128::from(*y).cmp(&i128::from(*x))
-                        }
-                        _ => std::cmp::Ordering::Equal,
-                    }
-                });
-                for idx in range {
-                    if let Some((id, r)) = rows.get(idx) {
-                        sink.push(idx, id.clone(), r.clone()).await?;
-                    }
-                }
-                Ok(())
-            }
-        })
-        .build()
-        .expect("build paged lens");
-    Arc::new(lens)
-}
-
-async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
-    tokio::time::timeout(Duration::from_millis(500), async {
-        loop {
-            if u64::from(*rx.borrow_and_update()) > current {
-                return u64::from(*rx.borrow());
-            }
-            rx.changed().await.expect("watch channel closed");
-        }
-    })
-    .await
-    .expect("timed out waiting for generation bump")
-}
-
-/// Let the viewport debounce + chunk load settle.
-async fn settle() {
-    tokio::time::sleep(Duration::from_millis(80)).await;
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<vantage_diorama::Lens> {
+    paged_lens_native_desc(cache, backend, "lu")
 }
 
 #[tokio::test]

--- a/vantage-diorama/tests/chunk_sort_fidelity.rs
+++ b/vantage-diorama/tests/chunk_sort_fidelity.rs
@@ -1,0 +1,208 @@
+//! High-fidelity reproduction of the launch-control launches grid:
+//!   - paged/chunk-loaded, NO eager `on_start` (cache fills via viewport loads)
+//!   - master serves rows in its own native order (`ordering=-last_updated`),
+//!     which DIFFERS from the user's chosen sort column AND changes between
+//!     refreshes (the live simulator bumps `last_updated`)
+//!   - the grid re-issues `set_viewport` after each generation bump (the watcher)
+//!
+//! The user's client-side sort by `v` must hold through all of it.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Generation, Lens, SortDir, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+/// A backend row: a stable id, a sort value `v`, and a `last_updated` `lu` that
+/// the "simulator" bumps to reorder the native (server) order.
+fn rec(v: &str, lu: i64) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r.insert("lu".to_string(), CborValue::Integer(lu.into()));
+    r
+}
+
+fn value(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get("v") {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+fn order(scenery: &Arc<dyn TableScenery>) -> Vec<String> {
+    (0..scenery.row_count())
+        .filter_map(|i| value(scenery, i))
+        .collect()
+}
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("v", "String"))
+        .with_column(Column::new("lu", "i64"))
+        .with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+/// Paged lens whose `on_load_chunk` serves rows in **native order** = `lu`
+/// descending (mirrors the launches URL `?ordering=-last_updated`), windowed.
+/// This is what a non-orderable paged master does: the client sort never
+/// reaches it.
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            async move {
+                // Native order: lu DESC, like the server's baked ordering.
+                let mut rows = b.lock().unwrap().clone();
+                rows.sort_by(|a, b| {
+                    let la = a.1.get("lu");
+                    let lb = b.1.get("lu");
+                    match (la, lb) {
+                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
+                            i128::from(*y).cmp(&i128::from(*x))
+                        }
+                        _ => std::cmp::Ordering::Equal,
+                    }
+                });
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+/// Let the viewport debounce + chunk load settle.
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(80)).await;
+}
+
+#[tokio::test]
+async fn client_sort_holds_through_reordering_refreshes() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    // Native order by lu desc is: c(30), a(20), b(10). Sort by v asc is a,b,c.
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("a", 20)),
+        ("b".into(), rec("b", 10)),
+        ("c".into(), rec("c", 30)),
+    ]));
+    let lens = paged_lens(tmp.path().join("c.redb"), backend.clone());
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    // Grid sets its viewport; cache fills from the master in native order.
+    let g = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..3);
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+    assert_eq!(
+        order(&scenery),
+        vec!["c", "a", "b"],
+        "native order (lu desc)"
+    );
+
+    // User sorts by v ascending.
+    let g = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("v".to_string()), SortDir::Asc);
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+    assert_eq!(order(&scenery), vec!["a", "b", "c"], "sorted by v");
+
+    // The simulator reorders native order (bump b's lu to the top) and a refresh
+    // fires. The client sort must still hold.
+    backend.lock().unwrap()[1].1 = rec("b", 99); // b now newest
+    let g = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+    // The grid re-issues its viewport after the bump (the watcher does this).
+    scenery.set_viewport(0..3);
+    settle().await;
+    assert_eq!(
+        order(&scenery),
+        vec!["a", "b", "c"],
+        "sort holds after a reordering refresh + viewport re-issue"
+    );
+
+    // A second refresh for good measure.
+    backend.lock().unwrap()[0].1 = rec("a", 1); // a now oldest
+    let g = u64::from(*gen_rx.borrow_and_update());
+    dio.refresh().await?;
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+    scenery.set_viewport(0..3);
+    settle().await;
+    assert_eq!(
+        order(&scenery),
+        vec!["a", "b", "c"],
+        "sort still holds after a second reordering refresh"
+    );
+    Ok(())
+}
+
+/// Same, but the cache is only PARTIALLY loaded when the user sorts (page_size <
+/// total) — then the user scrolls to load the rest. Documents how far the
+/// local sort reaches as more rows load.
+#[tokio::test]
+async fn client_sort_with_partial_then_full_load() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    // Native order lu desc: e,d,c,b,a. Sort by v asc: a,b,c,d,e.
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("a".into(), rec("a", 10)),
+        ("b".into(), rec("b", 20)),
+        ("c".into(), rec("c", 30)),
+        ("d".into(), rec("d", 40)),
+        ("e".into(), rec("e", 50)),
+    ]));
+    let lens = paged_lens(tmp.path().join("c.redb"), backend.clone());
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    // Load only the first viewport.
+    let g = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..5);
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+
+    // Sort by v asc, with everything loaded → full sort.
+    let g = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("v".to_string()), SortDir::Asc);
+    wait_for_gen(&mut gen_rx, g).await;
+    settle().await;
+    assert_eq!(order(&scenery), vec!["a", "b", "c", "d", "e"], "full sort");
+
+    Ok(())
+}

--- a/vantage-diorama/tests/chunk_warm_cache_order.rs
+++ b/vantage-diorama/tests/chunk_warm_cache_order.rs
@@ -4,14 +4,19 @@
 //! itself from the cache in id order and then skip the authoritative fetch.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_core::Result;
-use vantage_diorama::{Generation, Lens, TableScenery};
+use vantage_diorama::TableScenery;
 use vantage_types::Record;
-use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+use vantage_vista::Vista;
+
+mod support;
+use support::chunk::{
+    Backend, master as master_cols, order as order_col, paged_lens_native_desc, settle,
+    wait_for_gen,
+};
 
 fn rec(name: &str, pos: i64) -> Record<CborValue> {
     let mut r = Record::new();
@@ -20,82 +25,18 @@ fn rec(name: &str, pos: i64) -> Record<CborValue> {
     r
 }
 
-fn name_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
-    scenery.row(idx).and_then(|r| match r.record.get("name") {
-        Some(CborValue::Text(s)) => Some(s.clone()),
-        _ => None,
-    })
-}
-
 fn order(scenery: &Arc<dyn TableScenery>) -> Vec<String> {
-    (0..scenery.row_count())
-        .filter_map(|i| name_at(scenery, i))
-        .collect()
+    order_col(scenery, "name")
 }
 
 fn master() -> Vista {
-    let metadata = VistaMetadata::new()
-        .with_column(Column::new("id", "String").with_flag("id"))
-        .with_column(Column::new("name", "String"))
-        .with_column(Column::new("pos", "i64"))
-        .with_id_column("id");
-    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+    master_cols(&[("name", "String"), ("pos", "i64")])
 }
-
-type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
 
 /// `on_load_chunk` serves rows by `pos` DESC — the master's native order, which
 /// is deliberately different from id order.
-fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
-    let total = backend.clone();
-    let lens = Lens::new()
-        .cache_at(cache)
-        .total_provider(move |_dio| {
-            let b = total.clone();
-            async move { Ok(b.lock().unwrap().len()) }
-        })
-        .on_load_chunk(move |_dio, range, sink| {
-            let b = backend.clone();
-            async move {
-                let mut rows = b.lock().unwrap().clone();
-                rows.sort_by(|a, b| {
-                    let pa = a.1.get("pos");
-                    let pb = b.1.get("pos");
-                    match (pa, pb) {
-                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
-                            i128::from(*y).cmp(&i128::from(*x))
-                        }
-                        _ => std::cmp::Ordering::Equal,
-                    }
-                });
-                for idx in range {
-                    if let Some((id, r)) = rows.get(idx) {
-                        sink.push(idx, id.clone(), r.clone()).await?;
-                    }
-                }
-                Ok(())
-            }
-        })
-        .build()
-        .expect("build paged lens");
-    Arc::new(lens)
-}
-
-async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
-    tokio::time::timeout(Duration::from_millis(500), async {
-        loop {
-            if u64::from(*rx.borrow_and_update()) > current {
-                return u64::from(*rx.borrow());
-            }
-            rx.changed().await.expect("watch channel closed");
-        }
-    })
-    .await
-    .expect("timed out waiting for generation bump")
-}
-
-async fn settle() {
-    tokio::time::sleep(Duration::from_millis(80)).await;
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<vantage_diorama::Lens> {
+    paged_lens_native_desc(cache, backend, "pos")
 }
 
 #[tokio::test]

--- a/vantage-diorama/tests/chunk_warm_cache_order.rs
+++ b/vantage-diorama/tests/chunk_warm_cache_order.rs
@@ -1,0 +1,142 @@
+//! A chunk-loaded grid's row ORDER is the master's (fetched per page), not the
+//! cache's id-keyed iteration order. On reopen with a WARM cache (the redb file
+//! survives a restart), the grid must still show the master's order — not seed
+//! itself from the cache in id order and then skip the authoritative fetch.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Generation, Lens, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn rec(name: &str, pos: i64) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("name".to_string(), CborValue::Text(name.to_string()));
+    r.insert("pos".to_string(), CborValue::Integer(pos.into()));
+    r
+}
+
+fn name_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get("name") {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+fn order(scenery: &Arc<dyn TableScenery>) -> Vec<String> {
+    (0..scenery.row_count())
+        .filter_map(|i| name_at(scenery, i))
+        .collect()
+}
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_column(Column::new("pos", "i64"))
+        .with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+/// `on_load_chunk` serves rows by `pos` DESC — the master's native order, which
+/// is deliberately different from id order.
+fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            async move {
+                let mut rows = b.lock().unwrap().clone();
+                rows.sort_by(|a, b| {
+                    let pa = a.1.get("pos");
+                    let pb = b.1.get("pos");
+                    match (pa, pb) {
+                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
+                            i128::from(*y).cmp(&i128::from(*x))
+                        }
+                        _ => std::cmp::Ordering::Equal,
+                    }
+                });
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+async fn settle() {
+    tokio::time::sleep(Duration::from_millis(80)).await;
+}
+
+#[tokio::test]
+async fn warm_cache_reopen_shows_master_order_not_id_order() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("c.redb");
+    // id order is 1,2,3; master (pos desc) order is 2,3,1.
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("1".into(), rec("one", 10)),
+        ("2".into(), rec("two", 30)),
+        ("3".into(), rec("three", 20)),
+    ]));
+    let lens = paged_lens(cache, backend.clone());
+    let dio = lens.make_dio(master()).await?;
+
+    // First open warms the cache via a viewport load.
+    {
+        let s1 = dio.table_scenery().open().await?;
+        let mut rx = s1.subscribe();
+        let g = u64::from(*rx.borrow_and_update());
+        s1.set_viewport(0..3);
+        wait_for_gen(&mut rx, g).await;
+        settle().await;
+        assert_eq!(
+            order(&s1),
+            vec!["two", "three", "one"],
+            "master order on cold open"
+        );
+    }
+
+    // Reopen with the warm cache — same Dio, cache retains the 3 rows.
+    let s2 = dio.table_scenery().open().await?;
+    let mut rx = s2.subscribe();
+    s2.set_viewport(0..3);
+    settle().await;
+    let _ = wait_for_gen(&mut rx, 0).await;
+    settle().await;
+    assert_eq!(
+        order(&s2),
+        vec!["two", "three", "one"],
+        "warm-cache reopen must show the master's order, not the cache's id order"
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/nested_sort.rs
+++ b/vantage-diorama/tests/nested_sort.rs
@@ -1,0 +1,97 @@
+//! Sorting / filtering by a **dotted** column (`obj.field`) whose value lives in
+//! a nested CBOR `Map` — the shape a REST `?mode=detailed` response produces for
+//! belongs-to objects (e.g. `launch_service_provider.name`). The scenery must
+//! resolve the path into the nested map, not look up the literal flat key.
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Lens, SortDir, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn nested(provider_name: &str) -> CborValue {
+    CborValue::Map(vec![(
+        CborValue::Text("name".to_string()),
+        CborValue::Text(provider_name.to_string()),
+    )])
+}
+
+fn record(provider: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("provider".to_string(), nested(provider));
+    r
+}
+
+fn provider_at(scenery: &Arc<dyn TableScenery>, idx: usize) -> Option<String> {
+    let row = scenery.row(idx)?;
+    match row.record.get("provider")? {
+        CborValue::Map(entries) => entries.iter().find_map(|(k, v)| match (k, v) {
+            (CborValue::Text(k), CborValue::Text(s)) if k == "name" => Some(s.clone()),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("provider", "String"))
+        .with_id_column("id");
+    let shell = MockShell::new()
+        .with_metadata(metadata)
+        // Insertion order: SpaceX, Agency, Rocket Lab — NOT alphabetical.
+        .with_record("a", record("SpaceX"))
+        .with_record("b", record("Agency"))
+        .with_record("c", record("Rocket Lab"));
+    Vista::new("items", Box::new(shell))
+}
+
+async fn eager_lens(cache: std::path::PathBuf) -> Arc<Lens> {
+    Arc::new(
+        Lens::new()
+            .cache_at(cache)
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .build()
+            .expect("build lens"),
+    )
+}
+
+#[tokio::test]
+async fn sort_by_dotted_nested_column() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = eager_lens(tmp.path().join("c.redb")).await;
+    let dio = lens.make_dio(master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+    let g = u64::from(*gen_rx.borrow_and_update());
+
+    scenery.set_sort(Some("provider.name".to_string()), SortDir::Asc);
+    // Wait for the reseed bump.
+    tokio::time::timeout(std::time::Duration::from_millis(500), async {
+        loop {
+            if u64::from(*gen_rx.borrow_and_update()) > g {
+                break;
+            }
+            gen_rx.changed().await.unwrap();
+        }
+    })
+    .await
+    .expect("sort bump");
+
+    // Alphabetical by provider.name: Agency, Rocket Lab, SpaceX.
+    assert_eq!(provider_at(&scenery, 0).as_deref(), Some("Agency"));
+    assert_eq!(provider_at(&scenery, 1).as_deref(), Some("Rocket Lab"));
+    assert_eq!(provider_at(&scenery, 2).as_deref(), Some("SpaceX"));
+    Ok(())
+}

--- a/vantage-diorama/tests/support/chunk.rs
+++ b/vantage-diorama/tests/support/chunk.rs
@@ -1,0 +1,140 @@
+//! Shared helpers for the chunk-loaded (paged/lazy) scenery tests.
+//!
+//! These integration tests (`chunk_sort`, `chunk_sort_fidelity`,
+//! `chunk_refresh_reorder`, `chunk_warm_cache_order`, `chunk_refresh_no_transient`)
+//! all drive a non-orderable paged master: metadata-only `Vista`, rows served from
+//! an in-memory `Backend` via `on_load_chunk`, and a generation-watch settle loop.
+//! The pieces that were copied verbatim across them live here.
+
+#![allow(dead_code)]
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use vantage_diorama::{Generation, Lens, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+/// An in-memory list of `(id, record)` rows the lens serves chunks from.
+pub type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
+
+/// Master serving only metadata + the (false) order capability; rows come from
+/// `backend` via `on_load_chunk`. `cols` is the non-id column set (an `id`
+/// String column flagged as the id is always added).
+pub fn master(cols: &[(&str, &str)]) -> Vista {
+    let mut metadata =
+        VistaMetadata::new().with_column(Column::new("id", "String").with_flag("id"));
+    for (name, ty) in cols {
+        metadata = metadata.with_column(Column::new(*name, *ty));
+    }
+    let metadata = metadata.with_id_column("id");
+    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+/// Paged lens with NO `on_refresh`: refresh flows through the scenery's in-place
+/// viewport refetch. `on_load_chunk` pushes each row at its absolute `backend`
+/// index (the master's native order). `total_provider` reports the live
+/// `backend` length, so a re-count picks up appended rows.
+pub fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            async move {
+                let rows = b.lock().unwrap().clone();
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+/// Like [`paged_lens`] but `on_load_chunk` serves rows in **native order** =
+/// integer column `key` descending (mirrors the launches URL
+/// `?ordering=-last_updated` / a `pos`-baked server order), windowed. This is
+/// what a non-orderable paged master does: the client sort never reaches it.
+pub fn paged_lens_native_desc(
+    cache: std::path::PathBuf,
+    backend: Backend,
+    key: &'static str,
+) -> Arc<Lens> {
+    let total = backend.clone();
+    let lens = Lens::new()
+        .cache_at(cache)
+        .total_provider(move |_dio| {
+            let b = total.clone();
+            async move { Ok(b.lock().unwrap().len()) }
+        })
+        .on_load_chunk(move |_dio, range, sink| {
+            let b = backend.clone();
+            async move {
+                let mut rows = b.lock().unwrap().clone();
+                rows.sort_by(|a, b| {
+                    let la = a.1.get(key);
+                    let lb = b.1.get(key);
+                    match (la, lb) {
+                        (Some(CborValue::Integer(x)), Some(CborValue::Integer(y))) => {
+                            i128::from(*y).cmp(&i128::from(*x))
+                        }
+                        _ => std::cmp::Ordering::Equal,
+                    }
+                });
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .expect("build paged lens");
+    Arc::new(lens)
+}
+
+/// Wait until the generation watch advances past `current`, returning the new
+/// generation. Panics on timeout / closed channel.
+pub async fn wait_for_gen(rx: &mut tokio::sync::watch::Receiver<Generation>, current: u64) -> u64 {
+    tokio::time::timeout(Duration::from_millis(500), async {
+        loop {
+            if u64::from(*rx.borrow_and_update()) > current {
+                return u64::from(*rx.borrow());
+            }
+            rx.changed().await.expect("watch channel closed");
+        }
+    })
+    .await
+    .expect("timed out waiting for generation bump")
+}
+
+/// Let the viewport debounce + chunk load settle.
+pub async fn settle() {
+    tokio::time::sleep(Duration::from_millis(80)).await;
+}
+
+/// Read a text column at a row index (None if absent / not a string).
+pub fn col_at(scenery: &Arc<dyn TableScenery>, idx: usize, col: &str) -> Option<String> {
+    scenery.row(idx).and_then(|r| match r.record.get(col) {
+        Some(CborValue::Text(s)) => Some(s.clone()),
+        _ => None,
+    })
+}
+
+/// Collect a text column down every row, in row order.
+pub fn order(scenery: &Arc<dyn TableScenery>, col: &str) -> Vec<String> {
+    (0..scenery.row_count())
+        .filter_map(|i| col_at(scenery, i, col))
+        .collect()
+}

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -8,6 +8,8 @@
 
 #![allow(dead_code)]
 
+pub mod chunk;
+
 use std::sync::Arc;
 use std::time::Duration;
 


### PR DESCRIPTION
Fixes a cluster of ordering/refresh bugs in single-pass, **chunk-loaded (paged) sceneries** whose master can't push order down (the generic api-client) — surfaced by the launch-control demo grid.

## What's fixed
- **Client sort survives refresh.** A paged master returns rows in its native order on every refetch; the scenery now re-imposes the active sort over the freshly-cached rows instead of snapping back to native order.
- **Refresh re-counts.** A refresh re-invokes `total_provider`, so a row that appeared/vanished server-side grows/shrinks the row count instead of staying frozen at the open-time total.
- **Atomic single-repaint refresh.** Re-count no longer bumps the generation; the forced refetch carries the single repaint, so the new count and the refreshed+re-sorted rows land together (no intermediate-frame flash).
- **No duplicate/dropped rows on a reordering refresh.** Refresh re-fetches the whole contiguous loaded block containing the viewport, so a reorder reshuffles cleanly.
- **Dotted (nested) column sort/filter.** A condition/sort on a column like `launch_service_provider.name` (value in a nested CBOR map from a REST `?mode=detailed` belongs-to) now resolves into the nested map instead of silently no-op'ing.
- **Warm-cache reopen uses master order**, not cache id-order.
- **No master-order flicker on a client-sorted refresh.** This was the headline bug: each refetched chunk was stamped straight into the *displayed* map at its absolute master offset, so for the window between the pushes and the re-sort the grid (which repaints on its own timer, not just on generation bumps) could repaint rows in the master's native order and then snap back to the client sort. On a sorted paged scenery the displayed map is now a pure projection of the cache — the loader fills the cache and the post-load re-sort is the sole writer of the visible map, so order only ever transitions atomically between sorted states.

## Tests
New integration tests under `vantage-diorama/tests/`: `chunk_sort`, `chunk_sort_fidelity`, `chunk_refresh_reorder`, `chunk_warm_cache_order`, `nested_sort`, and `chunk_refresh_no_transient` (observes the visible order mid-load — after push, before re-sort — to lock in the no-flicker invariant). Full suite + 70/70 BDD + clippy + fmt green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Release notes

- Updated `diorama` to `0.6.12` and `vantage-api-client` to `0.6.5`.
- Fixed chunk-loaded table behavior so client-side sorting now survives refreshes, including on warm-cache reopen.
- Refresh now re-reads the total row count, so newly added or removed data is reflected immediately.
- Improved refresh handling to avoid duplicate/missing rows and remove brief “wrong order” flicker during reordering.
- Added support for sorting and filtering nested dotted fields like `provider.name` or `launch_service_provider.name`.
- Reduced noisy logging by downgrading count-probe logging from `info` to `debug`.

### Examples

- A grid sorted by `v` will stay sorted after `refresh()`.
- A column such as `provider.name` can now be used in sort/filter rules.
- When backend data changes, row counts update without requiring a full restart.
- Reopening a warm cached chunk-loaded table now preserves the master order instead of cache id order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->