### PR TITLE
diorama: client-side sort orders float columns numerically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.13 — 2026-07-01
+
+**Client-side sort orders numeric columns numerically**
+
+- A client-side sort on a `Float` (decimal) column now orders by numeric value
+  instead of by the value's `{:?}` debug string. The comparator only special-cased
+  `Text`/`Integer`/`Bool` and fell through to a lexicographic debug-string compare
+  for everything else, so a decimal column sorted like text: `657.96` ranked above
+  `1826.19` (because `'6' > '1'`). A single such value would wedge itself into the
+  wrong slot of an otherwise-ordered list — most visible on a live-updating,
+  decimal-valued grid or chart. `Integer`/`Float` mixes now compare numerically
+  too; `NaN` sorts as equal so it can't panic the sort.
+
 ## 0.6.12 — 2026-06-29
 
 **Chunk-loaded grids: sort survives refresh, count stays live**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -65,6 +65,18 @@ pub(crate) fn cbor_cmp(a: Option<&CborValue>, b: Option<&CborValue>) -> std::cmp
         (Some(lhs), Some(rhs)) => match (lhs, rhs) {
             (CborValue::Text(l), CborValue::Text(r)) => l.cmp(r),
             (CborValue::Integer(l), CborValue::Integer(r)) => i128::from(*l).cmp(&i128::from(*r)),
+            // Floats (and int/float mixes) sort by numeric value — NOT by their
+            // `{:?}` debug string, which would rank "657.96" above "1826.19".
+            // NaN is treated as equal so a stray NaN can't panic the sort.
+            (CborValue::Float(l), CborValue::Float(r)) => {
+                l.partial_cmp(r).unwrap_or(Ordering::Equal)
+            }
+            (CborValue::Integer(l), CborValue::Float(r)) => (i128::from(*l) as f64)
+                .partial_cmp(r)
+                .unwrap_or(Ordering::Equal),
+            (CborValue::Float(l), CborValue::Integer(r)) => l
+                .partial_cmp(&(i128::from(*r) as f64))
+                .unwrap_or(Ordering::Equal),
             (CborValue::Bool(l), CborValue::Bool(r)) => l.cmp(r),
             _ => format!("{lhs:?}").cmp(&format!("{rhs:?}")),
         },

