### PR TITLE
diorama: augment details can be fixed Vista handles; faker packages the folder-size vista as one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/agent/todo/dio-level-augment.md
+++ b/agent/todo/dio-level-augment.md
@@ -1,0 +1,30 @@
+# diorama: dio-level column augmentation from a secondary vista
+
+Shipped in PR #337 (vantage-diorama 0.6.15 `Detail::Fixed` + vantage-faker 0.6.3
+`LiveFolderSim::size_augment`): the pre-existing two-pass augmentation already
+carried the laziness (viewport-driven detail pass), coalescing (per-id
+single-flight), in-place patching, and modified-driven refetch (refresh
+reconciliation demotes rows whose list fields moved); the missing piece was a
+detail source that is a fixed get-only Vista handle rather than a catalog name.
+
+Needed by vantage-ui's `kind: finder` single-Dio invariant (vantage-ui
+agents/plans/2026-07-05-finder-component.md, rule 6).
+
+A Dio should be able to AUGMENT its rows with columns fetched from a secondary, get-only
+vista, keyed by one of the row's columns. Canonical case: vantage-faker's live_folder —
+the listing vista supplies `{name, kind, modified}`; the size vista supplies
+`{path → size, file_count}` with deliberate 100ms–1s latency. The dio pulls the augment
+lazily per row (folders only, keyed by path), patches the row via its normal ChangeEvent
+path when the value lands, and re-pulls when the base row's `modified` moves.
+
+Consumers (sceneries, vantage-ui observations) see ONE dio whose rows simply have the
+extra columns — no second data handle anywhere above the dio. Sources without the augment
+just lack the columns (S3: no folder sizes; column absent, not zero).
+
+Design notes:
+- Prefer type-driven: an Augment descriptor the Dio is built with (lens-level wiring), not
+  a bool/callback bolted on.
+- Laziness + coalescing are the point: only visible/hydrated rows fetch; slow gets must
+  not stall listing; per-row staleness (base row touched → augment refetch).
+- This is also the debounce showcase: the faker size vista's file-count-scaled latency
+  exists precisely to exercise this path.

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.15 — 2026-07-05
+
+**Augment details can be fixed Vista handles**
+
+- `Augmentation` now names its detail source through a `Detail` enum:
+  `Detail::Catalog(name)` resolves through the `VistaCatalog` per fetch (the
+  config/YAML form — behavior unchanged), and `Detail::Fixed(Arc<Vista>)` takes a
+  direct handle for get-only side tables that live in no catalog — e.g. a
+  folder-size vista a listing Dio augments its rows from, keyed by a row column
+  (`source: Column { from: "path" }`). Read-key fetches use the shared handle;
+  narrowing sources rebuild a private instance per row via
+  `TableShell::clone_shell` (a fixed detail whose shell isn't cloneable errors at
+  fetch time). Everything downstream is unchanged: hydration stays lazy and
+  viewport-driven with per-id single-flight, merged columns patch rows in place
+  as they land, and refresh reconciliation demotes a row whose list fields moved
+  (its `modified` bumped) so the standing viewport refetches the augment. (API
+  break: `Augmentation::table: String` → `Augmentation::detail: Detail`.)
+
 ## 0.6.14 — 2026-07-02
 
 **Server-side ordering when the master can order**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/examples/augmentation.rs
+++ b/vantage-diorama/examples/augmentation.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ciborium::Value as CborValue;
-use vantage_diorama::{Augmentation, Fetch, Lens, MergeRule, RowStatus, Source};
+use vantage_diorama::{Augmentation, Detail, Fetch, Lens, MergeRule, RowStatus, Source};
 use vantage_types::Record;
 use vantage_vista::mocks::MockShell;
 use vantage_vista::{Column, Vista, VistaMetadata};
