### PR TITLE
server-side ordering: push sort down to masters that can order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.14 — 2026-07-02
+
+**Server-side ordering when the master can order**
+
+- A paged scenery whose master reports `can_order` now pushes its sort **down to
+  the master** and skips the client-side re-sort. `Dio::fetch_window_ordered`
+  clones the master per fetch (`TableShell::clone_shell`), applies the sort with
+  `add_order`, and reads the ordered `[offset, limit)` window — the shared master
+  is never mutated, so differently-sorted views can't race. When the master can't
+  order (or can't be cloned) it fetches native order and the scenery re-sorts over
+  the cache, exactly as before. The eager (non-windowed) path is unchanged — its
+  cache is unordered, so it still sorts client-side.
+- `on_load_chunk` callbacks now receive the requesting scenery's `sort`
+  (`Fn(&Dio, Range, Option<(String, SortDir)>, ChunkSink)`) and should fetch via
+  `Dio::fetch_window_ordered`. (API break: add the `sort` parameter.)
+
 ## 0.6.13 — 2026-07-01
 
 **Client-side sort orders numeric columns numerically**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -403,6 +403,36 @@ impl Dio {
         Vista::new(name, Box::new(shell))
     }
 
+    /// Fetch a `[offset, limit)` window, preferring the master's own ordering.
+    ///
+    /// When `sort` is set and the master `can_order` and yields an independent
+    /// [`clone_shell`](vantage_vista::TableShell::clone_shell), the window is read
+    /// from a **per-call ordered clone** (`add_order` → `fetch_window`) — the
+    /// shared master is never mutated, so differently-sorted views never race. If
+    /// the master can't order or can't be cloned, it fetches the window in native
+    /// order and the caller re-sorts over the cache (the existing fallback).
+    pub async fn fetch_window_ordered(
+        &self,
+        offset: usize,
+        limit: usize,
+        sort: Option<(String, crate::SortDir)>,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        let master = self.master();
+        if let Some((col, dir)) = sort
+            && master.capabilities().can_order
+            && let Some(shell) = master.source.clone_shell()
+        {
+            let mut ordered = Vista::new(master.name(), shell);
+            let vdir = match dir {
+                crate::SortDir::Asc => vantage_vista::SortDirection::Ascending,
+                crate::SortDir::Desc => vantage_vista::SortDirection::Descending,
+            };
+            ordered.add_order(&col, vdir)?;
+            return ordered.fetch_window(offset, limit).await;
+        }
+        master.fetch_window(offset, limit).await
+    }
+
     // ---- Event bus — user-callable surface ----------------------------------
 
     /// Dispatch an upstream [`ChangeEvent`] through the lens's

--- a/vantage-diorama/src/lens/callbacks.rs
+++ b/vantage-diorama/src/lens/callbacks.rs
@@ -6,6 +6,7 @@ use ciborium::Value as CborValue;
 use vantage_core::Result;
 use vantage_types::Record;
 
+use crate::SortDir;
 use crate::dio::Dio;
 use crate::lens::chunk_sink::ChunkSink;
 use crate::ops::{ChangeEvent, QueryDescriptor, WriteOp};
@@ -36,8 +37,18 @@ pub type DioTotalProviderCallback =
 /// Callback that fetches a contiguous range of rows from the master
 /// and pushes them into the Scenery via [`ChunkSink::push`]. Returns
 /// `Ok(())` once it is done pushing for this invocation.
+///
+/// The `sort` is the requesting scenery's active order (`None` if unsorted).
+/// Callbacks should fetch through [`Dio::fetch_window_ordered`], which pushes
+/// the sort to a `can_order` master and otherwise returns the native-order
+/// window (the scenery then re-sorts over the cache).
 pub type DioLoadChunkCallback = Box<
-    dyn for<'a> Fn(&'a Dio, Range<usize>, ChunkSink) -> DioCallbackFuture<'a>
+    dyn for<'a> Fn(
+            &'a Dio,
+            Range<usize>,
+            Option<(String, SortDir)>,
+            ChunkSink,
+        ) -> DioCallbackFuture<'a>
         + Send
         + Sync
         + 'static,
@@ -129,10 +140,13 @@ where
 /// Wrap a user closure into a [`DioLoadChunkCallback`].
 pub fn boxed_load_chunk_callback<F, Fut>(f: F) -> DioLoadChunkCallback
 where
