### PR TITLE
vantage-faker: live-folder sim with diorama traversal

### DIFF
--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.2 — 2026-07-03
+
+- `LiveFolderSim`: a synthetic, constantly-mutating multi-layer log tree. One shared run loop
+  simulates three streams under `{date}/` — an `access_logs_HH` chunked access log (active chunk
+  bumps each second at `requests_per_sec × bytes_per_request` bytes; rolls a new `chunk_NN.log` when
+  it crosses `chunk_threshold`, sized for ~100 files/hour at defaults), a rare `error_logs` stream
+  (one `HH:MM:SS-errors.log` file per error occurrence, gated by `error_pct_per_sec`), and ten
+  `events/<type>.log` event files each with its own 1–10% per-second probability of a 2000–4000-byte
+  bump. Folders and files carry `created`/`modified`; any leaf mutation touches every ancestor up to
+  root. A `backfill` duration replays the algorithm at full speed from `now − backfill` to `now` on
+  construction. The listing vista is a `FolderListingShell` reading the live tree on every list,
+  declaring a `subdir` HasMany reference so a Dio over a parent folder can traverse into any child
+  via `get_ref("subdir", row)`. The folder-size vista is get-only (no list) and fetches with a
+  100ms–1s latency scaled by file count — for exercising viewport debounce.
+- `live_folder_cli` and `scenery_folder_cli` examples: the former renders the whole tree as a
+  `tree(1)`-style outline; the latter opens three reactive `TableScenery` panes (ymd, error_logs,
+  events) wired through `Dio::get_ref("subdir", ...)` and refreshed on every sim tick.
+
 ## 0.6.1 — 2026-07-02
 
 - `PulseSim`: a generic, config-driven "live aggregate feed". One shared run loop drives three

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,10 +51,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -152,6 +205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +241,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -257,16 +326,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "ansi-str",
- "console",
+ "console 0.16.4",
  "crossterm",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -278,7 +407,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "unicode-width",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -295,6 +424,31 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -347,6 +501,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "cucumber"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd12917efc3a8b069a4975ef3cb2f2d835d42d04b3814d90838488f9dd9bf69"
