### PR TITLE
vista: unsupported-capability refusals log at debug, not error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/agent/todo/api-client-remote-ordering.md
+++ b/agent/todo/api-client-remote-ordering.md
@@ -1,0 +1,16 @@
+# REST api-client: opt-in remote ordering
+
+**Today:** sorting is purely local — the scenery orders the Dio cache
+(`set_sort`), so only the hydrated viewport is ordered. `vantage-api-client`'s
+REST side has no ordering plumbing at all; GraphQL's `add_order_by`
+deliberately drops the order. On a 535-row table with a 200-row viewport,
+"sort by net desc" is correct within the window, not globally.
+
+**Want:** per-table opt-in in the datasource/table YAML: which columns are
+remotely orderable and the query-arg convention (e.g. `?ordering=-net`,
+LL2-style). The vista then advertises `can_order` for those columns; sceneries
+push the sort into the fetch; everything else keeps local sort.
+
+**Consumers:** vantage-ui shaped bindings (`scenery("launches").sort(...)`)
+and grid header clicks — both already call the same scenery sort seam, so
+they'd gain global ordering with no UI changes.

--- a/agent/todo/dio-persistent-cache-backend.md
+++ b/agent/todo/dio-persistent-cache-backend.md
@@ -1,0 +1,17 @@
+# Persistent CacheBackend for Dio
+
+**Want:** after an app restart, a table the user already loaded paints from
+cache immediately (stale-while-revalidate), instead of an empty grid until the
+API answers — painful on throttled backends (lldev 504s take ~50s to fail).
+
+**Seam exists:** `vantage-diorama/src/lens/mod.rs` defines `CacheBackend`;
+`memory_cache.rs` is the only impl ("one IndexMap per Dio, no persistence").
+
+**Shape:** a disk-backed `CacheBackend` (sqlite or CBOR file per Dio cache
+key), keyed the same way sceneries dedup (conditions/sort/search must be part
+of the key or the sorted variant misses). Load on open → rows paint instantly
+→ live fetches overwrite. Eviction/expiry policy TBD (age cap is probably
+enough for a viewer).
+
+**Consumer:** vantage-ui framework pages (and legacy grids) get restart-warm
+grids for free once the backend wires a persistent cache into `Dio` creation.

--- a/agent/todo/rest-count-chunk-double-fetch.md
+++ b/agent/todo/rest-count-chunk-double-fetch.md
@@ -1,0 +1,44 @@
+# REST paged open: count + first chunk = double fetch
+
+**Observed** (launch-control binder tab, 1-row relation):
+
+```
+GET payload_flights/?mode=detailed&offset=0&limit=1&launch__id=…   ← count probe
+REST count total=1
+GET payload_flights/?mode=detailed&offset=0&limit=100&launch__id=… ← first chunk
+```
+
+Two requests; for a 1-row relation the same detailed record twice.
+
+**Why:** diorama's paged loader asks `total_provider` (→ vista `get_count` →
+`Api::fetch_total`, a `limit=1` GET reading the envelope's `total_key`)
+BEFORE any chunk. The chunk GET's envelope carries the SAME total, but
+`fetch_windowed` returns rows only and discards it. The lens's
+`total_provider` has no sink, so the count's fetched row can't seed the
+cache either (vantage-ui `crates/backend/src/lens.rs:build_paged_lens`).
+
+**Constraints on the fix:**
+- Sorted masters now push `?ordering=` server-side (can_order), so a
+  "prefetch rows during count" hack regresses them: unsorted prefetch is
+  wasted, the sorted chunk refetches anyway. `total_provider` doesn't see
+  the scenery's sort.
+- `mode=detailed` is baked into the table path, so even the `limit=1`
+  count fetch pays for one fully-detailed record.
+
+**Decided shape (data-first, count-last, capability-gated):**
+1. A grid/list opens by fetching the FIRST PAGE (with the scenery's
+   ordering), and a second page if needed to fill the viewport. Rows paint
+   as soon as they land — no total gates first paint.
+2. The count runs AFTER the data, and ONLY to size the scrollbar (how far
+   scrolling can go). It runs only when the backend genuinely advertises a
+   count capability (`can_count`).
+3. REST has NO real count capability: a `limit=1` GET reading the
+   envelope's `total_key` is not a count — stop issuing it. When window
+   responses carry a `total_key`, read the total from the FIRST CHUNK's
+   envelope for free; a first chunk shorter than its window IS the total
+   even without one. Otherwise the scrollbar grows as pages load
+   (unknown-total mode).
+
+**Wins:** every paged open goes 2→1 requests; first paint no longer waits
+on a count round-trip; binder relation tabs (small) are a single fetch;
+refreshes stop re-paying counts.

--- a/agent/todo/rest-count-chunk-double-fetch.md
+++ b/agent/todo/rest-count-chunk-double-fetch.md
@@ -2,7 +2,7 @@
 
 **Observed** (launch-control binder tab, 1-row relation):
 
-```
+```text
 GET payload_flights/?mode=detailed&offset=0&limit=1&launch__id=…   ← count probe
 REST count total=1
 GET payload_flights/?mode=detailed&offset=0&limit=100&launch__id=… ← first chunk