-    F: for<'a> Fn(&'a Dio, Range<usize>, ChunkSink) -> Fut + Send + Sync + 'static,
+    F: for<'a> Fn(&'a Dio, Range<usize>, Option<(String, SortDir)>, ChunkSink) -> Fut
+        + Send
+        + Sync
+        + 'static,
     Fut: Future<Output = Result<()>> + Send + 'static,
 {
-    Box::new(move |dio, range, sink| Box::pin(f(dio, range, sink)))
+    Box::new(move |dio, range, sort, sink| Box::pin(f(dio, range, sort, sink)))
 }
 
 /// Wrap a user closure into a [`DioListPageCallback`].

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -237,7 +237,10 @@ impl LensBuilder {
     /// `ViewportChanged` and never load.
     pub fn on_load_chunk<F, Fut>(mut self, f: F) -> Self
     where
-        F: for<'a> Fn(&'a Dio, Range<usize>, ChunkSink) -> Fut + Send + Sync + 'static,
+        F: for<'a> Fn(&'a Dio, Range<usize>, Option<(String, crate::SortDir)>, ChunkSink) -> Fut
+            + Send
+            + Sync
+            + 'static,
         Fut: Future<Output = Result<()>> + Send + 'static,
     {
         self.on_load_chunk = Some(callbacks::boxed_load_chunk_callback(f));

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -285,7 +285,8 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     // Clear the dirty flag so it reflects only the rows this load writes;
     // `write_chunk_row` sets it when a row's content actually changes.
     state.reset_load_dirty();
-    let result = cb(&dio, effective_range.clone(), sink).await;
+    let sort = state.sort.read().unwrap().clone();
+    let result = cb(&dio, effective_range.clone(), sort, sink).await;
 
     *state.load_in_flight.lock().unwrap() = None;
 
@@ -310,16 +311,21 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             // the refetch instead of snapping back to native order. It orders only
             // the loaded rows — the documented cost of sorting a lazily-paged
             // source that can't order server-side.
-            let resorted = if state.sort.read().unwrap().is_some() {
-                if let Err(e) = state.reseed_from_cache().await {
-                    tracing::error!(error = %e, "post-load resort failed");
-                    false
+            // Only re-sort client-side when the master couldn't order it for us.
+            // A `can_order` master fetched this window server-ordered (via
+            // `Dio::fetch_window_ordered`), so `write_chunk_row` already stamped
+            // the rows in the right order — reseeding would be redundant.
+            let resorted =
+                if state.sort.read().unwrap().is_some() && !state.master_capabilities.can_order {
+                    if let Err(e) = state.reseed_from_cache().await {
+                        tracing::error!(error = %e, "post-load resort failed");
+                        false
+                    } else {
+                        true
+                    }
                 } else {
-                    true
-                }
-            } else {
-                false
-            };
+                    false
+                };
             // Drain the dirty flag regardless (so it doesn't leak into the next
             // load). Bump when this was a forced refetch (a refresh or load-more —
             // it carries the single repaint for the whole refresh, including a

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -372,14 +372,15 @@ impl SceneryChunkTarget for TableSceneryState {
         // Count every received row (before the skips below), so the loader can
         // tell a short page (end of set) from a full one.
         self.load_push_count.fetch_add(1, Ordering::SeqCst);
-        // With a client sort active, the displayed map is a pure projection of
-        // the cache, rebuilt by `reseed_from_cache` once the load finishes (the
-        // loader re-sorts whenever `sort` is set). The cache row was already
-        // written by `ChunkSink::push`, so there is nothing more to do here —
-        // and stamping this server-ordered row into the visible map would expose
-        // the master's native order in the window before the re-sort runs, a
-        // flicker the grid repaints on its own timer. Let reseed own the map.
-        if self.sort.read().unwrap().is_some() {
+        // With a *client-side* sort active, the displayed map is a pure
+        // projection of the cache, rebuilt by `reseed_from_cache` once the load
+        // finishes (the loader re-sorts whenever `sort` is set). Stamping this
+        // native-order row into the visible map would expose the master's order
+        // in the window before the re-sort runs — a flicker. Let reseed own the
+        // map. But a `can_order` master fetched this window *already* in sort
+        // order (`Dio::fetch_window_ordered`) and there is no client re-sort, so
+        // these rows must be written straight through.
+        if self.sort.read().unwrap().is_some() && !self.master_capabilities.can_order {
             return;
         }
         // Skip the write entirely when this slot already holds the same fresh

--- a/vantage-diorama/tests/bdd_support/world.rs
+++ b/vantage-diorama/tests/bdd_support/world.rs
@@ -503,7 +503,7 @@ impl LensBuilderState {
                 let error_once = spies.on_load_chunk_error_once.clone();
                 let source_latency = spies.source_latency_ms.clone();
                 let source_fail_reads = spies.source_fail_reads.clone();
-                b = b.on_load_chunk(move |dio, range, sink| {
+                b = b.on_load_chunk(move |dio, range, _sort, sink| {
                     let counter = counter.clone();
                     let master_list_counter = master_list_counter.clone();
                     let last_range = last_range.clone();
@@ -548,7 +548,7 @@ impl LensBuilderState {
             OnLoadChunkKind::RecordCalls => {
                 let counter = spies.on_load_chunk.clone();
                 let last_range = spies.last_load_chunk_range.clone();
-                b = b.on_load_chunk(move |_dio, range, _sink| {
+                b = b.on_load_chunk(move |_dio, range, _sort, _sink| {
                     let counter = counter.clone();
                     let last_range = last_range.clone();
                     async move {
@@ -561,7 +561,7 @@ impl LensBuilderState {
             OnLoadChunkKind::AlwaysError => {
                 let counter = spies.on_load_chunk.clone();
                 let last_range = spies.last_load_chunk_range.clone();
-                b = b.on_load_chunk(move |_dio, range, _sink| {
+                b = b.on_load_chunk(move |_dio, range, _sort, _sink| {
                     let counter = counter.clone();
                     let last_range = last_range.clone();
                     async move {

--- a/vantage-diorama/tests/chunk_refresh_no_transient.rs
+++ b/vantage-diorama/tests/chunk_refresh_no_transient.rs
@@ -72,7 +72,7 @@ async fn refresh_never_exposes_master_order_midload() -> Result<()> {
                     let b = total.clone();
                     async move { Ok(b.lock().unwrap().len()) }
                 })
-                .on_load_chunk(move |_dio, range, sink| {
+                .on_load_chunk(move |_dio, range, _sort, sink| {
                     let b = backend.clone();
                     let scenery_slot = scenery_slot.clone();
                     let observed = observed.clone();

--- a/vantage-diorama/tests/refresh.rs
+++ b/vantage-diorama/tests/refresh.rs
@@ -56,7 +56,7 @@ fn paged_lens(
             let b = total.clone();
             async move { Ok(b.lock().unwrap().len()) }
         })
-        .on_load_chunk(move |_dio, range, sink| {
+        .on_load_chunk(move |_dio, range, _sort, sink| {
             let b = backend.clone();
             let fail = fail_next.clone();
             async move {

--- a/vantage-diorama/tests/server_side_sort.rs
+++ b/vantage-diorama/tests/server_side_sort.rs
@@ -1,0 +1,145 @@
+//! Server-side ordering: when the master `can_order`, the scenery pushes its
+//! sort down (`Dio::fetch_window_ordered` → `add_order` on a per-call clone →
+//! `fetch_window`) and does NOT re-sort client-side. Contrast `chunk_sort.rs`,
+//! which covers the `can_order = false` fallback (client re-sort over the cache).
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use vantage_core::Result;
+use vantage_diorama::{Lens, SortDir};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell};
+
+mod support;
+use support::chunk::{col_at, wait_for_gen};
+use support::eager_dio;
+
+fn rec(v: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r
+}
+
+/// A master that can order + window server-side. Its *native* (insertion) order
+/// (v3, v1, v2) is deliberately unsorted, so any sorted result must come from
+/// the master applying `add_order` — there is no client-side sort in the helper.
+fn orderable_master() -> Vista {
+    // Orderable columns carry the ORDERABLE flag — exactly what the SQL / Mongo /
+    // Surreal factories set so `Vista::add_order` accepts the column.
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("v", "String").with_flag(vantage_vista::flags::ORDERABLE))
+        .with_id_column("id");
+    let caps = VistaCapabilities {
+        can_order: true,
+        can_fetch_window: true,
+        ..Default::default()
+    };
+    let shell = MockShell::new()
+        .with_metadata(metadata)
+        .with_capabilities(caps)
+        .with_record("a", rec("v3"))
+        .with_record("b", rec("v1"))
+        .with_record("c", rec("v2"));
+    Vista::new("items", Box::new(shell))
+}
+
+fn vs(rows: &[(String, Record<CborValue>)]) -> Vec<String> {
+    rows.iter()
+        .filter_map(|(_, r)| match r.get("v") {
+            Some(CborValue::Text(t)) => Some(t.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn fetch_window_ordered_orders_via_master() -> Result<()> {
+    let dio = eager_dio(orderable_master()).await;
+
+    // Ascending: the master returns v1, v2, v3 — its native order was v3,v1,v2,
+    // so this ordering can only come from the pushed-down `add_order`.
+    let asc = dio
+        .fetch_window_ordered(0, 10, Some(("v".to_string(), SortDir::Asc)))
+        .await?;
+    assert_eq!(
+        vs(&asc),
+        vec!["v1", "v2", "v3"],
+        "ascending, server-ordered"
+    );
+
+    // Descending, windowed: the top two by `v` desc.
+    let desc_head = dio
+        .fetch_window_ordered(0, 2, Some(("v".to_string(), SortDir::Desc)))
+        .await?;
+    assert_eq!(vs(&desc_head), vec!["v3", "v2"], "descending window");
+
+    // No sort → the master's NATIVE order, unpolluted. Checked *after* the two
+    // ordered fetches above: because each fetch orders a per-call `clone_shell`
+    // with its own query state, the master itself is never reordered. (If the
+    // clone shared the master's order — the bug this guards — this would come
+    // back v3,v2,v1 from the last `add_order`.)
+    let native = dio.fetch_window_ordered(0, 10, None).await?;
+    assert_eq!(
+        vs(&native),
+        vec!["v3", "v1", "v2"],
+        "master native order intact — clones didn't mutate it"
+    );
+
+    Ok(())
+}
+
+/// A paged scenery over a `can_order` master orders **server-side**: the loader
+/// hands the sort to `on_load_chunk` (which fetches via `fetch_window_ordered`),
+/// and — because `can_order` — skips the client re-sort, so the rows are written
+/// straight through in the master's returned order.
+#[tokio::test]
+async fn paged_scenery_orders_server_side() -> Result<()> {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .total_provider(|_dio| async { Ok(3) })
+            .on_load_chunk(|dio, range, sort, sink| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio
+                        .fetch_window_ordered(range.start, range.end - range.start, sort)
+                        .await?;
+                    for (offset, (id, rec)) in rows.into_iter().enumerate() {
+                        sink.push(range.start + offset, id, rec).await?;
+                    }
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("lens builds"),
+    );
+    let dio = lens.make_dio(orderable_master()).await?;
+    let scenery = dio.table_scenery().open().await?;
+    let mut gen_rx = scenery.subscribe();
+
+    let g0 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_viewport(0..3);
+    wait_for_gen(&mut gen_rx, g0).await;
+    assert_eq!(
+        col_at(&scenery, 0, "v").as_deref(),
+        Some("v3"),
+        "native order"
+    );
+
+    let g1 = u64::from(*gen_rx.borrow_and_update());
+    scenery.set_sort(Some("v".to_string()), SortDir::Asc);
+    wait_for_gen(&mut gen_rx, g1).await;
+    let got: Vec<Option<String>> = (0..3).map(|i| col_at(&scenery, i, "v")).collect();
+    assert_eq!(
+        got,
+        vec![
+            Some("v1".to_string()),
+            Some("v2".to_string()),
+            Some("v3".to_string())
+        ],
+        "server-ordered ascending, no client re-sort"
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/support/chunk.rs
+++ b/vantage-diorama/tests/support/chunk.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use ciborium::Value as CborValue;
 use vantage_diorama::{Generation, Lens, TableScenery};
 use vantage_types::Record;
-use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell};
 
 /// An in-memory list of `(id, record)` rows the lens serves chunks from.
 pub type Backend = Arc<Mutex<Vec<(String, Record<CborValue>)>>>;
@@ -29,7 +29,21 @@ pub fn master(cols: &[(&str, &str)]) -> Vista {
         metadata = metadata.with_column(Column::new(*name, *ty));
     }
     let metadata = metadata.with_id_column("id");
-    Vista::new("items", Box::new(MockShell::new().with_metadata(metadata)))
+    // A native-order paged master: it serves rows through `on_load_chunk` and
+    // genuinely can't push a sort down, so `can_order` is false — the scenery
+    // re-sorts client-side over the cache.
+    let caps = VistaCapabilities {
+        can_order: false,
+        ..Default::default()
+    };
+    Vista::new(
+        "items",
+        Box::new(
+            MockShell::new()
+                .with_metadata(metadata)
+                .with_capabilities(caps),
+        ),
+    )
 }
 
 /// Paged lens with NO `on_refresh`: refresh flows through the scenery's in-place
@@ -44,7 +58,7 @@ pub fn paged_lens(cache: std::path::PathBuf, backend: Backend) -> Arc<Lens> {
             let b = total.clone();
             async move { Ok(b.lock().unwrap().len()) }
         })
-        .on_load_chunk(move |_dio, range, sink| {
+        .on_load_chunk(move |_dio, range, _sort, sink| {
             let b = backend.clone();
             async move {
                 let rows = b.lock().unwrap().clone();
@@ -77,7 +91,7 @@ pub fn paged_lens_native_desc(
             let b = total.clone();
             async move { Ok(b.lock().unwrap().len()) }
         })
-        .on_load_chunk(move |_dio, range, sink| {
+        .on_load_chunk(move |_dio, range, _sort, sink| {
             let b = backend.clone();
             async move {
                 let mut rows = b.lock().unwrap().clone();

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.7 — 2026-07-02
+
+- SQLite's shell is now `Clone` and implements `TableShell::clone_shell`, so a
+  consumer (e.g. a diorama paged scenery) can build a per-view ordered copy —
+  `clone_shell()` → `add_order` → `fetch_window` — to page rows in server order.
+  The clone is cheap: it copies the wrapped table's query state (the same clone
+  `fetch_window` already does per call) while the connection pool stays shared.
+
 ## 0.6.6 — 2026-06-28
 
 - TLS support for the Postgres and MySQL connection pools: sqlx is now built with the `tls-rustls`

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -30,6 +30,7 @@ use crate::sqlite::operation::SqliteOperation;
 use crate::sqlite::types::AnySqliteType;
 use crate::types::{cbor_to_json, parse_json_host};
 
+#[derive(Clone)]
 pub struct SqliteTableShell<E = EmptyEntity>
 where
     E: Entity<AnySqliteType>,
@@ -223,6 +224,14 @@ where
     fn clear_orders(&mut self) -> Result<()> {
         self.table.clear_orders();
         Ok(())
+    }
+
+    /// Cheap: `Table` clones its query state (conditions/order/pagination) while
+    /// the `SqliteDB` connection pool behind it is `Arc`-shared. This is the same
+    /// clone `fetch_window` already does per call, so a per-view ordered copy
+    /// costs no more than a windowed fetch.
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        Some(Box::new(self.clone()))
     }
 
     fn add_search(&mut self, text: &str) -> Result<()> {

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.7 — 2026-07-02
+
+- `TableShell::clone_shell(&self) -> Option<Box<dyn TableShell>>` — a defaulted
+  (`None`) hook a driver overrides when it can be cloned cheaply, sharing the
+  backing store but owning its own query state (conditions / order / search). A
+  consumer builds a per-view ordered shell with `clone_shell()` → `add_order` →
+  `fetch_window`, without mutating the shared original. `MockShell` implements it
+  (and now serves an order-applying `fetch_window`) so it can stand in for an
+  orderable, windowed driver in tests.
+
 ## 0.6.6 — 2026-07-01
 
 ### Added

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -309,6 +309,41 @@ impl TableShell for MockShell {
         Ok(rows.into_iter().collect())
     }
 
+    /// Windowed read that honours the shell's current `add_order` — the mock's
+    /// analogue of a driver serving an ordered `[offset, limit)` page. Reuses
+    /// `list_vista_values` (filter + search + order) then slices, so a caller
+    /// that set an order via `add_order` gets it applied server-side. Gated by
+    /// `can_fetch_window` like every driver.
+    async fn fetch_window(
+        &self,
+        vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        let ordered = self.list_vista_values(vista).await?;
+        Ok(ordered.into_iter().skip(offset).take(limit).collect())
+    }
+
+    /// Share the backing store, but give the copy its **own** query state
+    /// (filters / order / search) — the `clone_shell` contract. `MockShell`'s
+    /// derived `Clone` shares those (they're `Arc<Mutex<_>>`), so it can't be
+    /// used here: narrowing the clone (e.g. `add_order` in
+    /// `Dio::fetch_window_ordered`) must not reach back and reorder the original.
+    /// `data` / `next_auto_id` / `fail_reads` stay shared (the store).
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        Some(Box::new(MockShell {
+            data: self.data.clone(),
+            next_auto_id: self.next_auto_id.clone(),
+            filters: Arc::new(Mutex::new(self.filters.lock().unwrap().clone())),
+            order: Arc::new(Mutex::new(self.order.lock().unwrap().clone())),
+            search: Arc::new(Mutex::new(self.search.lock().unwrap().clone())),
+            capabilities: self.capabilities.clone(),
+            metadata: self.metadata.clone(),
+            ref_targets: self.ref_targets.clone(),
+            fail_reads: self.fail_reads.clone(),
+        }))
+    }
+
     async fn get_vista_value(
         &self,
         _vista: &Vista,

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -304,6 +304,22 @@ pub trait TableShell: Send + Sync + 'static {
         Err(self.default_error("clear_orders", "can_order"))
     }
 
+    // ---- Cloning -----------------------------------------------------------
+
+    /// Produce an independent copy of this shell, or `None` if the driver can't
+    /// be cloned cheaply. The copy must share the backing store / connection
+    /// (typically `Arc`) but own its own query state (conditions / order /
+    /// search) so a caller can narrow it — set an ORDER BY, add a WHERE — without
+    /// disturbing the original. This is how a consumer builds a per-view ordered
+    /// Vista to fetch from: `clone_shell()` → `add_order(...)` → `fetch_window`.
+    ///
+    /// Default `None`: drivers opt in only where a clone is genuinely cheap
+    /// (query state is small; the store is `Arc`-shared). Callers that get `None`
+    /// fall back to reading the shared shell and ordering client-side.
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        None
+    }
+
     // ---- References --------------------------------------------------------
 
     /// Resolve a same-persistence relation using a known source row, returning


### PR DESCRIPTION
Sorting was always client-side, even when the master could do it. Now a paged scenery whose master reports `can_order` pushes the sort into the query and skips the client re-sort.

`Dio::fetch_window_ordered` clones the master per fetch (new defaulted `TableShell::clone_shell`, overridden by SQLite), applies the sort with `add_order`, and reads an ordered `[offset, limit)` window — the shared master is never mutated, so differently-sorted views can't race. The clone is cheap: SQLite copies its wrapped table's query state (the same clone `fetch_window` already does per call) while the connection pool stays shared. Masters that can't order (or can't be cloned) fetch native order and the scenery re-sorts over the cache, exactly as before; the eager path is unchanged (its cache is unordered).

API break: `on_load_chunk` callbacks now receive the scenery's `sort` and should fetch through `fetch_window_ordered`.

Scope: SQLite (paged, `can_order`) is the first server-ordered driver; pg/mysql inherit the diorama gate and are verified later. Other backends keep the client-sort fallback untouched.

Tests: `server_side_sort.rs` (the helper orders via the master; a paged scenery orders server-side end-to-end); existing `chunk_sort` still covers the `can_order=false` client fallback. Full suite + BDD (70/612) green; clippy `--all-targets` clean. Rebased on top of #332; diorama 0.6.14, vista/sql 0.6.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordered, windowed data fetching that performs server-side sorting when the backend supports it.
  * Introduced a per-view `clone_shell()` capability for table shells to safely apply ordering during pagination.
* **Bug Fixes**
  * Improved paging/sorting so ordered results are written directly from server-fetch when supported, reducing unnecessary client reseeding/resorting.
* **Documentation / Breaking Changes**
  * Updated `on_load_chunk` callback signatures to receive the active optional sort context (API breaking).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->