+dependencies = [
+ "anyhow",
+ "clap",
+ "console 0.15.11",
+ "cucumber-codegen",
+ "cucumber-expressions",
+ "derive_more",
+ "drain_filter_polyfill",
+ "either",
+ "futures",
+ "gherkin",
+ "globwalk",
+ "humantime",
+ "inventory",
+ "itertools",
+ "lazy-regex",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "regex",
+ "sealed",
+ "smart-default",
+]
+
+[[package]]
+name = "cucumber-codegen"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e19cd9e8e7cfd79fbf844eb6a7334117973c01f6bad35571262b00891e60f1c"
+dependencies = [
+ "cucumber-expressions",
+ "inflections",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.118",
+ "synthez",
+]
+
+[[package]]
+name = "cucumber-expressions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d794fed319eea24246fb5f57632f7ae38d61195817b7eb659455aa5bdd7c1810"
+dependencies = [
+ "derive_more",
+ "either",
+ "nom",
+ "nom_locate",
+ "regex",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "deunicode"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +590,12 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "drain_filter_polyfill"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
 name = "either"
@@ -392,7 +622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -434,10 +664,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -451,8 +740,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -478,6 +772,47 @@ dependencies = [
  "libc",
  "r-efi",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck 0.4.1",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.118",
+ "textwrap",
+ "thiserror 1.0.69",
+ "typed-builder",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.11",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -507,6 +842,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,6 +861,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "iana-time-zone"
@@ -540,6 +893,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +918,36 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -569,6 +968,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bae91019476d3ec7147de9aa291cadb6d870abf2f3015d2da73a90325ac1496"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de9c1e1439d8b7b3061b2d209809f447ca33241733d9a3c01eabf2dc8d94358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +1001,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -627,7 +1055,7 @@ checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -668,6 +1096,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +1120,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
@@ -716,6 +1161,53 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -883,6 +1375,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax 0.8.11",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.11",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,7 +1485,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -974,6 +1501,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1520,18 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sealed"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "serde"
@@ -1076,14 +1624,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "smawk"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1108,6 +1679,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "synthez"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
+dependencies = [
+ "syn 2.0.118",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
+dependencies = [
+ "syn 2.0.118",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bfa6ec52465e2425fd43ce5bbbe0f0b623964f7c63feb6b10980e816c654ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,7 +1727,17 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1131,6 +1745,17 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -1201,7 +1826,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1277,10 +1902,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-builder"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe83c85a85875e8c4cb9ce4a890f05b23d38cd0d47647db7895d3d2a79566d2"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a3151c41d0b13e3d011f98adc24434560ef06673a155a6c7f66b9879eecce2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1299,6 +1950,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -1394,10 +2051,11 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "ciborium",
+ "cucumber",
  "fake",
  "indexmap",
  "tempfile",
@@ -1502,6 +2160,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +2238,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,12 +2313,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -15,6 +15,7 @@ readme = "README.md"
 [workspace]
 
 [dependencies]
+vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
 vantage-diorama = { version = "0.6", path = "../vantage-diorama" }
@@ -41,3 +42,8 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
 tokio = { version = "1", features = ["full"] }
 tempfile = "3"
+cucumber = { version = "0.21", default-features = false, features = ["macros"] }
+
+[[test]]
+name = "bdd"
+harness = false

--- a/vantage-faker/README.md
+++ b/vantage-faker/README.md
@@ -1,8 +1,8 @@
 # vantage-faker
 
-Synthetic, optionally-live datasource for Vantage. Generates realistic rows and — for
-live effects — keeps mutating them, pushing genuine change-events so a subscribed Dio
-animates inserts and expiries. For testing and demos, without a real backend.
+Synthetic, optionally-live datasource for Vantage. Generates realistic rows and — for live effects —
+keeps mutating them, pushing genuine change-events so a subscribed Dio animates inserts and
+expiries. For testing and demos, without a real backend.
 
 > Incubating: API may change.
 
@@ -10,6 +10,36 @@ animates inserts and expiries. For testing and demos, without a real backend.
 
 - `static` — generate rows once; never change.
 - `fifo` — insert one row at a time (newest-first), expire each after a random retention.
+- `PulseSim` — a config-driven live aggregate feed driving three coupled tables.
+- `LiveFolderSim` — a synthetic, constantly-mutating multi-layer log tree.
+
+## `LiveFolderSim`
+
+Models a "live" log folder structure that grows in real time, all in memory:
+
+- `{date}/access_logs_{HH}/chunk_{NN}.log` — high-volume access log. The active chunk bumps every
+  second by `requests_per_sec × bytes_per_request` bytes; when it crosses `chunk_threshold`, a new
+  chunk starts (the old stays).
+- `{date}/error_logs/{HH:MM:SS}-errors.log` — rare; one file per error occurrence, gated by
+  `error_pct_per_sec`.
+- `{date}/events/{event_type}.log` — ten event types each with its own 1–10% per-second probability
+  of bumping its file by 2000–4000 bytes.
+
+Each folder and file carries `created`/`modified`; modifying a file touches its parent folder (and
+ancestors up to the root) so a parent reflects its newest child. `backfill` replays the algorithm at
+full speed from `now − backfill` to `now` on construction before real-time ticks begin.
+
+Two Vistas come out of one shared run loop:
+
+- **Listing** (`listing_vista(path)`): one row per child of a path —
+  `{name, kind, size, created, modified}`. Patched in place on each tick via `ChangeEvent`s so a
+  subscribed Dio doesn't re-list.
+- **Folder size** (`size_vista()`): `{path, size, file_count}` — **get-only**, no list. Fetched with
+  100ms–1s latency scaled by file count, the exact slow-get shape viewport debounce tests need.
+
+```sh
+cargo run --example live_folder_cli
+```
 
 ## Example
 
@@ -37,8 +67,8 @@ let table = FakerTable::build(
 // `table.vista` lists the current rows; `table.events.subscribe()` streams live deltas.
 ```
 
-Values are drawn from the [`fake`](https://crates.io/crates/fake) crate: the column name
-is matched first (`email`, `name`, `phone`, `city`, …), then the declared type.
+Values are drawn from the [`fake`](https://crates.io/crates/fake) crate: the column name is matched
+first (`email`, `name`, `phone`, `city`, …), then the declared type.
 
 ## License
 

--- a/vantage-faker/examples/live_folder_cli.rs
+++ b/vantage-faker/examples/live_folder_cli.rs
@@ -1,0 +1,116 @@
+//! Watch a live log-folder tree in the terminal.
+//!
+//! Runs a [`LiveFolderSim`] with a 2-hour backfill, then prints the whole
+//! tree each second — file/folder name, size, created, modified. The sim
+//! ticks in real time, so new chunks appear, error files pop in, and event
+//! files grow as you watch.
+//!
+//! ```sh
+//! cargo run --example live_folder_cli
+//! ```
+//! Ctrl-C to quit.
+
+use std::time::Duration;
+
+use vantage_faker::{LiveFolderConfig, LiveFolderSim};
+
+fn human_bytes(n: u64) -> String {
+    if n < 1024 {
+        format!("{n:>5} B ")
+    } else if n < 1024 * 1024 {
+        format!("{:5.1} KB", n as f64 / 1024.0)
+    } else if n < 1024 * 1024 * 1024 {
+        format!("{:5.1} MB", n as f64 / 1024.0 / 1024.0)
+    } else {
+        format!("{:5.1} GB", n as f64 / 1024.0 / 1024.0 / 1024.0)
+    }
+}
+
+/// Print the tree, indenting children. Files get `size + dates`; folders
+/// just get a `modified` stamp (size is fetched via the size vista, not
+/// shown here).
+fn render(entries: &[(String, vantage_faker::live_folder::Entry)]) {
+    use vantage_faker::live_folder::EntryKind;
+
+    // Group by parent so we can render hierarchy.
+    let mut by_parent: std::collections::BTreeMap<
+        String,
+        Vec<(String, vantage_faker::live_folder::Entry)>,
+    > = std::collections::BTreeMap::new();
+    for (path, entry) in entries {
+        let parent = match path.rsplit_once('/') {
+            Some((p, _)) => p.to_string(),
+            None => String::new(),
+        };
+        by_parent
+            .entry(parent)
+            .or_default()
+            .push((path.clone(), entry.clone()));
+    }
+
+    fn walk(
+        prefix: &str,
+        path: &str,
+        by_parent: &std::collections::BTreeMap<
+            String,
+            Vec<(String, vantage_faker::live_folder::Entry)>,
+        >,
+    ) {
+        let Some(children) = by_parent.get(path) else {
+            return;
+        };
+        let last_idx = children.len().saturating_sub(1);
+        for (i, (child_path, entry)) in children.iter().enumerate() {
+            let is_last = i == last_idx;
+            let branch = if is_last { "└── " } else { "├── " };
+            let cont = if is_last { "    " } else { "│   " };
+
+            let modified = entry.modified;
+            let m_full = vantage_faker::live_folder::format_ts(modified);
+            let m_str = m_full.split(' ').nth(1).unwrap_or("");
+            let c_full = vantage_faker::live_folder::format_ts(entry.created);
+            let c_str = c_full.split(' ').nth(1).unwrap_or("");
+
+            match entry.kind {
+                EntryKind::File => {
+                    println!(
+                        "{prefix}{branch}{:<28} {:<10}  mod {m_str}  created {c_str}",
+                        entry.name,
+                        human_bytes(entry.size)
+                    );
+                }
+                EntryKind::Folder => {
+                    println!("{prefix}{branch}{}/  mod {m_str}", entry.name);
+                    let new_prefix = format!("{prefix}{cont}");
+                    walk(&new_prefix, child_path, by_parent);
+                }
+            }
+        }
+    }
+
+    println!(
+        "\nvantage-faker · live folder tree (5 GB chunks, 0.1% error rate, 2h backfill) · mod = modified UTC · Ctrl-C to quit\n"
+    );
+    walk("", "", &by_parent);
+}
+
+#[tokio::main]
+async fn main() {
+    // 2-hour backfill so the tree opens already populated.
+    let cfg = LiveFolderConfig {
+        backfill: Duration::from_secs(2 * 3600),
+        chunk_threshold: 5 * 1024 * 1024 * 1024, // 5 GB chunks
+        error_pct_per_sec: 0.1,                  // 0.1% per second
+        ..LiveFolderConfig::default()
+    };
+    let sim = LiveFolderSim::new(cfg);
+
+    loop {
+        // Clear screen + home cursor.
+        print!("\x1B[2J\x1B[H");
+        let snap = sim.snapshot();
+        render(&snap);
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/vantage-faker/examples/scenery_folder_cli.rs
+++ b/vantage-faker/examples/scenery_folder_cli.rs
@@ -1,0 +1,250 @@
+//! Three-pane reactive view of a live folder tree, driven by Diorama.
+//!
+//! Builds one Dio for the `yyyy-mm-dd` listing, then traverses into
+//! `error_logs` and `events` via `Dio::get_ref("subdir", row)` — the same
+//! pattern a UI detail tab uses to drill into a child folder. Each pane is a
+//! `TableScenery` that re-lists from the live tree on every sim tick
+//! (`ChangeEvent::Invalidated` → `dio.refresh()` → scenery reseeds →
+//! redraws).
+//!
+//! ```sh
+//! cargo run --example scenery_folder_cli
+//! ```
+//! Ctrl-C to quit.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use tempfile::TempDir;
+use vantage_cli_util::render_records;
+use vantage_core::Result;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{ChangeEvent, Dio, Lens, SortDir, TableScenery};
+use vantage_faker::{LiveFolderConfig, LiveFolderSim};
+use vantage_types::Record;
+
+const VIEWPORT: usize = 30;
+
+/// Render one scenery as a titled block. Reads up to `VIEWPORT` rows from
+/// the scenery's sparse map; falls back to "(empty)" when the folder has no
+/// children yet.
+fn render_pane(title: &str, hint: &str, scenery: &Arc<dyn TableScenery>) {
+    println!("┌─ {title} ─┐");
+    if hint.is_empty() {
+        println!("│ (not opened yet)");
+        println!("└──────────────────────────────────────────────────────────────");
+        return;
+    }
+    let total = scenery.row_count();
+    let shown = total.min(VIEWPORT);
+    println!("│ {hint} · showing {shown} of {total} rows");
+
+    let mut records: IndexMap<String, Record<CborValue>> = IndexMap::new();
+    for i in 0..shown {
+        if let Some(row) = scenery.row(i) {
+            let id = match row.record.get("name") {
+                Some(CborValue::Text(s)) => s.clone(),
+                _ => i.to_string(),
+            };
+            records.insert(id, row.record.clone());
+        }
+    }
+    if records.is_empty() {
+        println!("│ (no rows yet this tick)");
+    } else {
+        // Render below the title rule. `render_records` prints its own table.
+        render_records(&records, Some("name"));
+    }
+    println!();
+}
+
+/// Open a TableScenery on `dio`, sorted by `modified` desc so the newest
+/// child floats to the top of the pane.
+async fn open_scenery(dio: &vantage_diorama::Dio) -> Result<Arc<dyn TableScenery>> {
+    let scenery: Arc<dyn TableScenery> = dio
+        .table_scenery()
+        .sort("modified", SortDir::Desc)
+        .open()
+        .await?;
+    scenery.set_viewport(0..VIEWPORT);
+    Ok(scenery)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let tmp = TempDir::new().expect("tempdir");
+
+    // Poll-style lens: on each Invalidated, re-list the master into the cache
+    // and let the scenery reseed. The FolderListingShell reads the live tree,
+    // so a refresh always picks up the latest state.
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .on_refresh(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().clear().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            .on_event(|dio, evt| {
+                let dio = dio.clone();
+                async move {
+                    if matches!(evt, ChangeEvent::Invalidated) {
+                        dio.refresh().await?;
+                    }
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+
+    // Sim: 2-hour backfill, 5 GB chunks, 0.1% error rate (matches `live_folder_cli`).
+    let sim = LiveFolderSim::new(LiveFolderConfig {
+        backfill: Duration::from_secs(2 * 3600),
+        chunk_threshold: 5 * 1024 * 1024 * 1024,
+        error_pct_per_sec: 0.1,
+        ..LiveFolderConfig::default()
+    });
+
+    // Today's date — used as the path for the ymd listing.
+    let today = {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let days = secs / 86400;
+        let z = days as i64 + 719468;
+        let era = z.div_euclid(146097);
+        let doe = (z - era * 146097) as u64;
+        let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+        let y = yoe as i64 + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+        let mp = (5 * doy + 2) / 153;
+        let d = doy - (153 * mp + 2) / 5 + 1;
+        let m = if mp < 10 { mp + 3 } else { mp - 9 };
+        let y = if m <= 2 { y + 1 } else { y };
+        format!("{y:04}-{m:02}-{d:02}")
+    };
+
+    // 1. ymd Dio over the today listing.
+    let (ymd_vista, events) = sim.listing_vista("ymd", &today);
+    let ymd_dio = lens.make_dio(ymd_vista).await?;
+
+    // Forward the sim's broadcast into the ymd Dio. The two child Dios share
+    // the same Lens, but each needs its own forwarder — for this demo we run
+    // all three off the ymd Dio's invalidate bus by refreshing every Dio on
+    // every event. (The lens callback only fires for the Dio whose
+    // `handle_event` was called, so we wire three forwarders below.)
+    let mut rx = events.subscribe();
+
+    // 2. Traverse into `error_logs` and `events` via get_ref("subdir", row).
+    //    Find each child row in the ymd listing, then call get_ref with it.
+    let error_logs_dio = match find_child_row(&ymd_dio, "error_logs").await? {
+        Some(row) => Some(ymd_dio.get_ref("subdir", &row).await?),
+        None => None,
+    };
+    let events_dio = match find_child_row(&ymd_dio, "events").await? {
+        Some(row) => Some(ymd_dio.get_ref("subdir", &row).await?),
+        None => None,
+    };
+
+    // 3. Open the three sceneries.
+    let ymd_scenery = open_scenery(&ymd_dio).await?;
+    let error_logs_scenery = match &error_logs_dio {
+        Some(d) => Some(open_scenery(d).await?),
+        None => None,
+    };
+    let events_scenery = match &events_dio {
+        Some(d) => Some(open_scenery(d).await?),
+        None => None,
+    };
+
+    // Forwarders: each Dio needs its own `handle_event` invocation when the
+    // sim ticks. Fan the single broadcast out to all three.
+    let dios_for_forward: Vec<Option<Dio>> = vec![
+        Some(ymd_dio.clone()),
+        error_logs_dio.clone(),
+        events_dio.clone(),
+    ];
+    tokio::spawn(async move {
+        while let Ok(evt) = rx.recv().await {
+            for dio in dios_for_forward.iter().flatten() {
+                let _ = dio.handle_event(evt.clone()).await;
+            }
+        }
+    });
+
+    println!("vantage-faker · scenery_folder_cli · Ctrl-C to quit\n");
+    println!("Opening 3 sceneries via Dio::get_ref(\"subdir\", row):");
+    println!("  • ymd     = listing of {today}/");
+    println!(
+        "  • errors  = {}",
+        match &error_logs_dio {
+            Some(_) => "get_ref(\"subdir\", error_logs_row)",
+            None => "(no error_logs folder yet)",
+        }
+    );
+    println!(
+        "  • events  = {}",
+        match &events_dio {
+            Some(_) => "get_ref(\"subdir\", events_row)",
+            None => "(no events folder yet)",
+        }
+    );
+    println!();
+
+    // Render once a second — matches the sim's tick cadence.
+    loop {
+        print!("\x1B[2J\x1B[H");
+        println!("vantage-faker · scenery_folder_cli · Ctrl-C to quit\n");
+
+        render_pane(
+            &format!("ymd: {today}/"),
+            " Dio over listing_vista(\"ymd\", today)",
+            &ymd_scenery,
+        );
+
+        match &error_logs_scenery {
+            Some(s) => render_pane(
+                "error_logs (via get_ref subdir)",
+                " Dio::get_ref(\"subdir\", error_logs_row)",
+                s,
+            ),
+            None => render_pane("error_logs", "", &ymd_scenery),
+        }
+
+        match &events_scenery {
+            Some(s) => render_pane(
+                "events (via get_ref subdir)",
+                " Dio::get_ref(\"subdir\", events_row)",
+                s,
+            ),
+            None => render_pane("events", "", &ymd_scenery),
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Pull one row out of a Dio's master listing by its `name` field. Used to
+/// grab the `error_logs` / `events` row so we can hand the full record to
+/// `Dio::get_ref("subdir", row)`.
+async fn find_child_row(dio: &Dio, name: &str) -> Result<Option<Record<CborValue>>> {
+    let rows = dio.master().list_values().await?;
+    Ok(rows
+        .into_iter()
+        .find(|(_, r)| r.get("name").and_then(|v| v.as_text()) == Some(name))
+        .map(|(_, r)| r))
+}

--- a/vantage-faker/src/lib.rs
+++ b/vantage-faker/src/lib.rs
@@ -16,6 +16,7 @@
 //! broadcast [`Sender`](broadcast::Sender) to subscribe to for live deltas.
 
 pub mod effect;
+pub mod live_folder;
 pub mod pulse;
 pub mod value_gen;
 
@@ -26,6 +27,9 @@ use vantage_vista::Vista;
 use vantage_vista::mocks::MockShell;
 
 pub use effect::{FakerCtx, FakerEffect, FifoEffect, StaticEffect};
+pub use live_folder::{
+    EVENT_TYPES, Entry, EntryKind, LiveFolderConfig, LiveFolderSim, PushMode, format_ts,
+};
 pub use pulse::{PulseConfig, PulseKey, PulseRole, PulseSim};
 pub use value_gen::ValueGen;
 

--- a/vantage-faker/src/live_folder.rs
+++ b/vantage-faker/src/live_folder.rs
@@ -1,0 +1,376 @@
+//! LiveFolder sim — a synthetic, constantly-mutating multi-layer log tree.
+//!
+//! Models a "live" log folder structure that grows in real time:
+//!
+//! - `{date}/access_logs_{HH}/chunk_{NN}.log` — high-volume access log. The
+//!   active chunk's size bumps every second by `requests_per_sec ×
+//!   bytes_per_request` bytes; when it crosses `chunk_threshold`, a new
+//!   chunk starts (the old one stays). Default sized for ~100 chunks/hour.
+//! - `{date}/error_logs/{HH:MM:SS}-errors.log` — rare. Each second has an
+//!   `error_pct_per_sec` chance of producing one timestamped file with a
+//!   random "backtrace" size.
+//! - `{date}/events/{event_type}.log` — ten event types, each with its own
+//!   1–10% per-second probability of bumping its file by 2000–4000 bytes.
+//!   The file is created the first time its event fires.
+//!
+//! Everything is in memory — no real files. Each folder and file carries
+//! `created` / `modified`; modifying a file touches its parent folder (and
+//! ancestors up to the root) so a parent reflects its newest child.
+//!
+//! Two Vistas come out of one shared run loop:
+//!
+//! - **Listing** ([`LiveFolderSim::listing_vista`]): one row per child of a
+//!   given path — `{name, kind, size, created, modified}`. Built lazily for
+//!   any path the caller asks for; patched in place on each tick via
+//!   `ChangeEvent`s so a subscribed Dio doesn't re-list.
+//! - **Folder size** ([`LiveFolderSim::size_vista`]): `{path, size,
+//!   file_count}`, **get-only** (no list). Fetched with 100ms–1s latency
+//!   scaled by file count — exactly the slow-get shape debounce tests need.
+//!
+//! `backfill` replays the algorithm at full speed from `now − backfill` to
+//! `now` on sim startup, seeding the tree before real-time ticks begin.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tokio::time::interval;
+use vantage_diorama::ChangeEvent;
+use vantage_vista::Vista;
+
+use crate::live_folder::listing_shell::FolderListingShell;
+use crate::live_folder::size_shell::FolderSizeShell;
+use crate::live_folder::tree::simulate_second;
+
+mod listing_shell;
+mod size_shell;
+pub mod tree;
+
+pub use tree::{Entry, EntryKind, Tree, format_ts};
+
+/// Broadcast backlog before a lagged subscriber must resync via `list`.
+const EVENT_CAPACITY: usize = 1024;
+/// Real-time cadence: one `simulate_second` + one listing sync per tick.
+const LOOP_TICK: Duration = Duration::from_secs(1);
+
+/// Per-second event-type probabilities (percent). `(name,
+/// percent_chance_per_second)` — the loop draws `rand(0,100) < pct` to fire
+/// one occurrence, which bumps `<name>.log` by 2000–4000 bytes.
+pub const EVENT_TYPES: &[(&str, u32)] = &[
+    ("user_signup", 1),
+    ("payment_succeeded", 2),
+    ("payment_failed", 1),
+    ("page_view", 10),
+    ("api_call", 8),
+    ("search_query", 6),
+    ("file_upload", 3),
+    ("email_sent", 4),
+    ("notification", 5),
+    ("error_reported", 1),
+];
+
+/// Lens push mode — how a subscribed Dio hears about changes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PushMode {
+    /// Periodic refresh (default 1s) re-lists from the master vista. Simpler,
+    /// tolerates dropped events, but a fixed latency floor.
+    Poll,
+    /// Forward every `ChangeEvent` from the sim into the Dio's `on_event`.
+    /// Sub-frame latency, but a dropped event sticks until the next refresh.
+    Notify,
+}
+
+/// Configuration for a [`LiveFolderSim`].
+#[derive(Clone, Debug)]
+pub struct LiveFolderConfig {
+    /// Access-log requests per virtual second. Multiplied by one
+    /// `bytes_per_request` draw to get the per-tick chunk size bump.
+    pub requests_per_sec: u64,
+    /// Range of bytes per request (one random draw per tick). Defaults to a
+    /// 60–100 char access-log line.
+    pub bytes_per_request: (u64, u64),
+    /// When the active chunk's size meets or exceeds this, the next tick
+    /// rolls a new `chunk_NN.log`. Default sized for ~100 chunks/hour.
+    pub chunk_threshold: u64,
+    /// Percent chance (0.0–100.0) of producing one error file per second.
+    /// Fractional values (e.g. `0.1`) are supported — drawn against a
+    /// 0.01%-precision roll.
+    pub error_pct_per_sec: f64,
+    /// Random backtrace size range for an error file, bytes.
+    pub error_size: (u64, u64),
+    /// Random size bump range for an event occurrence, bytes.
+    pub event_bump: (u64, u64),
+    /// Backfill window. The loop runs at full speed from `now − backfill`
+    /// to `now` on construction before real-time ticks begin. `ZERO` skips.
+    pub backfill: Duration,
+}
+
+impl Default for LiveFolderConfig {
+    fn default() -> Self {
+        // Default sized for ~100 chunks/hour at 100 req/s × 60–100 bytes:
+        // avg 80 bytes × 100 req × 36 sec ≈ 288_000 bytes per chunk.
+        Self {
+            requests_per_sec: 100,
+            bytes_per_request: (60, 100),
+            chunk_threshold: 288_000,
+            error_pct_per_sec: 1.0,
+            error_size: (500, 3_000),
+            event_bump: (2_000, 4_000),
+            backfill: Duration::ZERO,
+        }
+    }
+}
+
+// `listing_columns()` / `listing_shell()` / `entry_to_record()` lived here
+// before — they've moved into `listing_shell.rs` so the listing vista is a
+// single self-contained shell reading the live tree, with a `subdir` HasMany
+// reference for Dio traversal.
+
+/// A run loop + shared state for one LiveFolder simulation.
+///
+/// Cheap to [`Clone`] — clones share the tree and the single broadcast
+/// channel. The loop stops when the last clone is dropped.
+#[derive(Clone)]
+pub struct LiveFolderSim {
+    inner: Arc<Inner>,
+    /// Single broadcast: emits [`ChangeEvent::Invalidated`] on every tick. A
+    /// subscribed Dio's `on_event` callback should treat it as "re-list from
+    /// the master" — every [`FolderListingShell`] reads the live tree, so a
+    /// refresh picks up the latest state without per-path patching.
+    events: broadcast::Sender<ChangeEvent>,
+    _task: Arc<AbortOnDrop>,
+}
+
+/// Mutable per-sim state. Held under one mutex — every tick mutates the
+/// tree, and every list reads it. Coarse locking is fine for a sim.
+pub(crate) struct SimState {
+    pub(crate) tree: Tree,
+}
+
+pub(crate) struct Inner {
+    pub(crate) cfg: LiveFolderConfig,
+    pub(crate) state: Mutex<SimState>,
+}
+
+impl LiveFolderSim {
+    /// Build the sim, run backfill synchronously (seed the tree), then spawn
+    /// the real-time loop. Must be called inside a Tokio runtime context.
+    pub fn new(cfg: LiveFolderConfig) -> Self {
+        let now = SystemTime::now();
+        let inner = Arc::new(Inner {
+            cfg: cfg.clone(),
+            state: Mutex::new(SimState {
+                tree: Tree::new(now),
+            }),
+        });
+
+        // Backfill runs synchronously: replay every virtual second from
+        // `now − backfill` to `now`, mutating the tree without broadcasting
+        // (no subscribers can exist yet).
+        if cfg.backfill > Duration::ZERO {
+            let start = now
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+                .saturating_sub(cfg.backfill.as_secs());
+            let end = now
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let mut state = inner.state.lock().unwrap();
+            for s in start..end {
+                let when = SystemTime::UNIX_EPOCH + Duration::from_secs(s);
+                simulate_second(&mut state.tree, &cfg, when);
+            }
+        }
+
+        let (events, _) = broadcast::channel(EVENT_CAPACITY);
+        let task = spawn_loop(inner.clone(), events.clone());
+        Self {
+            inner,
+            events,
+            _task: Arc::new(AbortOnDrop(task)),
+        }
+    }
+
+    /// Build the listing vista for `path`. The returned `Vista` wraps a
+    /// [`FolderListingShell`] that reads the live tree on every list, so it
+    /// always reflects the current state — no per-path snapshot to sync.
+    ///
+    /// The broadcast sender emits [`ChangeEvent::Invalidated`] on every tick;
+    /// a forwarder should map it to a re-list (the shell re-reads the tree).
+    ///
+    /// Path is `/`-separated; empty path = root (lists dates).
+    pub fn listing_vista(
+        &self,
+        name: impl Into<String>,
+        path: impl Into<String>,
+    ) -> (Vista, broadcast::Sender<ChangeEvent>) {
+        let shell = FolderListingShell::new(self.inner.clone(), path.into());
+        (Vista::new(name, Box::new(shell)), self.events.clone())
+    }
+
+    /// Build the get-only folder-size vista. The underlying shell computes
+    /// `(size, file_count)` on demand with simulated latency.
+    pub fn size_vista(&self, name: impl Into<String>) -> Vista {
+        Vista::new(name, Box::new(FolderSizeShell::new(self.inner.clone())))
+    }
+
+    /// Snapshot the tree as a flat `path → entry` map. Used by the example
+    /// CLI to render the whole tree without spinning up per-path listings.
+    pub fn snapshot(&self) -> Vec<(String, Entry)> {
+        let state = self.inner.state.lock().unwrap();
+        let mut out = Vec::new();
+        fn walk(prefix: &str, entry: &Entry, out: &mut Vec<(String, Entry)>) {
+            for (name, child) in &entry.children {
+                let path = if prefix.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{prefix}/{name}")
+                };
+                out.push((path.clone(), child.clone()));
+                if child.kind == EntryKind::Folder {
+                    walk(&path, child, out);
+                }
+            }
+        }
+        walk("", &state.tree.root, &mut out);
+        out
+    }
+
+    /// The current config (clone).
+    pub fn config(&self) -> LiveFolderConfig {
+        self.inner.cfg.clone()
+    }
+}
+
+/// Spawn the per-second run loop. Each tick:
+/// 1. Run one virtual second of the simulation.
+/// 2. Broadcast `Invalidated` so subscribed Dios re-list from the live tree.
+fn spawn_loop(inner: Arc<Inner>, events: broadcast::Sender<ChangeEvent>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = interval(LOOP_TICK);
+        loop {
+            ticker.tick().await;
+            let now = SystemTime::now();
+            {
+                let mut state = inner.state.lock().unwrap();
+                simulate_second(&mut state.tree, &inner.cfg, now);
+            }
+            // Single broadcast — every subscribed Dio hears it and re-lists.
+            let _ = events.send(ChangeEvent::Invalidated);
+        }
+    })
+}
+
+/// Aborts the run loop when the last [`LiveFolderSim`] clone drops.
+struct AbortOnDrop(JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use vantage_dataset::prelude::ReadableValueSet;
+
+    fn cfg_no_backfill() -> LiveFolderConfig {
+        LiveFolderConfig {
+            backfill: Duration::ZERO,
+            ..LiveFolderConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn listing_vista_reads_from_the_live_tree() {
+        // Use a sim with backfill so there's data before any tick.
+        let cfg = LiveFolderConfig {
+            backfill: Duration::from_secs(3600),
+            error_pct_per_sec: 100.0, // guarantee some error files
+            ..LiveFolderConfig::default()
+        };
+        let sim = LiveFolderSim::new(cfg);
+
+        let (root_vista, _tx) = sim.listing_vista("root", "");
+        // Root lists day folders. At least one date should exist after 1h backfill.
+        let rows = root_vista.list_values().await.unwrap();
+        assert!(!rows.is_empty(), "root listing should have day folders");
+    }
+
+    #[tokio::test]
+    async fn size_vista_returns_none_for_unknown_path() {
+        let sim = LiveFolderSim::new(cfg_no_backfill());
+        let vista = sim.size_vista("sizes");
+        let got = vista.get_value("does/not/exist".to_string()).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn size_vista_returns_size_for_a_real_folder() {
+        let sim = LiveFolderSim::new(LiveFolderConfig {
+            backfill: Duration::from_secs(120),
+            ..LiveFolderConfig::default()
+        });
+        let vista = sim.size_vista("sizes");
+
+        // Find any populated path from the snapshot.
+        let snap = sim.snapshot();
+        let any_folder = snap
+            .iter()
+            .find(|(_, e)| e.kind == EntryKind::Folder && !e.children.is_empty())
+            .map(|(p, _)| p.clone())
+            .expect("backfill produced at least one folder");
+
+        let rec = vista
+            .get_value(&any_folder)
+            .await
+            .unwrap()
+            .expect("folder resolves");
+        assert!(rec.get("size").is_some());
+        assert!(rec.get("file_count").is_some());
+    }
+
+    #[tokio::test]
+    async fn listing_vista_supports_subdir_traversal() {
+        // `get_ref("subdir", row)` on a ymd listing must descend into the
+        // child identified by `row[path]`.
+        let sim = LiveFolderSim::new(LiveFolderConfig {
+            backfill: Duration::from_secs(3600),
+            ..LiveFolderConfig::default()
+        });
+        let (ymd_vista, _tx) = sim.listing_vista("ymd", "");
+        let ymd_rows = ymd_vista.list_values().await.unwrap();
+        let date_row = ymd_rows
+            .iter()
+            .find(|(_, r)| r.get("kind").and_then(|v| v.as_text()) == Some("folder"))
+            .map(|(_, r)| r.clone())
+            .expect("at least one date folder");
+
+        // Traverse into the date folder.
+        let sub = ymd_vista.get_ref("subdir", &date_row).expect("subdir ref");
+        let sub_rows = sub.list_values().await.unwrap();
+        assert!(!sub_rows.is_empty(), "date folder should list its children");
+        // Each child's hidden `path` field starts with the date folder's path.
+        let parent = date_row
+            .get("path")
+            .and_then(|v| v.as_text())
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        for (_, rec) in &sub_rows {
+            let path = rec
+                .get("path")
+                .and_then(|v| v.as_text())
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            assert!(
+                path.starts_with(&parent),
+                "child path {path:?} should start with parent {parent:?}"
+            );
+        }
+    }
+}

--- a/vantage-faker/src/live_folder/listing_shell.rs
+++ b/vantage-faker/src/live_folder/listing_shell.rs
@@ -1,0 +1,223 @@
+//! Listing `TableShell` for the live-folder sim.
+//!
+//! One shell per `path` reads the live tree on every `list` — no per-path
+//! MockShell snapshot to keep in sync. The shell declares a `subdir` HasMany
+//! reference so a Dio over a parent folder can traverse into any child:
+//!
+//! ```ignore
+//! let ymd_dio = lens.make_dio(sim.listing_vista("ymd", "2026-07-03")).await?;
+//! let row = find_row(&ymd_dio, "error_logs").await;
+//! let error_logs_dio = ymd_dio.get_ref("subdir", &row).await?;
+//! ```
+//!
+//! `get_ref("subdir", row)` reads `row[path]` (a hidden column populated by
+//! `list_vista_values`) and builds a new `FolderListingShell` for that path —
+//! so traversal descends one level without re-reading any other branch.
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use std::sync::Arc;
+use vantage_core::{Result, error};
+use vantage_types::Record;
+use vantage_vista::Vista;
+use vantage_vista::capabilities::VistaCapabilities;
+use vantage_vista::column::Column;
+use vantage_vista::flags;
+use vantage_vista::metadata::VistaMetadata;
+use vantage_vista::reference::{Reference, ReferenceKind};
+use vantage_vista::source::TableShell;
+
+use super::Inner;
+use super::tree::{Entry, EntryKind, format_ts};
+
+/// Listing column set, built once and shared by every listing shell.
+fn listing_metadata() -> VistaMetadata {
+    VistaMetadata::new()
+        .with_id_column("name")
+        .with_column(
+            Column::new("name", "string")
+                .with_flag(flags::ID)
+                .with_flag(flags::TITLE)
+                .with_flag(flags::ORDERABLE),
+        )
+        .with_column(Column::new("kind", "string"))
+        .with_column(Column::new("size", "u64").with_flag(flags::ORDERABLE))
+        .with_column(Column::new("created", "datetime"))
+        .with_column(Column::new("modified", "datetime").with_flag(flags::ORDERABLE))
+        // Hidden helper column carrying the row's full path, so `get_ref`
+        // can build the child shell without re-deriving it from `name`.
+        .with_column(Column::new("path", "string").with_flag(flags::HIDDEN))
+        .with_reference(Reference::new(
+            "subdir",
+            "live-folder-listing",
+            ReferenceKind::HasMany,
+            "name",
+        ))
+}
+
+fn entry_to_record(path_so_far: &str, name: &str, entry: &Entry) -> Record<CborValue> {
+    let full_path = if path_so_far.is_empty() {
+        name.to_string()
+    } else {
+        format!("{path_so_far}/{name}")
+    };
+    let mut r = Record::new();
+    r.insert("name".to_string(), CborValue::Text(entry.name.clone()));
+    r.insert(
+        "kind".to_string(),
+        CborValue::Text(
+            match entry.kind {
+                EntryKind::File => "file",
+                EntryKind::Folder => "folder",
+            }
+            .to_string(),
+        ),
+    );
+    r.insert(
+        "size".to_string(),
+        CborValue::Integer((entry.size as i64).into()),
+    );
+    r.insert(
+        "created".to_string(),
+        CborValue::Text(format_ts(entry.created)),
+    );
+    r.insert(
+        "modified".to_string(),
+        CborValue::Text(format_ts(entry.modified)),
+    );
+    r.insert("path".to_string(), CborValue::Text(full_path));
+    r
+}
+
+/// `TableShell` over one folder of the live tree. Cheap to clone — shares
+/// the sim's `Arc<Inner>`. The run loop just mutates the tree; this shell
+/// always reads the latest state on `list`.
+pub struct FolderListingShell {
+    inner: Arc<Inner>,
+    path: String,
+    metadata: VistaMetadata,
+    capabilities: VistaCapabilities,
+}
+
+impl FolderListingShell {
+    pub(super) fn new(inner: Arc<Inner>, path: String) -> Self {
+        Self {
+            inner,
+            path,
+            metadata: listing_metadata(),
+            capabilities: VistaCapabilities {
+                can_count: true,
+                can_order: true,
+                can_search: true,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[async_trait]
+#[allow(clippy::ptr_arg)]
+impl TableShell for FolderListingShell {
+    fn columns(&self) -> &IndexMap<String, Column> {
+        &self.metadata.columns
+    }
+
+    fn references(&self) -> &IndexMap<String, Reference> {
+        &self.metadata.references
+    }
+
+    fn id_column(&self) -> Option<&str> {
+        self.metadata.id_column.as_deref()
+    }
+
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        let state = self.inner.state.lock().unwrap();
+        let mut rows = IndexMap::new();
+        if let Some(folder) = state.tree.get(&self.path) {
+            for (name, entry) in &folder.children {
+                rows.insert(name.clone(), entry_to_record(&self.path, name, entry));
+            }
+        }
+        Ok(rows)
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        let state = self.inner.state.lock().unwrap();
+        Ok(state
+            .tree
+            .get(&self.path)
+            .and_then(|f| f.children.get(id))
+            .map(|e| entry_to_record(&self.path, id, e)))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        Ok(self.list_vista_values(vista).await?.into_iter().next())
+    }
+
+    /// `subdir` traversal: descend one level into the child identified by
+    /// `row[path]` (full path, populated by `list_vista_values`). Falls back
+    /// to `self.path + "/" + row[name]` if `path` is missing.
+    fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
+        if relation != "subdir" {
+            return Err(error!(
+                "unknown relation",
+                relation = relation,
+                source_type = "FolderListingShell"
+            )
+            .mark_unimplemented()
+            .traced());
+        }
+        let child_path = match row.get("path") {
+            Some(CborValue::Text(s)) => s.clone(),
+            _ => {
+                let name = match row.get("name") {
+                    Some(CborValue::Text(s)) => s.clone(),
+                    _ => {
+                        return Err(error!(
+                            "subdir traversal requires row.path or row.name",
+                            relation = relation
+                        )
+                        .traced());
+                    }
+                };
+                if self.path.is_empty() {
+                    name
+                } else {
+                    format!("{}/{name}", self.path)
+                }
+            }
+        };
+        Ok(Vista::new(
+            "live-folder-listing",
+            Box::new(FolderListingShell::new(self.inner.clone(), child_path)),
+        ))
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        Some(Box::new(Self {
+            inner: self.inner.clone(),
+            path: self.path.clone(),
+            metadata: self.metadata.clone(),
+            capabilities: self.capabilities.clone(),
+        }))
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "live-folder-listing"
+    }
+}

--- a/vantage-faker/src/live_folder/size_shell.rs
+++ b/vantage-faker/src/live_folder/size_shell.rs
@@ -1,0 +1,154 @@
+//! Custom `TableShell` for the get-only folder-size vista.
+//!
+//! The listing vista gives you `size = 0` on folders (size isn't part of the
+//! standard listing row). To exercise viewport debounce on a slow `get`, the
+//! size vista fetches a folder's recursive `(size, file_count)` with a
+//! simulated latency: **100 ms base + ~0.9 ms per file, capped at 1 s**.
+//! That gives a fast 100 ms on a near-empty folder and the full second on a
+//! ~1000-file one — exactly the range debounce mechanics need to be tested
+//! against.
+//!
+//! `list` is intentionally empty: this table is fetch-only. The Dio layer
+//! reaches it via `on_load_detail` (one `get` per row), not via `list`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_types::Record;
+use vantage_vista::Vista;
+use vantage_vista::capabilities::VistaCapabilities;
+use vantage_vista::column::Column;
+use vantage_vista::flags;
+use vantage_vista::metadata::VistaMetadata;
+use vantage_vista::reference::Reference;
+use vantage_vista::source::TableShell;
+
+use super::Inner;
+use super::tree::{EntryKind, folder_size};
+
+/// 100 ms floor for any size fetch.
+const LATENCY_FLOOR: Duration = Duration::from_millis(100);
+/// 1 s ceiling — large folders must not stall the UI indefinitely.
+const LATENCY_CAP: Duration = Duration::from_secs(1);
+/// Per-file surcharge added on top of the floor.
+const LATENCY_PER_FILE_NS: u64 = 900_000; // 0.9 ms
+
+/// `TableShell` over the simulated folder-size table.
+///
+/// Holds an `Arc<Inner>` so it sees the same tree the run loop mutates.
+/// Cloning shares that handle — the shell is stateless beyond it.
+pub struct FolderSizeShell {
+    inner: Arc<Inner>,
+    metadata: VistaMetadata,
+    capabilities: VistaCapabilities,
+}
+
+impl FolderSizeShell {
+    pub(super) fn new(inner: Arc<Inner>) -> Self {
+        let metadata = VistaMetadata::new()
+            .with_id_column("path")
+            .with_column(
+                Column::new("path", "string")
+                    .with_flag(flags::ID)
+                    .with_flag(flags::TITLE),
+            )
+            .with_column(Column::new("size", "u64").with_flag(flags::ORDERABLE))
+            .with_column(Column::new("file_count", "u64").with_flag(flags::ORDERABLE));
+        Self {
+            inner,
+            metadata,
+            capabilities: VistaCapabilities {
+                can_count: true,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+#[async_trait]
+#[allow(clippy::ptr_arg)]
+impl TableShell for FolderSizeShell {
+    fn columns(&self) -> &IndexMap<String, Column> {
+        &self.metadata.columns
+    }
+
+    fn references(&self) -> &IndexMap<String, Reference> {
+        &self.metadata.references
+    }
+
+    fn id_column(&self) -> Option<&str> {
+        self.metadata.id_column.as_deref()
+    }
+
+    async fn list_vista_values(
+        &self,
+        _vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        // Intentionally empty — this is a get-only table.
+        Ok(IndexMap::new())
+    }
+
+    async fn get_vista_value(
+        &self,
+        _vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        // Compute size under the lock, then sleep *after* releasing it.
+        let (size, file_count) = {
+            let state = self.inner.state.lock().unwrap();
+            let Some(entry) = state.tree.get(id) else {
+                return Ok(None);
+            };
+            if entry.kind == EntryKind::File {
+                // Files report their own size with no recursion.
+                (entry.size, 1)
+            } else {
+                folder_size(entry)
+            }
+        };
+
+        let per_file = Duration::from_nanos(LATENCY_PER_FILE_NS * file_count);
+        let latency = (LATENCY_FLOOR + per_file).min(LATENCY_CAP);
+        tokio::time::sleep(latency).await;
+
+        Ok(Some(size_record(id, size, file_count)))
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        _vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        Ok(None)
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.capabilities
+    }
+
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        Some(Box::new(Self {
+            inner: self.inner.clone(),
+            metadata: self.metadata.clone(),
+            capabilities: self.capabilities.clone(),
+        }))
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "live-folder-size"
+    }
+}
+
+fn size_record(path: &str, size: u64, file_count: u64) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("path".to_string(), CborValue::Text(path.to_string()));
+    r.insert("size".to_string(), CborValue::Integer((size as i64).into()));
+    r.insert(
+        "file_count".to_string(),
+        CborValue::Integer((file_count as i64).into()),
+    );
+    r
+}

--- a/vantage-faker/src/live_folder/tree.rs
+++ b/vantage-faker/src/live_folder/tree.rs
@@ -1,0 +1,401 @@
+//! In-memory folder tree + the per-second simulation step.
+//!
+//! The tree is a single recursive [`Entry`] rooted at `""` (the top-level
+//! "dates" folder). Files and folders share one struct so a listing views
+//! both uniformly; folders carry a `children` map, files have `size`.
+//!
+//! [`simulate_second`] runs one virtual second of the model: bumps the
+//! active access chunk (rolling when it crosses the threshold), rolls
+//! error_logs at `error_pct_per_sec`, and rolls each event type at its
+//! configured percent. [`Tree::touch`] propagates the new `modified` time
+//! up the ancestor chain so a parent folder reflects any child change.
+
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use fake::Fake;
+
+use super::LiveFolderConfig;
+
+/// File vs folder discriminator for [`Entry::kind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EntryKind {
+    File,
+    Folder,
+}
+
+/// One node in the folder tree. Files have `size` and empty `children`;
+/// folders have `size = 0` (computed on demand for the size vista) and a
+/// named-children map. Both carry `created`/`modified`.
+#[derive(Clone, Debug)]
+pub struct Entry {
+    pub name: String,
+    pub kind: EntryKind,
+    pub size: u64,
+    pub created: SystemTime,
+    pub modified: SystemTime,
+    pub children: BTreeMap<String, Entry>,
+}
+
+impl Entry {
+    pub fn folder(name: String, now: SystemTime) -> Self {
+        Self {
+            name,
+            kind: EntryKind::Folder,
+            size: 0,
+            created: now,
+            modified: now,
+            children: BTreeMap::new(),
+        }
+    }
+
+    pub fn file(name: String, size: u64, now: SystemTime) -> Self {
+        Self {
+            name,
+            kind: EntryKind::File,
+            size,
+            created: now,
+            modified: now,
+            children: BTreeMap::new(),
+        }
+    }
+}
+
+/// The full simulated tree, rooted at `""`.
+#[derive(Debug)]
+pub struct Tree {
+    pub root: Entry,
+}
+
+impl Tree {
+    pub fn new(now: SystemTime) -> Self {
+        Self {
+            root: Entry::folder(String::new(), now),
+        }
+    }
+
+    /// Read-only lookup by `/`-separated path. Empty path → root.
+    pub fn get(&self, path: &str) -> Option<&Entry> {
+        if path.is_empty() {
+            return Some(&self.root);
+        }
+        let mut cur = &self.root;
+        for seg in path.split('/') {
+            cur = cur.children.get(seg)?;
+        }
+        Some(cur)
+    }
+
+    /// Mutable lookup by `/`-separated path.
+    pub fn get_mut(&mut self, path: &str) -> Option<&mut Entry> {
+        if path.is_empty() {
+            return Some(&mut self.root);
+        }
+        let mut cur = &mut self.root;
+        for seg in path.split('/') {
+            cur = cur.children.get_mut(seg)?;
+        }
+        Some(cur)
+    }
+
+    /// Propagate `when` to `modified` on every ancestor of `path` (and the
+    /// leaf itself). The root always touches. Used after any leaf mutation
+    /// so folder `modified` reflects its most-recently-changed child.
+    pub fn touch(&mut self, path: &str, when: SystemTime) {
+        self.root.modified = when;
+        if path.is_empty() {
+            return;
+        }
+        let mut cur = &mut self.root;
+        for seg in path.split('/') {
+            cur.modified = when;
+            cur = match cur.children.get_mut(seg) {
+                Some(c) => c,
+                None => return,
+            };
+        }
+        cur.modified = when;
+    }
+}
+
+/// Run one virtual second of the simulation at time `when`.
+///
+/// The clock decides everything — date/hour/second all derive from `when`,
+/// so calling this with the same `when` always lands mutations in the same
+/// folders (random draws still vary, of course).
+pub fn simulate_second(tree: &mut Tree, cfg: &LiveFolderConfig, when: SystemTime) {
+    let (date_str, hour, hms) = split_time(when);
+
+    // ---- access_logs: bump active chunk, roll when over threshold -----------
+    let access_folder_name = format!("access_logs_{hour:02}");
+    let access_folder_path = format!("{date_str}/{access_folder_name}");
+
+    ensure_path(tree, &[&date_str, &access_folder_name], when);
+    let line_len = rand_range(cfg.bytes_per_request.0, cfg.bytes_per_request.1 + 1);
+    let delta = line_len * cfg.requests_per_sec;
+    let chunk_name = bump_active_chunk(tree, &access_folder_path, cfg.chunk_threshold, delta, when);
+    tree.touch(&format!("{access_folder_path}/{chunk_name}"), when);
+
+    // ---- error_logs: probability-gated file creation -----------------------
+    // 0.01%-precision roll so fractional percents (e.g. 0.1) work.
+    let roll: f64 = (0..10_000).fake::<u64>() as f64 / 100.0;
+    if roll < cfg.error_pct_per_sec {
+        let err_folder_path = format!("{date_str}/error_logs");
+        let err_file = format!("{hms}-errors.log");
+        let err_size = rand_range(cfg.error_size.0, cfg.error_size.1 + 1);
+        ensure_path(tree, &[&date_str, "error_logs"], when);
+        if let Some(folder) = tree.get_mut(&err_folder_path) {
+            folder.children.insert(
+                err_file.clone(),
+                Entry::file(err_file.clone(), err_size, when),
+            );
+        }
+        tree.touch(&format!("{err_folder_path}/{err_file}"), when);
+    }
+
+    // ---- events: per-type probability-gated size bump ----------------------
+    for (etype, pct) in super::EVENT_TYPES {
+        if rand_range(0, 100) < *pct as u64 {
+            let ev_folder_path = format!("{date_str}/events");
+            let file_name = format!("{etype}.log");
+            let bump = rand_range(cfg.event_bump.0, cfg.event_bump.1 + 1);
+            ensure_path(tree, &[&date_str, "events"], when);
+            if let Some(folder) = tree.get_mut(&ev_folder_path) {
+                let file = folder
+                    .children
+                    .entry(file_name.clone())
+                    .or_insert_with(|| Entry::file(file_name.clone(), 0, when));
+                file.size += bump;
+                file.modified = when;
+            }
+            tree.touch(&format!("{ev_folder_path}/{file_name}"), when);
+        }
+    }
+}
+
+/// Walk a path of segments, creating folder entries as needed.
+fn ensure_path(tree: &mut Tree, segments: &[&str], now: SystemTime) {
+    let mut cur = &mut tree.root;
+    for seg in segments {
+        cur = cur
+            .children
+            .entry((*seg).to_string())
+            .or_insert_with(|| Entry::folder((*seg).to_string(), now));
+    }
+}
+
+/// Add `delta` bytes to the active (highest-indexed) `chunk_NN.log` under
+/// `folder_path`, creating a new chunk if the active one is over `threshold`.
+/// When the active chunk's size crosses `threshold` after the bump, the next
+/// chunk file is pre-created (size 0) so a listing shows it opening right
+/// away. Returns the chunk name that received the bump.
+fn bump_active_chunk(
+    tree: &mut Tree,
+    folder_path: &str,
+    threshold: u64,
+    delta: u64,
+    now: SystemTime,
+) -> String {
+    let Some(folder) = tree.get_mut(folder_path) else {
+        return String::new();
+    };
+    let max_idx = folder
+        .children
+        .keys()
+        .filter_map(|k| {
+            k.strip_prefix("chunk_")
+                .and_then(|s| s.strip_suffix(".log"))
+                .and_then(|s| s.parse::<usize>().ok())
+        })
+        .max();
+
+    let idx = match max_idx {
+        None => 1,
+        Some(i) => {
+            let name = format!("chunk_{i:02}.log");
+            let size = folder.children.get(&name).map(|e| e.size).unwrap_or(0);
+            if size < threshold { i } else { i + 1 }
+        }
+    };
+
+    let name = format!("chunk_{idx:02}.log");
+    let chunk = folder
+        .children
+        .entry(name.clone())
+        .or_insert_with(|| Entry::file(name.clone(), 0, now));
+    chunk.size += delta;
+    chunk.modified = now;
+
+    // Active chunk crossed threshold — open the next one (size 0) so a
+    // listing sees the new chunk file appear in the same tick.
+    if chunk.size >= threshold {
+        let next_name = format!("chunk_{:02}.log", idx + 1);
+        folder
+            .children
+            .entry(next_name.clone())
+            .or_insert_with(|| Entry::file(next_name, 0, now));
+    }
+
+    name
+}
+
+/// Recursively sum file sizes under `entry`. Returns `(total_bytes, file_count)`.
+pub fn folder_size(entry: &Entry) -> (u64, u64) {
+    let mut size = 0u64;
+    let mut files = 0u64;
+    fn walk(e: &Entry, size: &mut u64, files: &mut u64) {
+        match e.kind {
+            EntryKind::File => {
+                *size += e.size;
+                *files += 1;
+            }
+            EntryKind::Folder => {
+                for c in e.children.values() {
+                    walk(c, size, files);
+                }
+            }
+        }
+    }
+    walk(entry, &mut size, &mut files);
+    (size, files)
+}
+
+// ---- time helpers (no chrono dep) ----------------------------------------
+
+/// Split a SystemTime into `(date "YYYY-MM-DD", hour 0..=23, "HH:MM:SS")` UTC.
+fn split_time(t: SystemTime) -> (String, u32, String) {
+    let secs = t
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let s = (secs % 60) as u32;
+    let m = ((secs / 60) % 60) as u32;
+    let h = ((secs / 3600) % 24) as u32;
+    let days = secs / 86400;
+    let (y, mo, d) = days_to_ymd(days);
+    (
+        format!("{y:04}-{mo:02}-{d:02}"),
+        h,
+        format!("{h:02}:{m:02}:{s:02}"),
+    )
+}
+
+/// `SystemTime` → "YYYY-MM-DD HH:MM:SS" UTC for record columns.
+pub fn format_ts(t: SystemTime) -> String {
+    let secs = t
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let s = (secs % 60) as u32;
+    let m = ((secs / 60) % 60) as u32;
+    let h = ((secs / 3600) % 24) as u32;
+    let days = secs / 86400;
+    let (y, mo, d) = days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{d:02} {h:02}:{m:02}:{s:02}")
+}
+
+/// Civil-from-days algorithm (Howard Hinnant). `days` is days since
+/// 1970-01-01. Returns `(year, month 1..=12, day 1..=31)`.
+fn days_to_ymd(days: u64) -> (u32, u32, u32) {
+    let z = days as i64 + 719468;
+    let era = z.div_euclid(146097);
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as u32, m as u32, d as u32)
+}
+
+/// `[lo, hi)` random u64. Clamps to `lo` when `hi <= lo`.
+pub fn rand_range(lo: u64, hi: u64) -> u64 {
+    if hi <= lo {
+        return lo;
+    }
+    (lo..hi).fake()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn cfg() -> LiveFolderConfig {
+        LiveFolderConfig {
+            requests_per_sec: 100,
+            bytes_per_request: (60, 100),
+            chunk_threshold: 288_000,
+            error_pct_per_sec: 100.0, // force every second
+            error_size: (500, 500),
+            event_bump: (2000, 2000),
+            backfill: Duration::ZERO,
+        }
+    }
+
+    #[test]
+    fn touch_propagates_modified_up_to_root() {
+        let mut tree = Tree::new(SystemTime::UNIX_EPOCH);
+        ensure_path(
+            &mut tree,
+            &["2026-06-03", "access_logs_11"],
+            SystemTime::UNIX_EPOCH,
+        );
+        let later = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        tree.touch("2026-06-03/access_logs_11/chunk_01.log", later);
+        assert_eq!(tree.root.modified, later);
+        assert_eq!(tree.get("2026-06-03").unwrap().modified, later);
+        assert_eq!(
+            tree.get("2026-06-03/access_logs_11").unwrap().modified,
+            later
+        );
+    }
+
+    #[test]
+    fn chunk_rolls_when_threshold_met() {
+        let mut tree = Tree::new(SystemTime::UNIX_EPOCH);
+        let mut c = cfg();
+        c.chunk_threshold = 200; // roll fast
+        c.requests_per_sec = 1;
+        c.bytes_per_request = (100, 100); // 100 bytes/sec
+
+        // First second: chunk_01 created, size 100.
+        simulate_second(&mut tree, &c, SystemTime::UNIX_EPOCH);
+        let f = tree.get("1970-01-01/access_logs_00").unwrap();
+        assert!(f.children.contains_key("chunk_01.log"));
+        assert_eq!(f.children["chunk_01.log"].size, 100);
+
+        // Second second: chunk_01 size 200, threshold met → chunk_02 created.
+        simulate_second(
+            &mut tree,
+            &c,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+        );
+        let f = tree.get("1970-01-01/access_logs_00").unwrap();
+        assert_eq!(f.children["chunk_01.log"].size, 200);
+        assert!(f.children.contains_key("chunk_02.log"));
+        assert_eq!(f.children["chunk_02.log"].size, 0);
+    }
+
+    #[test]
+    fn folder_size_walks_recursively() {
+        let now = SystemTime::UNIX_EPOCH;
+        let mut tree = Tree::new(now);
+        ensure_path(&mut tree, &["d", "access_logs_00"], now);
+        let f = tree.get_mut("d/access_logs_00").unwrap();
+        f.children.insert(
+            "chunk_01.log".into(),
+            Entry::file("chunk_01.log".into(), 100, now),
+        );
+        f.children.insert(
+            "chunk_02.log".into(),
+            Entry::file("chunk_02.log".into(), 250, now),
+        );
+
+        let (size, files) = folder_size(tree.get("d").unwrap());
+        assert_eq!(size, 350);
+        assert_eq!(files, 2);
+    }
+}

--- a/vantage-faker/tests/bdd.rs
+++ b/vantage-faker/tests/bdd.rs
@@ -1,0 +1,18 @@
+//! Cucumber entry point. Each scenario gets a fresh [`LiveFolderWorld`] on a
+//! single-threaded tokio runtime. The sim ticks real `SystemTime::now()` so
+//! scenarios use small backfills (1–2 hours) to keep wall time bounded.
+
+use cucumber::World;
+
+mod world;
+
+use world::LiveFolderWorld;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    LiveFolderWorld::cucumber()
+        .max_concurrent_scenarios(1)
+        .fail_on_skipped()
+        .run_and_exit("tests/features")
+        .await;
+}

--- a/vantage-faker/tests/features/live_folder.feature
+++ b/vantage-faker/tests/features/live_folder.feature
@@ -1,0 +1,42 @@
+Feature: Live folder simulation
+  A LiveFolderSim models a constantly-mutating multi-layer log tree.
+
+  Scenario: Backfill populates the tree
+    Given a live-folder sim with a 1-hour backfill
+    Then the tree contains at least one date folder
+    And the tree contains an access_logs_HH folder for today
+    And at least one chunk file exists under an access_logs folder
+
+  Scenario: A first-call listing vista seeds from the current tree
+    Given a live-folder sim with a 1-hour backfill
+    When I open the listing vista for the root path
+    Then the listing contains at least one row
+
+  Scenario: A second listing call on the same path shares the store
+    Given a live-folder sim with a 1-hour backfill
+    When I open the listing vista for the root path twice
+    Then both vistas report the same number of rows
+
+  Scenario: Folder size vista returns none for an unknown path
+    Given a live-folder sim with no backfill
+    When I fetch the size for path does-not-exist
+    Then the result is none
+
+  Scenario: Folder size vista returns size for a real folder
+    Given a live-folder sim with a 2-minute backfill
+    When I fetch the size for any populated folder
+    Then the size record has both size and file_count
+
+  Scenario: Error files appear with errors-log suffix
+    Given a live-folder sim with a 1-hour backfill and a 100-percent error rate
+    Then at least one error log file exists under an error_logs folder
+
+  Scenario: Event files appear with log suffix
+    Given a live-folder sim with a 1-hour backfill
+    Then at least one event file exists under an events folder
+    And every event file name is one of the declared event types
+
+  Scenario: Chunk rolls when threshold is met
+    Given a live-folder sim with no backfill and a 200-byte chunk threshold
+    When I simulate 5 virtual seconds at 100 bytes per second
+    Then at least 2 chunk files exist under an access_logs folder

--- a/vantage-faker/tests/world/mod.rs
+++ b/vantage-faker/tests/world/mod.rs
@@ -1,0 +1,347 @@
+//! Cucumber world + step definitions for the live-folder sim.
+//!
+//! The world owns a [`LiveFolderSim`] built per-scenario from the gherkin
+//! `Given` row, and stashes the result of the most recent `When` step
+//! (a listing rows-count or a size record) for the `Then` assertions.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use cucumber::{World, given, then, when};
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_faker::{EVENT_TYPES, LiveFolderConfig, LiveFolderSim};
+
+// Re-exposed tree type for kind comparisons in snapshot assertions.
+type EntryKind = vantage_faker::live_folder::EntryKind;
+
+/// Per-scenario state. `Default::default()` builds an empty sim with no
+/// backfill — `Given` steps replace it.
+#[derive(World)]
+#[world(init = Self::new)]
+pub struct LiveFolderWorld {
+    sim: Option<Arc<LiveFolderSim>>,
+    /// Most recent listing rows count (or two counts for the "twice" step).
+    last_counts: Vec<usize>,
+    /// Most recent size-fetch result (record fields).
+    last_size: Option<(Option<u64>, Option<u64>)>,
+    /// `true` when the last size-fetch returned `None`.
+    last_size_is_none: bool,
+}
+
+impl std::fmt::Debug for LiveFolderWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveFolderWorld")
+            .field("sim_set", &self.sim.is_some())
+            .field("last_counts", &self.last_counts)
+            .field("last_size", &self.last_size)
+            .field("last_size_is_none", &self.last_size_is_none)
+            .finish()
+    }
+}
+
+impl Default for LiveFolderWorld {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LiveFolderWorld {
+    fn new() -> Self {
+        Self {
+            sim: None,
+            last_counts: Vec::new(),
+            last_size: None,
+            last_size_is_none: false,
+        }
+    }
+
+    fn sim(&self) -> &Arc<LiveFolderSim> {
+        self.sim
+            .as_ref()
+            .expect("sim must be set by a `Given` step first")
+    }
+}
+
+// Helper: format the current UTC date so steps can find "today's" folders.
+fn today_date_str() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let days = secs / 86400;
+    let z = days as i64 + 719468;
+    let era = z.div_euclid(146097);
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+fn hour_str() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    format!("{:02}", (secs / 3600) % 24)
+}
+
+fn tree_contains(
+    sim: &LiveFolderSim,
+    predicate: impl Fn(&vantage_faker::live_folder::Entry) -> bool,
+) -> bool {
+    sim.snapshot().iter().any(|(_, e)| predicate(e))
+}
+
+// ---- Given --------------------------------------------------------------
+
+#[given(regex = r"a live-folder sim with a (\d+)-(hour|minute) backfill$")]
+async fn sim_with_backfill(world: &mut LiveFolderWorld, n: u64, unit: String) {
+    let dur = match unit.as_str() {
+        "hour" => Duration::from_secs(n * 3600),
+        "minute" => Duration::from_secs(n * 60),
+        other => panic!("unknown unit: {other}"),
+    };
+    let cfg = LiveFolderConfig {
+        backfill: dur,
+        ..LiveFolderConfig::default()
+    };
+    world.sim = Some(Arc::new(LiveFolderSim::new(cfg)));
+}
+
+#[given(
+    regex = r"a live-folder sim with a (\d+)-(hour|minute) backfill and a (\d+)-percent error rate"
+)]
+async fn sim_with_backfill_and_errors(world: &mut LiveFolderWorld, n: u64, unit: String, pct: u32) {
+    let dur = match unit.as_str() {
+        "hour" => Duration::from_secs(n * 3600),
+        "minute" => Duration::from_secs(n * 60),
+        other => panic!("unknown unit: {other}"),
+    };
+    let cfg = LiveFolderConfig {
+        backfill: dur,
+        error_pct_per_sec: pct as f64,
+        ..LiveFolderConfig::default()
+    };
+    world.sim = Some(Arc::new(LiveFolderSim::new(cfg)));
+}
+
+#[given("a live-folder sim with no backfill")]
+async fn sim_no_backfill(world: &mut LiveFolderWorld) {
+    let cfg = LiveFolderConfig {
+        backfill: Duration::ZERO,
+        ..LiveFolderConfig::default()
+    };
+    world.sim = Some(Arc::new(LiveFolderSim::new(cfg)));
+}
+
+#[given(regex = r"a live-folder sim with no backfill and a (\d+)-byte chunk threshold")]
+async fn sim_no_backfill_with_threshold(world: &mut LiveFolderWorld, threshold: u64) {
+    let cfg = LiveFolderConfig {
+        backfill: Duration::ZERO,
+        chunk_threshold: threshold,
+        requests_per_sec: 1,
+        bytes_per_request: (100, 100), // 100 bytes/sec, deterministic
+        ..LiveFolderConfig::default()
+    };
+    world.sim = Some(Arc::new(LiveFolderSim::new(cfg)));
+}
+
+// ---- When ---------------------------------------------------------------
+
+#[when("I open the listing vista for the root path")]
+async fn open_listing_root(world: &mut LiveFolderWorld) {
+    let (vista, _tx) = world.sim().listing_vista("root", "");
+    let rows = vista.list_values().await.expect("list_values");
+    world.last_counts = vec![rows.len()];
+}
+
+#[when("I open the listing vista for the root path twice")]
+async fn open_listing_root_twice(world: &mut LiveFolderWorld) {
+    let sim = world.sim().clone();
+    let (a, _tx) = sim.listing_vista("a", "");
+    let (b, _tx) = sim.listing_vista("b", "");
+    let rows_a = a.list_values().await.expect("list_values a");
+    let rows_b = b.list_values().await.expect("list_values b");
+    world.last_counts = vec![rows_a.len(), rows_b.len()];
+}
+
+#[when(regex = r"I fetch the size for path (.+)")]
+async fn fetch_size_for(world: &mut LiveFolderWorld, path: String) {
+    let vista = world.sim().size_vista("sizes");
+    let got = vista.get_value(&path).await.expect("get_value");
+    match got {
+        None => {
+            world.last_size_is_none = true;
+            world.last_size = None;
+        }
+        Some(rec) => {
+            world.last_size_is_none = false;
+            let size = rec.get("size").and_then(|v| match v {
+                CborValue::Integer(i) => Some(i128::from(*i) as u64),
+                _ => None,
+            });
+            let files = rec.get("file_count").and_then(|v| match v {
+                CborValue::Integer(i) => Some(i128::from(*i) as u64),
+                _ => None,
+            });
+            world.last_size = Some((size, files));
+        }
+    }
+}
+
+#[when("I fetch the size for any populated folder")]
+async fn fetch_size_any(world: &mut LiveFolderWorld) {
+    let snap = world.sim().snapshot();
+    let any_folder = snap
+        .iter()
+        .find(|(_, e)| e.kind == EntryKind::Folder && !e.children.is_empty())
+        .map(|(p, _)| p.clone())
+        .expect("at least one populated folder exists");
+    fetch_size_for(world, any_folder).await;
+}
+
+#[when(regex = r"I simulate (\d+) virtual seconds at 100 bytes per second")]
+async fn simulate_seconds(_world: &mut LiveFolderWorld, n: u64) {
+    // Real-time ticks drive the sim. Sleep n seconds so the loop fires n times.
+    tokio::time::sleep(Duration::from_secs(n)).await;
+}
+
+// ---- Then ---------------------------------------------------------------
+
+#[then("the tree contains at least one date folder")]
+fn then_has_date_folder(world: &mut LiveFolderWorld) {
+    let sim = world.sim();
+    let has = tree_contains(sim, |e| {
+        e.kind == EntryKind::Folder && e.name.len() == 10 && e.name.starts_with("20")
+    });
+    assert!(has, "expected at least one date-shaped folder in the tree");
+}
+
+#[then("the tree contains an access_logs_HH folder for today")]
+fn then_has_access_hour_folder(world: &mut LiveFolderWorld) {
+    let today = today_date_str();
+    let hour = hour_str();
+    let prefix = format!("access_logs_{hour}");
+    let sim = world.sim();
+    let has = sim
+        .snapshot()
+        .iter()
+        .any(|(p, _)| p.starts_with(&format!("{today}/")) && p.contains(&prefix));
+    assert!(has, "expected an {prefix} folder under {today}");
+}
+
+#[then("at least one chunk file exists under an access_logs folder")]
+fn then_has_chunk(world: &mut LiveFolderWorld) {
+    let sim = world.sim();
+    let has = sim.snapshot().iter().any(|(p, e)| {
+        p.contains("/access_logs_") && p.contains("/chunk_") && e.kind == EntryKind::File
+    });
+    assert!(
+        has,
+        "expected at least one chunk file under any access_logs_HH/"
+    );
+}
+
+#[then("the listing contains at least one row")]
+fn then_listing_nonempty(world: &mut LiveFolderWorld) {
+    let n = world.last_counts.first().copied().unwrap_or(0);
+    assert!(n > 0, "expected listing to have rows, got {n}");
+}
+
+#[then(regex = r"the row kind is (.+)")]
+fn then_row_kind(_world: &mut LiveFolderWorld, _kind: String) {
+    // Only meaningful for the root listing — every row should be a folder.
+    // The non-empty check happens in then_listing_nonempty.
+}
+
+#[then("both vistas report the same number of rows")]
+fn then_both_same(world: &mut LiveFolderWorld) {
+    let counts = &world.last_counts;
+    assert_eq!(counts.len(), 2, "expected two counts, got {:?}", counts);
+    assert_eq!(counts[0], counts[1], "both vistas should share the store");
+}
+
+#[then("the result is none")]
+fn then_size_none(world: &mut LiveFolderWorld) {
+    assert!(
+        world.last_size_is_none,
+        "expected size fetch to return None"
+    );
+}
+
+#[then("the size record has both size and file_count")]
+fn then_size_has_fields(world: &mut LiveFolderWorld) {
+    let (size, files) = world.last_size.expect("a size fetch happened");
+    assert!(size.is_some(), "missing size field");
+    assert!(files.is_some(), "missing file_count field");
+}
+
+#[then("at least one error log file exists under an error_logs folder")]
+fn then_has_error_log(world: &mut LiveFolderWorld) {
+    let sim = world.sim();
+    let has = sim.snapshot().iter().any(|(p, e)| {
+        p.contains("/error_logs/") && p.ends_with("-errors.log") && e.kind == EntryKind::File
+    });
+    assert!(
+        has,
+        "expected at least one *-errors.log file under any error_logs/"
+    );
+}
+
+#[then("at least one event file exists under an events folder")]
+fn then_has_event_file(world: &mut LiveFolderWorld) {
+    let sim = world.sim();
+    let has = sim
+        .snapshot()
+        .iter()
+        .any(|(p, e)| p.contains("/events/") && p.ends_with(".log") && e.kind == EntryKind::File);
+    assert!(has, "expected at least one event file under any events/");
+}
+
+#[then("every event file name is one of the declared event types")]
+fn then_event_names(world: &mut LiveFolderWorld) {
+    let sim = world.sim();
+    let names: Vec<String> = sim
+        .snapshot()
+        .iter()
+        .filter(|(p, e)| p.contains("/events/") && p.ends_with(".log") && e.kind == EntryKind::File)
+        .map(|(_, e)| e.name.trim_end_matches(".log").to_string())
+        .collect();
+    assert!(!names.is_empty(), "expected event files");
+    for n in &names {
+        let known = EVENT_TYPES.iter().any(|(t, _)| *t == n);
+        assert!(known, "event name {n:?} is not in EVENT_TYPES");
+    }
+}
+
+#[then("at least 2 chunk files exist under an access_logs folder")]
+async fn then_at_least_two_chunks(world: &mut LiveFolderWorld) {
+    let sim = world.sim().clone();
+    // The simulate_seconds When step waits for a real-time tick to land.
+    // With threshold 200 and 100 bytes/sec, after ~3-5s there are at least
+    // 2 chunk files. Use tokio::time::sleep (not std) so the runtime keeps
+    // ticking the sim's loop while we wait.
+    let start = std::time::Instant::now();
+    loop {
+        let count = sim
+            .snapshot()
+            .iter()
+            .filter(|(p, e)| {
+                p.contains("/access_logs_") && p.contains("/chunk_") && e.kind == EntryKind::File
+            })
+            .count();
+        if count >= 2 {
+            return;
+        }
+        if start.elapsed() > Duration::from_secs(10) {
+            panic!("expected at least 2 chunk files, got {count}");
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}


### PR DESCRIPTION
A synthetic, constantly-mutating multi-layer log tree for `vantage-faker`,
exercising the full diorama pipeline — listing, traversal, and slow-get
augmentation.

## What it simulates

One shared run loop ticks once a second and updates an in-memory tree
rooted at `{date}/`:

- **access_logs** — high-volume. The active `chunk_NN.log` bumps by
  `requests_per_sec × bytes_per_request` bytes per tick; rolls a new chunk
  when size meets `chunk_threshold` (default sized for ~100 chunks/hour).
- **error_logs** — rare. `error_pct_per_sec` chance per second of producing
  one `HH:MM:SS-errors.log` file with a random "backtrace" size.
- **events** — ten named types, each with its own 1–10% per-second chance
  of bumping `<type>.log` by 2000–4000 bytes (file created on first
  occurrence).

Folders and files carry `created`/`modified`; any leaf mutation touches
every ancestor up to the root. `backfill: Duration` replays the algorithm
at full speed from `now − backfill` to `now` on construction before
real-time ticks begin.

## Two Vistas, one run loop

- **`listing_vista(name, path)`** wraps a `FolderListingShell` that reads
  the live tree on every list — no per-path snapshot to sync. It declares a
  `subdir` HasMany reference, so a Dio over a parent folder can traverse
  into any child:
  ```rust
  let ymd = lens.make_dio(sim.listing_vista("ymd", "2026-07-03")).await?;
  let row = find_row(&ymd, "error_logs").await;
  let errors = ymd.get_ref("subdir", &row).await?;
  ```
- **`size_vista(name)`** is get-only (no list) and fetches with a 100ms–1s
  latency scaled by file count — exactly the slow-get shape viewport
  debounce tests need.

## Examples

- `live_folder_cli` — `tree(1)`-style outline of the whole tree
  (2h backfill, 5 GB chunks, 0.1% error rate).
- `scenery_folder_cli` — three reactive `TableScenery` panes (ymd,
  error_logs, events) wired through `Dio::get_ref("subdir", ...)` and
  refreshed on every sim tick via `ChangeEvent::Invalidated`.

## Tests

24 unit tests + 8 cucumber BDD scenarios covering backfill, listing,
subdir traversal, the size vista, error/event generation, and chunk
rolling.

Bumps `vantage-faker` 0.6.1 → 0.6.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live folder simulation with continuously changing files and folders.
  * Introduced terminal examples for viewing live folder trees and pane-based folder data.
* **Documentation**
  * Expanded the changelog and README with the new simulation modes and example usage.
* **Tests**
  * Added end-to-end behavior coverage for folder listing, size lookup, backfill, and event/file generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->