--- a/vantage-core/CHANGELOG.md
+++ b/vantage-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.1 — 2026-07-04
+
+- `VantageError::traced_debug()`: emit the same structured event as
+  `traced()` at DEBUG level — for errors that are a legitimate answer to a
+  probing caller (e.g. an `Unsupported` capability refusal) rather than
+  faults.
+
 ## 0.6.0 — unreleased
 
 - **Breaking:** the error-kind annotators `VantageError::is_unsupported` /

--- a/vantage-core/Cargo.toml
+++ b/vantage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Core error types and utilities for the Vantage data framework"

--- a/vantage-core/src/util/error.rs
+++ b/vantage-core/src/util/error.rs
@@ -263,6 +263,21 @@ impl VantageError {
         self
     }
 
+    /// Emit the same structured event as [`traced`](Self::traced) at DEBUG
+    /// level — for errors that are a legitimate answer to a probing caller
+    /// (e.g. an `Unsupported` capability refusal) rather than faults: the
+    /// error value carries the message to the caller, the log stays quiet.
+    pub fn traced_debug(self) -> Self {
+        tracing::debug!(
+            kind = ?self.kind,
+            location = self.location.as_deref().unwrap_or(""),
+            context = %self.context_string(),
+            "{}",
+            self.message
+        );
+        self
+    }
+
     /// `true` if this error is classified as [`ErrorKind::Unsupported`].
     pub fn is_unsupported(&self) -> bool {
         self.kind == ErrorKind::Unsupported
@@ -279,9 +294,19 @@ impl VantageError {
     }
 
     fn emit_trace(&self) {
-        // Flatten context into a single string so it lands as a structured
-        // attribute on the tracing event without needing a serializer.
-        let context_str = if self.context.is_empty() {
+        tracing::error!(
+            kind = ?self.kind,
+            location = self.location.as_deref().unwrap_or(""),
+            context = %self.context_string(),
+            "{}",
+            self.message
+        );
+    }
+
+    /// Flatten context into a single string so it lands as a structured
+    /// attribute on a tracing event without needing a serializer.
+    fn context_string(&self) -> String {
+        if self.context.is_empty() {
             String::new()
         } else {
             self.context
@@ -289,14 +314,7 @@ impl VantageError {
                 .map(|(k, v)| format!("{}={}", k, v))
                 .collect::<Vec<_>>()
                 .join(", ")
-        };
-        tracing::error!(
-            kind = ?self.kind,
-            location = self.location.as_deref().unwrap_or(""),
-            context = %context_str,
-            "{}",
-            self.message
-        );
+        }
     }
 
     /// Create a "no data available" error

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.8 — 2026-07-04
+
+- `TableShell::default_error` no longer emits a `tracing::error!` for an
+  `Unsupported` refusal (capability flag honestly `false`) — the error value
+  already carries the full message to the caller, so it traces at DEBUG via
+  the new `vantage_core::VantageError::traced_debug()`. The `Unimplemented`
+  case (flag `true` but no impl — a driver bug) keeps the ERROR-level trace.
+
 ## 0.6.7 — 2026-07-02
 
 - `TableShell::clone_shell(&self) -> Option<Box<dyn TableShell>>` — a defaulted

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -466,8 +466,11 @@ pub trait TableShell: Send + Sync + 'static {
     /// → `Unimplemented`); a `false` flag means the driver honestly doesn't
     /// claim the op (caller should have checked → `Unsupported`).
     ///
-    /// Both kinds emit a `tracing::error!` at construction with `method`,
-    /// `capability`, `source_type`, and `vista_name` as structured fields.
+    /// Only the `Unimplemented` kind traces at error level — it's a driver
+    /// bug. An `Unsupported` refusal is a legitimate answer to a caller
+    /// probing a capability (e.g. an exploratory data script calling
+    /// `set_page_size` on a cache-mode vista): the error value carries the
+    /// full message to the caller, so it logs at debug only.
     fn default_error(&self, method: &str, capability: &str) -> VantageError {
         let source_type = std::any::type_name::<Self>();
         if self.capability_flag(capability) {
@@ -492,7 +495,7 @@ pub trait TableShell: Send + Sync + 'static {
                 source_type = source_type
             )
             .mark_unsupported()
-            .traced()
+            .traced_debug()
         }
     }
 }


### PR DESCRIPTION
An honest `Unsupported` capability refusal (flag `false` — e.g. a data script probing `set_page_size` on a cache-mode vista) is a legitimate answer to the caller, not a fault: the error value already carries the full message. It now traces at DEBUG via the new `VantageError::traced_debug()`, while the `Unimplemented` case (flag `true` but no impl — a driver bug) keeps the ERROR-level trace.

Also checks in three data-layer design notes under `agent/todo/` (REST count/chunk double-fetch, api-client remote ordering, dio persistent cache) and bumps vantage-core 0.6.1 / vantage-vista 0.6.8 for publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined capability-probe error reporting: genuine “unsupported” refusals now trace at lower severity (reducing noisy error-level logs), while “unimplemented” driver issues remain error-level.

* **Documentation**
  * Added documentation for an opt-in approach to pushing sort order to the REST client via per-table configuration.
  * Added a design note for restart-warm, persistent caching with stale-while-revalidate behavior.
  * Added a write-up of a REST pagination “double fetch” scenario and a revised pagination strategy.

* **Chores**
  * Bumped core/UI versions and updated changelogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->