@@ -108,9 +108,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dio = lens.make_dio(master()).await?.augment(
         Arc::new(catalog),
         vec![Augmentation {
-            table: "tfstate-detail".into(), // catalog name of the detail Vista
-            source: Source::Id,             // master.id -> detail.id
-            fetch: Fetch::PerRow,           // one detail record per master row
+            // catalog name of the detail Vista (`Detail::Fixed` takes a
+            // direct handle for catalog-less get-only sources)
+            detail: Detail::Catalog("tfstate-detail".into()),
+            source: Source::Id,   // master.id -> detail.id
+            fetch: Fetch::PerRow, // one detail record per master row
             merge: MergeRule {
                 columns: vec!["resources".into(), "serial".into()],
             },

--- a/vantage-diorama/src/augment/lower.rs
+++ b/vantage-diorama/src/augment/lower.rs
@@ -7,7 +7,7 @@ use vantage_core::{Result, error};
 use vantage_vista_factory::VistaCatalog;
 
 use super::spec::{AugmentSpec, FetchSpec, SourceSpec};
-use super::{Augmentation, Fetch, MergeRule, Source};
+use super::{Augmentation, Detail, Fetch, MergeRule, Source};
 
 /// Lower one declared augmentation into its runtime form. `catalog` backs the
 /// `table(name)` resolver used by scripted sources.
@@ -27,7 +27,7 @@ pub fn lower_augment(spec: AugmentSpec, catalog: &Arc<VistaCatalog>) -> Result<A
         }
     };
     Ok(Augmentation {
-        table: spec.table,
+        detail: Detail::Catalog(spec.table),
         source,
         fetch,
         merge: MergeRule {

--- a/vantage-diorama/src/augment/mod.rs
+++ b/vantage-diorama/src/augment/mod.rs
@@ -61,6 +61,28 @@ pub enum Fetch {
     Custom(FetchFn),
 }
 
+/// Where an augmentation's detail records come from.
+pub enum Detail {
+    /// Resolve the base detail Vista from the catalog by name, per fetch —
+    /// the config/YAML form (a name is all a spec can carry).
+    Catalog(String),
+    /// A fixed secondary Vista handle — for get-only side tables that live
+    /// in no catalog (a folder-size vista keyed by path). Read-key fetches
+    /// use the shared handle directly; narrowing sources rebuild a private
+    /// instance per row via `TableShell::clone_shell`.
+    Fixed(Arc<Vista>),
+}
+
+impl Detail {
+    /// The detail model's name, for relation labels and error context.
+    fn name(&self) -> &str {
+        match self {
+            Detail::Catalog(name) => name,
+            Detail::Fixed(vista) => vista.name(),
+        }
+    }
+}
+
 /// Which detail columns land on the master row.
 pub struct MergeRule {
     /// Columns to lift. Empty = lift all detail columns.
@@ -86,8 +108,8 @@ impl MergeRule {
 
 /// One declared augmentation in runtime form.
 pub struct Augmentation {
-    /// Catalog name of the detail model.
-    pub table: String,
+    /// The detail model this augmentation reads from.
+    pub detail: Detail,
     pub source: Source,
     pub fetch: Fetch,
     pub merge: MergeRule,
@@ -116,13 +138,32 @@ impl Augmentation {
     /// uniform "one record by key" primitive (cmd runs its detail script, SQL a
     /// `WHERE id =`, REST a `GET /{id}`). Other-column and `Build` sources narrow
     /// the detail vista and take the first record.
+    /// An owned base detail Vista for one fetch: catalog details resolve by
+    /// name; fixed details rebuild a private instance from the shared handle
+    /// (`clone_shell` — cheap for the get-only shells this serves).
+    fn base_vista(&self, catalog: &VistaCatalog) -> Result<Vista> {
+        match &self.detail {
+            Detail::Catalog(name) => catalog.build_vista(name),
+            Detail::Fixed(vista) => vista
+                .source
+                .clone_shell()
+                .map(|shell| Vista::new(vista.name().to_string(), shell))
+                .ok_or_else(|| {
+                    error!(
+                        "augment: fixed detail vista's shell is not cloneable",
+                        table = vista.name()
+                    )
+                }),
+        }
+    }
+
     async fn fetch_one(
         &self,
         master_id_column: &str,
         row: &Record<CborValue>,
         catalog: &VistaCatalog,
     ) -> Result<Option<Record<CborValue>>> {
-        let base = catalog.build_vista(&self.table)?;
+        let base = self.base_vista(catalog)?;
         match &self.fetch {
             Fetch::PerRow => match &self.source {
                 // `get_value_with_row` hands the cheap master row to drivers that
@@ -163,7 +204,7 @@ impl Augmentation {
         row: &Record<CborValue>,
         catalog: &VistaCatalog,
     ) -> Result<Vista> {
-        let mut base = catalog.build_vista(&self.table)?;
+        let mut base = self.base_vista(catalog)?;
         match &self.source {
             Source::Id => {
                 let detail_id = self.detail_id_column(&base)?;
@@ -191,7 +232,7 @@ impl Augmentation {
     ) -> Result<()> {
         Relation::single_key(
             "augment",
-            &self.table,
+            self.detail.name(),
             ReferenceKind::HasOne,
             detail_column.to_string(),
             master_field.to_string(),
@@ -203,7 +244,7 @@ impl Augmentation {
         base.get_id_column().map(str::to_string).ok_or_else(|| {
             error!(
                 "augment: detail vista has no id column",
-                table = self.table.as_str()
+                table = self.detail.name()
             )
         })
     }

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -11,8 +11,8 @@ pub mod ops;
 pub mod scenery;
 
 pub use augment::{
-    AugmentSpec, Augmentation, BuildFn, Fetch, FetchFn, FetchSpec, MergeRule, SetOp, Source,
-    SourceSpec, lower_augment,
+    AugmentSpec, Augmentation, BuildFn, Detail, Fetch, FetchFn, FetchSpec, MergeRule, SetOp,
+    Source, SourceSpec, lower_augment,
 };
 pub use composition::Diorama;
 pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};

--- a/vantage-diorama/tests/augment.rs
+++ b/vantage-diorama/tests/augment.rs
@@ -13,7 +13,9 @@ use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use tempfile::TempDir;
-use vantage_diorama::{Augmentation, Dio, Fetch, Lens, MergeRule, RowStatus, Source, TableScenery};
+use vantage_diorama::{
+    Augmentation, Detail, Dio, Fetch, Lens, MergeRule, RowStatus, Source, TableScenery,
+};
 use vantage_types::Record;
 use vantage_vista::mocks::MockShell;
 use vantage_vista::{Column, Vista, VistaMetadata};
@@ -79,7 +81,7 @@ fn catalog() -> Arc<VistaCatalog> {
 
 fn aug(table: &str, source: Source, merge: &[&str]) -> Augmentation {
     Augmentation {
-        table: table.into(),
+        detail: Detail::Catalog(table.into()),
         source,
         fetch: Fetch::PerRow,
         merge: MergeRule {
@@ -250,7 +252,7 @@ async fn custom_fetch_closure_reads_narrowed_detail() {
 
     let tmp = TempDir::new().unwrap();
     let augmentation = Augmentation {
-        table: "runs-detail".into(),
+        detail: Detail::Catalog("runs-detail".into()),
         source: Source::Id,
         fetch: Fetch::Custom(Arc::new(|detail: V| {
             Box::pin(async move { Ok(detail.list_values().await?.into_values().collect()) })
@@ -298,4 +300,144 @@ async fn scripted_source_augments_via_rhai() {
     .await;
     assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
     assert_eq!(col_of(&scenery, 1, "detail").as_deref(), Some("full-r1"));
+}
+
+/// The finder/live_folder shape: the detail is a FIXED get-only Vista handle,
+/// registered in no catalog, keyed by a master column (`path`). Rows hydrate
+/// the merged columns through the same lazy detail pass.
+#[tokio::test]
+async fn fixed_detail_vista_hydrates_without_a_catalog() {
+    let tmp = TempDir::new().unwrap();
+
+    // Get-only side table keyed by path — the folder-size vista shape.
+    let size_meta = VistaMetadata::new()
+        .with_column(Column::new("path", "String").with_flag("id"))
+        .with_column(Column::new("size", "String"))
+        .with_column(Column::new("file_count", "String"))
+        .with_id_column("path");
+    let size_shell = MockShell::new()
+        .with_record(
+            "a/logs",
+            record(&[("path", "a/logs"), ("size", "4096"), ("file_count", "3")]),
+        )
+        .with_record(
+            "a/tmp",
+            record(&[("path", "a/tmp"), ("size", "512"), ("file_count", "1")]),
+        )
+        .with_metadata(size_meta);
+    let fixed = Arc::new(Vista::new("folder_size", Box::new(size_shell)));
+
+    let master = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("path", "a/logs")]))
+        .with_record("r1", record(&[("id", "r1"), ("path", "a/tmp")]))
+        .with_metadata(meta(&["id", "path"]));
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .viewport_debounce(Duration::from_millis(1))
+            .build()
+            .expect("lens builds"),
+    );
+    let dio = lens
+        .make_dio(Vista::new("listing", Box::new(master)))
+        .await
+        .expect("make_dio")
+        .augment(
+            Arc::new(VistaCatalog::new()), // EMPTY — the fixed handle needs no catalog
+            vec![Augmentation {
+                detail: Detail::Fixed(fixed),
+                source: Source::Column {
+                    from: "path".into(),
+                    to: None,
+                },
+                fetch: Fetch::PerRow,
+                merge: MergeRule {
+                    columns: vec!["size".into(), "file_count".into()],
+                },
+            }],
+        );
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+
+    eventually("rows hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && matches!(status_of(&scenery, 1), Some(RowStatus::Fresh))
+    })
+    .await;
+    assert_eq!(col_of(&scenery, 0, "size").as_deref(), Some("4096"));
+    assert_eq!(col_of(&scenery, 0, "file_count").as_deref(), Some("3"));
+    assert_eq!(col_of(&scenery, 1, "size").as_deref(), Some("512"));
+    // The merge list is respected: the detail's own key column stays put.
+    assert_eq!(col_of(&scenery, 0, "path").as_deref(), Some("a/logs"));
+}
+
+/// Staleness: when a base row's list fields move (its `modified` bumps), the
+/// refresh reconciliation demotes it and the standing viewport refetches the
+/// augment — the row shows the NEW detail value, not the stale hydration.
+#[tokio::test]
+async fn changed_master_row_refetches_its_augment() {
+    use vantage_dataset::prelude::WritableValueSet;
+
+    let tmp = TempDir::new().unwrap();
+
+    // MockShell clones share one store — the writer handles mutate what the
+    // dio's master and fixed detail read.
+    let master_shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("modified", "t1")]))
+        .with_metadata(meta(&["id", "modified"]));
+    let detail_shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("size", "100")]))
+        .with_metadata(meta(&["id", "size"]));
+    let master_writer = Vista::new("m", Box::new(master_shell.clone()));
+    let detail_writer = Vista::new("d", Box::new(detail_shell.clone()));
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .viewport_debounce(Duration::from_millis(1))
+            .build()
+            .expect("lens builds"),
+    );
+    let dio = lens
+        .make_dio(Vista::new("listing", Box::new(master_shell)))
+        .await
+        .expect("make_dio")
+        .augment(
+            Arc::new(VistaCatalog::new()),
+            vec![Augmentation {
+                detail: Detail::Fixed(Arc::new(Vista::new("sizes", Box::new(detail_shell)))),
+                source: Source::Id,
+                fetch: Fetch::PerRow,
+                merge: MergeRule {
+                    columns: vec!["size".into()],
+                },
+            }],
+        );
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..1);
+    eventually("hydrated with the first size", || {
+        col_of(&scenery, 0, "size").as_deref() == Some("100")
+    })
+    .await;
+
+    // The world moves: the folder's modified bumps and its size grows.
+    detail_writer
+        .replace_value("r0", &record(&[("id", "r0"), ("size", "200")]))
+        .await
+        .expect("detail write");
+    master_writer
+        .replace_value("r0", &record(&[("id", "r0"), ("modified", "t2")]))
+        .await
+        .expect("master write");
+
+    // Reconcile (demotes r0 — a list field changed), then let the standing
+    // viewport re-run the detail pass for the demoted row.
+    dio.refresh().await.expect("refresh");
+    scenery.set_viewport(0..1);
+
+    eventually("augment refetched", || {
+        col_of(&scenery, 0, "size").as_deref() == Some("200")
+            && col_of(&scenery, 0, "modified").as_deref() == Some("t2")
+    })
+    .await;
 }

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use ciborium::Value as CborValue;
 use vantage_dataset::prelude::ReadableValueSet;
-use vantage_diorama::{Augmentation, Dio, Fetch, Lens, MergeRule, Source, TableScenery};
+use vantage_diorama::{Augmentation, Detail, Dio, Fetch, Lens, MergeRule, Source, TableScenery};
 use vantage_types::Record;
 use vantage_vista::mocks::MockShell;
 use vantage_vista::{Column, Vista, VistaMetadata};
@@ -78,7 +78,7 @@ pub fn bucket_catalog() -> Arc<VistaCatalog> {
 
 pub fn augment_name() -> Augmentation {
     Augmentation {
-        table: "names".into(),
+        detail: Detail::Catalog("names".into()),
         source: Source::Id,
         fetch: Fetch::PerRow,
         merge: MergeRule {

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.3 — 2026-07-05
+
+- `LiveFolderSim::size_augment()` — the folder-size vista packaged as a dio-level
+  augment (`Detail::Fixed`, keyed by the listing's hidden `path` column, merging
+  `{size, file_count}`). A listing Dio built with it patches folder rows in place
+  as hydration lands, with the size vista's file-count-scaled latency intact —
+  one Dio, no second observation anywhere above it. Requires vantage-diorama
+  0.6.15.
+
 ## 0.6.2 — 2026-07-03
 
 - `LiveFolderSim`: a synthetic, constantly-mutating multi-layer log tree. One shared run loop

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "atty",
  "indexmap",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2067,6 +2067,7 @@ dependencies = [
  "vantage-diorama",
  "vantage-types",
  "vantage-vista",
+ "vantage-vista-factory",
 ]
 
 [[package]]
@@ -2117,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.6", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.6.15", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"
@@ -38,6 +38,8 @@ tracing = "0.1"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 # `list_values` in tests reads back through the Vista's dataset traits.
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
+# `Dio::augment` takes a catalog; the size-augment test passes an empty one.
+vantage-vista-factory = { version = "0.6", path = "../vantage-vista-factory" }
 # Styled table output for the `fifo_cli` example.
 vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
 tokio = { version = "1", features = ["full"] }

--- a/vantage-faker/src/live_folder.rs
+++ b/vantage-faker/src/live_folder.rs
@@ -217,6 +217,29 @@ impl LiveFolderSim {
         Vista::new(name, Box::new(FolderSizeShell::new(self.inner.clone())))
     }
 
+    /// The folder-size vista as a **dio-level augment** over a listing Dio:
+    /// hydrated rows gain `{size, file_count}` lazily, keyed by their full
+    /// `path`, with the size vista's file-count-scaled latency intact (the
+    /// debounce showcase). The detail rides as a fixed handle — it lives in
+    /// no catalog — and every listing Dio of the same sim can carry its own
+    /// copy: they all read the one shared tree. Rows whose base fields move
+    /// (`modified` bumps) refetch through the Dio's refresh reconciliation.
+    pub fn size_augment(&self) -> vantage_diorama::Augmentation {
+        vantage_diorama::Augmentation {
+            detail: vantage_diorama::Detail::Fixed(std::sync::Arc::new(
+                self.size_vista("folder_size"),
+            )),
+            source: vantage_diorama::Source::Column {
+                from: "path".to_string(),
+                to: None,
+            },
+            fetch: vantage_diorama::Fetch::PerRow,
+            merge: vantage_diorama::MergeRule {
+                columns: vec!["size".to_string(), "file_count".to_string()],
+            },
+        }
+    }
+
     /// Snapshot the tree as a flat `path → entry` map. Used by the example
     /// CLI to render the whole tree without spinning up per-path listings.
     pub fn snapshot(&self) -> Vec<(String, Entry)> {
@@ -372,5 +395,54 @@ mod tests {
                 "child path {path:?} should start with parent {parent:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn size_augment_hydrates_listing_rows_over_one_dio() {
+        use std::sync::Arc;
+
+        // A backfilled tree so the root has day folders with real content.
+        let sim = LiveFolderSim::new(LiveFolderConfig {
+            backfill: Duration::from_secs(1800),
+            ..LiveFolderConfig::default()
+        });
+        let (listing, _tx) = sim.listing_vista("root", "");
+        let lens = Arc::new(
+            vantage_diorama::Lens::new()
+                .cache_in_memory()
+                .viewport_debounce(Duration::from_millis(1))
+                .build()
+                .expect("lens builds"),
+        );
+        let dio = lens.make_dio(listing).await.expect("make_dio").augment(
+            // The size augment is a fixed handle — no catalog entry needed.
+            Arc::new(vantage_vista_factory::VistaCatalog::new()),
+            vec![sim.size_augment()],
+        );
+        let scenery = dio.table_scenery().open().await.expect("scenery opens");
+        scenery.set_viewport(0..10);
+
+        // The listing's own size column reports 0 on folders; the augment
+        // patches the recursive size in as hydration lands (with the size
+        // vista's deliberate latency).
+        let mut augmented = false;
+        for _ in 0..100 {
+            let n = scenery.row_count();
+            augmented = (0..n).filter_map(|i| scenery.row(i)).any(|row| {
+                row.record.get("file_count").is_some()
+                    && matches!(
+                        row.record.get("size"),
+                        Some(ciborium::Value::Integer(i)) if i128::from(*i) > 0
+                    )
+            });
+            if augmented {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            augmented,
+            "a folder row gained a positive size + file_count from the augment"
+        );
     }
 }


### PR DESCRIPTION
## What this is

`vantage-diorama` 0.6.15 + `vantage-faker` 0.6.3.

An `Augmentation` names its detail source through a new `Detail` enum:

- `Detail::Catalog(name)` — resolved through the `VistaCatalog` per fetch. The config/YAML form; behavior unchanged.
- `Detail::Fixed(Arc<Vista>)` — a direct handle for get-only side tables that live in no catalog. Read-key fetches (`Source::Column { from, to: None }` / `Source::Id`) use the shared handle; narrowing sources rebuild a private instance per row via `TableShell::clone_shell`, and a fixed detail whose shell isn't cloneable errors at fetch time.

Everything downstream of the descriptor is the existing two-pass machinery: hydration stays lazy and viewport-driven with per-id single-flight, merged columns patch rows in place as they land, and refresh reconciliation demotes a row whose list fields moved (its `modified` bumped) so the standing viewport refetches the augment.

`vantage-faker` wires the canonical consumer: `LiveFolderSim::size_augment()` packages the get-only folder-size vista as such an augment — keyed by the listing's hidden `path` column, merging `{size, file_count}`, with the size vista's file-count-scaled latency intact (the debounce showcase). A listing Dio built with it stays ONE Dio; nothing above it holds a second data handle.

API break: `Augmentation::table: String` → `Augmentation::detail: Detail` (all in-repo call sites migrated).

## Tests

- `tests/augment.rs`: `fixed_detail_vista_hydrates_without_a_catalog` (empty catalog, path-keyed fixed detail) and `changed_master_row_refetches_its_augment` (shared-store mock shells: bump the master row's `modified` + the detail value, refresh, standing viewport shows the new value).
- `vantage-faker`: `size_augment_hydrates_listing_rows_over_one_dio` — a backfilled sim's root listing Dio gains positive `size` + `file_count` on folder rows through the augment.

Consumed by vantage-ui's `kind: finder` (single-Dio invariant, rule 6 of its plan).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for augmenting rows from a fixed detail source, not just catalog-based sources.
  * Updated examples and helpers to use the new augmentation configuration.
  * Added live folder size augmentation so listing rows can gain folder size and file count data as hydration completes.

* **Bug Fixes**
  * Improved refresh behavior so updated detail data is reloaded and reflected in augmented rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->