--- a/vantage-diorama/tests/eager_live_sort.rs
+++ b/vantage-diorama/tests/eager_live_sort.rs
@@ -1,0 +1,233 @@
+//! Client-side sort must survive a LIVE `patched` insert on an eager
+//! (single-pass) Dio — the analogue of `chunk_sort.rs`'s refresh guarantee, but
+//! for the live push path (`dio.patched`) that a streaming source (faker) drives.
+//! A newly inserted row must land at its *sorted* position, not be appended in
+//! insertion order. This is the path that decayed the faker dashboard's sorted
+//! pie chart: correct at open, drifting as fifo inserts arrived.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use vantage_core::Result;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Dio, Lens, SortDir, TableScenery};
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Vista, VistaMetadata};
+
+mod support;
+use support::chunk::wait_for_gen;
+use support::eager_dio;
+
+fn amount_rec(id: &str, amount: i64) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("id".to_string(), CborValue::Text(id.to_string()));
+    r.insert("amount".to_string(), CborValue::Integer(amount.into()));
+    r
+}
+
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("amount", "i64"))
+        .with_id_column("id");
+    let shell = MockShell::new()
+        .with_metadata(metadata)
+        .with_record("a", amount_rec("a", 30))
+        .with_record("b", amount_rec("b", 10))
+        .with_record("c", amount_rec("c", 20));
+    Vista::new("items", Box::new(shell))
+}
+
+fn order(scenery: &Arc<dyn TableScenery>) -> Vec<String> {
+    (0..scenery.row_count())
+        .filter_map(|i| {
+            scenery.row(i).and_then(|r| match r.record.get("id") {
+                Some(CborValue::Text(t)) => Some(t.clone()),
+                _ => None,
+            })
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn client_sort_survives_live_patched_insert() -> Result<()> {
+    let dio = eager_dio(master()).await;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    // Sort by amount descending → a(30), c(20), b(10).
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("amount".to_string()), SortDir::Desc);
+    wait_for_gen(&mut gen_rx, g0).await;
+    assert_eq!(order(&scenery), vec!["a", "c", "b"], "sorted desc at open");
+
+    // A live insert of the smallest amount must land at the BOTTOM.
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    dio.patched("d", amount_rec("d", 5)).await?;
+    wait_for_gen(&mut gen_rx, g1).await;
+    assert_eq!(
+        order(&scenery),
+        vec!["a", "c", "b", "d"],
+        "small live insert must sort to the bottom, not append blindly"
+    );
+
+    // A live insert of a middle amount must land in its sorted position.
+    let g2 = u64::from(*gen_rx.borrow_and_update());
+    dio.patched("e", amount_rec("e", 25)).await?;
+    wait_for_gen(&mut gen_rx, g2).await;
+    assert_eq!(
+        order(&scenery),
+        vec!["a", "e", "c", "b", "d"],
+        "middle live insert must sort into place"
+    );
+
+    Ok(())
+}
+
+fn float_rec(id: &str, amount: f64) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("id".to_string(), CborValue::Text(id.to_string()));
+    r.insert("amount".to_string(), CborValue::Float(amount));
+    r
+}
+
+/// A `Float` sort column must order numerically, not by the debug-string of the
+/// value. Amounts are picked so lexicographic order of `"Float(<n>)"` diverges
+/// from numeric order (differing digit counts / leading digits) — the faker
+/// dashboard's real shape (`amount` is a decimal), and the true cause of the
+/// "sorted pie decays" report.
+#[tokio::test]
+async fn float_column_sorts_numerically_not_lexically() -> Result<()> {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("amount", "f64"))
+        .with_id_column("id");
+    let shell = MockShell::new()
+        .with_metadata(metadata)
+        .with_record("hi", float_rec("hi", 6416.51))
+        .with_record("mid", float_rec("mid", 1826.19))
+        .with_record("lo", float_rec("lo", 657.96));
+    let dio = eager_dio(Vista::new("items", Box::new(shell))).await;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("amount".to_string()), SortDir::Desc);
+    wait_for_gen(&mut gen_rx, g0).await;
+
+    // Numeric desc: 6416.51, 1826.19, 657.96 → [hi, mid, lo].
+    // A lexical (debug-string) comparator ranks "657.." above "1826.." / "6416.."
+    // → [lo, hi, mid] (or similar) — the decay signature.
+    assert_eq!(
+        order(&scenery),
+        vec!["hi", "mid", "lo"],
+        "float column must sort by numeric value, not debug string"
+    );
+    Ok(())
+}
+
+// ---- fuller reproduction: shared Dio + on_refresh + interleaved refresh ------
+
+fn amounts(scenery: &Arc<dyn TableScenery>) -> Vec<i64> {
+    (0..scenery.row_count())
+        .filter_map(|i| {
+            scenery.row(i).and_then(|r| match r.record.get("amount") {
+                Some(CborValue::Integer(v)) => i64::try_from(*v).ok(),
+                _ => None,
+            })
+        })
+        .collect()
+}
+
+fn is_desc(scenery: &Arc<dyn TableScenery>) -> bool {
+    amounts(scenery).windows(2).all(|w| w[0] >= w[1])
+}
+
+/// Eager Dio whose `on_refresh` snapshot-replaces the cache from the master —
+/// exactly `vantage-ui`'s `build_eager_lens` shape (the path faker uses).
+async fn eager_dio_with_refresh(master: Vista) -> Dio {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .on_refresh(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().clear().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("lens builds"),
+    );
+    lens.make_dio(master).await.expect("make_dio")
+}
+
+/// Mirrors the running faker dashboard: one sorted scenery and one unsorted
+/// scenery share a single eager Dio; a fifo stream writes to the master AND
+/// patches the Dio (the effect + forwarder), while the list's `request_refresh`
+/// fires periodically. The sorted view must stay sorted through all of it.
+#[tokio::test]
+async fn client_sort_survives_shared_dio_live_stream() -> Result<()> {
+    let meta = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("amount", "i64"))
+        .with_id_column("id");
+    let shell = MockShell::new()
+        .with_metadata(meta)
+        .with_record("a", amount_rec("a", 30))
+        .with_record("b", amount_rec("b", 10))
+        .with_record("c", amount_rec("c", 20));
+    let master_handle = shell.clone();
+    let dio = eager_dio_with_refresh(Vista::new("items", Box::new(shell))).await;
+
+    // Sorted scenery opened WITH the sort (like vantage-ui's `open_scenery`), plus
+    // an unsorted sibling on the same Dio (like the feed-order list / charts).
+    let sorted = dio
+        .table_scenery()
+        .sort("amount", SortDir::Desc)
+        .open()
+        .await?;
+    let _unsorted = dio.table_scenery().open().await?;
+
+    let mut gen_rx = sorted.subscribe();
+    sorted.set_viewport(0..100);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(is_desc(&sorted), "sorted at open: {:?}", amounts(&sorted));
+
+    for i in 0..12i64 {
+        let id = format!("live{i}");
+        let amount = (i * 13 + 5) % 40; // spread across the range
+        // Effect writes to the master store...
+        master_handle.set_record(&id, amount_rec(&id, amount));
+        // ...forwarder patches the Dio cache + broadcasts RecordChanged.
+        let gp = u64::from(*gen_rx.borrow_and_update());
+        dio.patched(&id, amount_rec(&id, amount)).await?;
+        wait_for_gen(&mut gen_rx, gp).await;
+
+        // The list's 2s poll fires a whole-Dio refresh on some ticks.
+        if i % 3 == 2 {
+            let gr = u64::from(*gen_rx.borrow_and_update());
+            sorted.request_refresh();
+            wait_for_gen(&mut gen_rx, gr).await;
+        }
+
+        assert!(
+            is_desc(&sorted),
+            "sorted view decayed after tick {i}: {:?}",
+            amounts(&sorted)
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
A client-side sort on a decimal column ordered by the value's `{:?}` debug string instead of its number. `cbor_cmp` only special-cased `Text`/`Integer`/`Bool` and fell through to a lexicographic debug-string compare for everything else, so `657.96` ranked above `1826.19` and a single decimal would wedge into the wrong slot of an otherwise-ordered list — most visible on a live-updating decimal grid or chart.

Now `Float` (and int/float mixes) compare numerically; `NaN` sorts equal so it can't panic the sort. Adds eager live-sort tests: the float case, plus live `patched` inserts staying ordered on a shared Dio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table sorting so numeric columns sort by actual value instead of text-like ordering.
  * Mixed whole-number and decimal values now compare correctly.
  * Sorting is more stable when values can’t be directly compared, reducing the chance of sort errors.

* **Tests**
  * Added coverage for live-updating sorted tables, including numeric ordering and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->