### PR TITLE
Augment reconciliation: no flap, gap rule, column demand, stale-while-refetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/agent/todo/s3-delimiter-aware-listing.md
+++ b/agent/todo/s3-delimiter-aware-listing.md
@@ -1,0 +1,23 @@
+# vantage-aws: delimiter-aware S3 folder listing
+
+Needed by vantage-ui's `kind: finder` composite (see vantage-ui
+agents/plans/2026-07-05-finder-component.md).
+
+`objects_table` today extracts only `<Contents>` from ListObjectsV2. Hierarchical browsing
+sets `prefix` + `delimiter="/"`, and the response then splits children into two lists:
+`<Contents>` (files) and `<CommonPrefixes>` (the "folders"). The second list is currently
+dropped.
+
+Wanted: a listing table that, given `prefix` + `delimiter`, merges both lists into one row
+set with a synthesized `kind` column (`folder` for each CommonPrefix, `file` for each
+Contents entry) and a `name` (the Key/Prefix with the current prefix stripped). Shape
+target — the canonical finder row `{name, kind, size, modified}`; `size`/`modified` empty
+for folders (S3 has no cheap folder aggregates; do NOT scan).
+
+Prefer type-driven design over a bool flag on the existing table (per house rule): a
+distinct listing model/table, not `objects_table(with_folders: true)`.
+
+Constraint from the finder design: all per-prefix sceneries route to ONE Dio per
+bucket/datasource, so a single refresh serves every open tree node. Pagination must stay
+honest — ListObjectsV2's 1000-key pages surface as truncation, never auto-paged to
+exhaustion.

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 0.6.16 — 2026-07-05
+
+**Augment reconciliation: no flap, gap rule, column demand, stale-while-refetch**
+
+- Refresh reconciliation no longer flaps augmented columns. The list pass may
+  paint a column the augment owns (a folder listing's cheap `size` under the
+  augment's real recursive size); comparing it demoted every hydrated row on
+  every refresh — the visible 0 → value → 0 flap. Augment-owned columns are now
+  excluded from the change comparison: an unchanged list row keeps its augmented
+  values and fetches nothing, and a `modified` bump demotes exactly the moved
+  row. Regression: refresh with unchanged rows issues zero detail fetches.
+- The gap rule: an augmentation fetches ONLY rows where the list leaves at
+  least one augment column absent/null (a folder without a recursive size); a
+  row the list already completes (a file's own `size`) stubs `Complete` and
+  never touches the detail source. Un-enumerable augments (empty merge list =
+  "lift all") always count as a gap.
+- Stale-while-refetch: a demoted row takes the fresh list values but KEEPS its
+  augmented values while the refetch is in flight — the staleness lives
+  out-of-band in `CacheStatus::Incomplete` (what drives the detail pass), so a
+  hot row's size ticks up in place instead of strobing blank once a second.
+  Blank is reserved for rows never filled; the list's null placeholder never
+  erases a fill.
+- Augment log lines carry `dio=` — the owning dio's master vista name (which
+  embeds the listing key). Two completion series on one `key=` with different
+  `dio=` values means two dios are augmenting the same path: a bug made
+  visible in the log instead of inferred from gap arithmetic.
+- Column demand: sceneries gain a `columns()` open parameter declaring which
+  columns the view actually shows (`None` = everything — existing callers
+  unchanged; demand joins the dedup key). The Dio's active demand is the union
+  over its OPEN sceneries, recomputed as views open and close, and the augment
+  detail pass runs only while that union intersects the augment columns — a
+  tree of folder names never pays for folder sizes; the listing beside it
+  (which demands `size`) is what starts the fetches, and closing it stops
+  them. One get still merges ALL augment columns; already-merged values stay
+  when demand drains (they just stop refreshing), and a demotion under drained
+  demand leaves the columns blank until re-demanded. The full trigger is now
+  demand ∧ gap ∧ visibility.
+- Augment observability: `vantage_diorama::augment` logs `augment completed` at
+  info with the augment key (e.g. the folder path) and the merged `k=v` pairs,
+  `no detail record` at debug, and `row demoted for augment refetch` at debug
+  when a list-field move triggers a refetch — enough to watch, live, which rows
+  re-augment and why.
+
 ## 0.6.15 — 2026-07-05
 
 **Augment details can be fixed Vista handles**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/augment/mod.rs
+++ b/vantage-diorama/src/augment/mod.rs
@@ -117,17 +117,55 @@ pub struct Augmentation {
 
 impl Augmentation {
     /// Resolve → fetch → merge the matching detail record onto `row` in place.
-    /// The per-row unit the two-pass detail pass drives.
+    /// The per-row unit the two-pass detail pass drives. `dio_name` identifies
+    /// the OWNING dio (its master vista name, which embeds the listing key) —
+    /// two completion series on one key with different `dio=` values means two
+    /// dios are augmenting the same path, which is a bug made visible.
     pub async fn augment_row(
         &self,
+        dio_name: &str,
         master_id_column: &str,
         row: &mut Record<CborValue>,
         catalog: &VistaCatalog,
     ) -> Result<()> {
-        if let Some(detail) = self.fetch_one(master_id_column, row, catalog).await? {
-            self.merge.apply(row, &detail);
+        match self.fetch_one(master_id_column, row, catalog).await? {
+            Some(detail) => {
+                self.merge.apply(row, &detail);
+                let merged: Vec<String> = detail
+                    .iter()
+                    .filter(|(k, _)| self.merge.wants(k))
+                    .map(|(k, v)| format!("{k}={}", scalar_text(v)))
+                    .collect();
+                tracing::info!(
+                    target: "vantage_diorama::augment",
+                    dio = %dio_name,
+                    detail = %self.detail.name(),
+                    key = %self.key_display(row, master_id_column),
+                    merged = %merged.join(" "),
+                    "augment completed",
+                );
+            }
+            None => {
+                tracing::debug!(
+                    target: "vantage_diorama::augment",
+                    dio = %dio_name,
+                    detail = %self.detail.name(),
+                    key = %self.key_display(row, master_id_column),
+                    "augment found no detail record — row stays as listed",
+                );
+            }
         }
         Ok(())
+    }
+
+    /// The row's augment key value, for log lines — the `Column` source's
+    /// field (e.g. the folder path), else the master id.
+    fn key_display(&self, row: &Record<CborValue>, master_id_column: &str) -> String {
+        let field = match &self.source {
+            Source::Column { from, .. } => from.as_str(),
+            Source::Id | Source::Build(_) => master_id_column,
+        };
+        row.get(field).map(scalar_text).unwrap_or_default()
     }
 
     /// Fetch the single detail record for one master row, or `None` if there is
@@ -263,6 +301,19 @@ impl Augmentation {
                 field = field
             )),
         }
+    }
+}
+
+/// A cell's short text form for log lines: scalars print directly, anything
+/// nested prints a marker (log lines must stay cheap).
+fn scalar_text(v: &CborValue) -> String {
+    match v {
+        CborValue::Text(s) => s.clone(),
+        CborValue::Integer(i) => i128::from(*i).to_string(),
+        CborValue::Float(f) => f.to_string(),
+        CborValue::Bool(b) => b.to_string(),
+        CborValue::Null => "null".to_string(),
+        _ => "<nested>".to_string(),
     }
 }
 

--- a/vantage-diorama/src/dio/augment_passes.rs
+++ b/vantage-diorama/src/dio/augment_passes.rs
@@ -48,8 +48,9 @@ pub(crate) async fn load_detail_with(
 ) -> Result<Record<CborValue>> {
     let mut row = dio.cache().get_value(&id).await?.unwrap_or_default();
     let master_id_column = dio.master().get_id_column().unwrap_or("id").to_string();
+    let dio_name = dio.master().name().to_string();
     for aug in augmentations {
-        aug.augment_row(&master_id_column, &mut row, catalog)
+        aug.augment_row(&dio_name, &master_id_column, &mut row, catalog)
             .await?;
     }
     Ok(row)
@@ -58,31 +59,60 @@ pub(crate) async fn load_detail_with(
 /// **Refresh pass**: re-run the cheap list pass and reconcile against the cache
 /// without discarding still-valid augmentation. Unchanged list fields keep their
 /// hydrated detail columns + `Complete` status; changed ones merge the fresh
-/// list values and demote to `Incomplete` (re-hydrate on next viewport); new ids
-/// stub `Incomplete`; vanished ids are deleted.
+/// list values and demote per the gap rule; new ids stub per the gap rule;
+/// vanished ids are deleted.
+///
+/// Augment-owned columns are excluded from the change COMPARISON — the cached
+/// row's augmented value against the list's unfilled column is not a change
+/// (comparing it demoted every hydrated row on every refresh: the 0 → value → 0
+/// flap). A row that genuinely moved takes the fresh list values but KEEPS its
+/// augmented values while the refetch is in flight — stale-while-refetch. The
+/// staleness lives out-of-band in [`CacheStatus`]: `Incomplete` is what drives
+/// the detail pass, so the cell never has to blank to signal the gap. Blank is
+/// reserved for rows that were never filled.
 pub(crate) async fn refresh(dio: &Dio) -> Result<()> {
     let fresh = dio.master().list_values().await?;
     let cache = dio.cache();
     let existing = cache.list_values_with_status().await?;
+    let augmented = dio.inner.augmented_columns.read().unwrap().clone();
 
     for (id, list_row) in &fresh {
+        let gap = has_augment_gap(list_row, &augmented);
+        let status = if gap {
+            CacheStatus::Incomplete
+        } else {
+            CacheStatus::Complete
+        };
         match existing.get(id) {
             Some((old, _)) => {
-                if !list_fields_changed(list_row, old) {
+                if !list_fields_changed(list_row, old, &augmented) {
                     continue;
                 }
+                tracing::debug!(
+                    target: "vantage_diorama::augment",
+                    id = %id,
+                    gap,
+                    "list fields moved — row demoted for augment refetch",
+                );
+                // Merge fresh list values over the cached row: every list
+                // value (a file's own size included) wins, but augment columns
+                // the list leaves unfilled KEEP their previous values — the
+                // display stays on the stale number while `Incomplete` status
+                // sends the row back through the detail pass.
                 let mut merged = old.clone();
                 for (k, v) in list_row {
+                    if augmented.contains(k)
+                        && matches!(v, CborValue::Null)
+                        && merged.get(k).is_some()
+                    {
+                        continue; // list's null placeholder never erases a fill
+                    }
                     merged.insert(k.clone(), v.clone());
                 }
-                cache
-                    .insert_value_with_status(id, &merged, CacheStatus::Incomplete)
-                    .await?;
+                cache.insert_value_with_status(id, &merged, status).await?;
             }
             None => {
-                cache
-                    .insert_value_with_status(id, list_row, CacheStatus::Incomplete)
-                    .await?;
+                cache.insert_value_with_status(id, list_row, status).await?;
             }
         }
     }
@@ -94,18 +124,43 @@ pub(crate) async fn refresh(dio: &Dio) -> Result<()> {
     Ok(())
 }
 
-/// True when any field the list pass paints differs from the cached record. Only
-/// keys present in `list_row` are compared — the detail pass's own columns (which
-/// exist only in `cached`) are never inspected.
+/// The gap rule: an augmentation exists to FILL columns the list leaves
+/// unfilled. A row whose list-supplied values already cover every augment
+/// column (a file's own `size`) has no gap and never fetches; a row with an
+/// absent/null augment column (a folder) does. An un-enumerable augment
+/// (empty merge list = "lift all") always counts as a gap — there is nothing
+/// to test against.
+pub(crate) fn has_augment_gap(
+    list_row: &Record<CborValue>,
+    augmented: &std::collections::HashSet<String>,
+) -> bool {
+    if augmented.is_empty() {
+        return true;
+    }
+    augmented
+        .iter()
+        .any(|column| matches!(list_row.get(column), None | Some(CborValue::Null)))
+}
+
+/// True when any field the list pass paints differs from the cached record.
+/// Only keys present in `list_row` are compared — the detail pass's own
+/// columns (which exist only in `cached`) are never inspected — and columns
+/// in `augmented` are skipped even when the list supplies them: the augment
+/// owns those values, so the list's cheap placeholder is never a change.
 pub(crate) fn list_fields_changed(
     list_row: &Record<CborValue>,
     cached: &Record<CborValue>,
+    augmented: &std::collections::HashSet<String>,
 ) -> bool {
-    list_row.iter().any(|(k, v)| cached.get(k) != Some(v))
+    list_row
+        .iter()
+        .any(|(k, v)| !augmented.contains(k) && cached.get(k) != Some(v))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::list_fields_changed;
     use ciborium::Value;
     use vantage_types::Record;
@@ -115,6 +170,10 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.clone()))
             .collect()
+    }
+
+    fn none() -> HashSet<String> {
+        HashSet::new()
     }
 
     #[test]
@@ -128,7 +187,7 @@ mod tests {
             ("updated_at", Value::from("t1")),
             ("subject_area", Value::from("finance")),
         ]);
-        assert!(!list_fields_changed(&list, &cached));
+        assert!(!list_fields_changed(&list, &cached, &none()));
     }
 
     #[test]
@@ -142,7 +201,7 @@ mod tests {
             ("updated_at", Value::from("t1")),
             ("subject_area", Value::from("finance")),
         ]);
-        assert!(list_fields_changed(&list, &cached));
+        assert!(list_fields_changed(&list, &cached, &none()));
     }
 
     #[test]
@@ -152,6 +211,28 @@ mod tests {
             ("region", Value::from("eu")),
         ]);
         let cached = rec(&[("status", Value::from("LIVE"))]);
-        assert!(list_fields_changed(&list, &cached));
+        assert!(list_fields_changed(&list, &cached, &none()));
+    }
+
+    /// The flap regression in miniature: the list paints an augment-owned
+    /// column with a cheap placeholder (a folder's `size: 0`); the cached row
+    /// holds the augmented value. That difference is NOT a change — the
+    /// augment owns the column.
+    #[test]
+    fn a_list_placeholder_under_an_augmented_column_is_not_a_change() {
+        let list = rec(&[("modified", Value::from("t1")), ("size", Value::from("0"))]);
+        let cached = rec(&[
+            ("modified", Value::from("t1")),
+            ("size", Value::from("4096")),
+            ("file_count", Value::from("3")),
+        ]);
+        let augmented: HashSet<String> = ["size", "file_count"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert!(!list_fields_changed(&list, &cached, &augmented));
+        // …while a real list-field move on the same row still demotes it.
+        let moved = rec(&[("modified", Value::from("t2")), ("size", Value::from("0"))]);
+        assert!(list_fields_changed(&moved, &cached, &augmented));
     }
 }

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -145,6 +145,46 @@ impl DioInner {
         self.augmented_columns.read().unwrap().contains(col)
     }
 
+    /// The union of every LIVE open scenery's demanded columns — the Dio's
+    /// active demand. `None` = at least one open view demands everything (or
+    /// no view declared a demand): the pre-demand behavior. `Some(union)` =
+    /// only these columns are looked at; the augment detail pass runs only
+    /// while the union intersects the augment columns. Recomputed on the fly
+    /// from the dedup registry's live entries, so demand follows scenery
+    /// open/close with no extra lifecycle machinery.
+    pub(crate) fn demanded_columns(&self) -> Option<std::collections::HashSet<String>> {
+        let mut union = std::collections::HashSet::new();
+        let mut any_live = false;
+        let guard = self.table_sceneries.lock().unwrap();
+        for weak in guard.values() {
+            let Some(scenery) = weak.upgrade() else {
+                continue;
+            };
+            any_live = true;
+            match scenery.demanded_columns() {
+                None => return None,
+                Some(columns) => union.extend(columns),
+            }
+        }
+        // No live views at all: stay permissive (a detail pass mid-flight on
+        // a closing scenery must not stall on an empty union).
+        if !any_live { None } else { Some(union) }
+    }
+
+    /// Whether the augment detail pass has work under the current demand:
+    /// true when this Dio's augment columns intersect the open sceneries'
+    /// demand union (or when either side is un-enumerable).
+    pub(crate) fn augment_demanded(&self) -> bool {
+        let augmented = self.augmented_columns.read().unwrap();
+        if augmented.is_empty() {
+            return true; // un-enumerable augment ("lift all"): always demanded
+        }
+        match self.demanded_columns() {
+            None => true,
+            Some(demanded) => augmented.iter().any(|c| demanded.contains(c)),
+        }
+    }
+
     /// Return the live shared table scenery for `key`, or `None` if none is
     /// open (or the last handle was just released — a dead `Weak`).
     pub(crate) fn lookup_table_scenery(&self, key: &str) -> Option<Arc<dyn TableScenery>> {

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -22,6 +22,7 @@ pub struct TableSceneryBuilder {
     pub(crate) page_size: usize,
     pub(crate) initial_range: Option<std::ops::Range<usize>>,
     pub(crate) titles_only: bool,
+    pub(crate) demand: Option<Vec<String>>,
 }
 
 impl TableSceneryBuilder {
@@ -34,6 +35,7 @@ impl TableSceneryBuilder {
             page_size: 100,
             initial_range: None,
             titles_only: false,
+            demand: None,
         }
     }
 
@@ -79,6 +81,24 @@ impl TableSceneryBuilder {
         self
     }
 
+    /// Declare which columns this view actually shows — its **demand**.
+    /// Default (`None`) demands everything, the pre-demand behavior. Demand
+    /// gates the AUGMENT detail pass only: the Dio unions the demands of its
+    /// open sceneries and fetches augment values only while some open view
+    /// demands an augmented column (a tree of folder names never pays for
+    /// folder sizes; the listing beside it does). Non-augment (list-pass)
+    /// columns always flow regardless of demand. Recomputed naturally as
+    /// sceneries open and close; already-merged values stay when demand
+    /// drains — they just stop refreshing.
+    pub fn columns<I, S>(mut self, columns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.demand = Some(columns.into_iter().map(Into::into).collect());
+        self
+    }
+
     /// Open the Scenery — runs `total_provider` (if configured),
     /// seeds the sparse map from the cache, spawns the reactor and
     /// viewport-debounce tasks, optionally schedules a background
@@ -92,6 +112,7 @@ impl TableSceneryBuilder {
             page_size,
             initial_range,
             titles_only,
+            demand,
         } = self;
 
         // Inherit the Dio's base query semantics. The Dio owns "what this table
@@ -122,14 +143,26 @@ impl TableSceneryBuilder {
                 };
                 (col.as_str(), dir)
             });
+            // Demand joins the dedup key: a tree demanding [name, kind] and a
+            // grid demanding [.., size] over the same query are DISTINCT
+            // sceneries — sharing one would erase the cheaper view's savings.
+            let demand_key = match &demand {
+                None => "*".to_string(),
+                Some(columns) => {
+                    let mut sorted = columns.clone();
+                    sorted.sort();
+                    sorted.join(",")
+                }
+            };
             format!(
-                "table\u{1}{}\u{1}{}\u{1}{}",
+                "table\u{1}{}\u{1}{}\u{1}{}\u{1}{}",
                 dio.master
                     .read()
                     .unwrap()
                     .index_key(&conditions, vista_sort),
                 search.as_deref().unwrap_or(""),
                 titles_only as u8,
+                demand_key,
             )
         };
         if let Some(existing) = dio.lookup_table_scenery(&key) {
@@ -195,6 +228,7 @@ impl TableSceneryBuilder {
             two_pass,
             local_refine,
             titles_only,
+            demand,
             index: RwLock::new(index),
             registry_key: Mutex::new(Some(key.clone())),
             detail_in_flight: Mutex::new(std::collections::HashSet::new()),

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -94,6 +94,13 @@ pub trait TableScenery: Send + Sync {
     /// `set_viewport`; cursor-only (`can_fetch_next`) → call
     /// `request_load_more` to walk forward.
     fn master_capabilities(&self) -> &VistaCapabilities;
+
+    /// The columns this view declared it shows (its demand, from the
+    /// builder's `columns()`). `None` = demands everything — the default for
+    /// implementations that don't track demand.
+    fn demanded_columns(&self) -> Option<Vec<String>> {
+        None
+    }
 }
 
 pub(crate) struct TableSceneryImpl {
@@ -280,5 +287,9 @@ impl TableScenery for TableSceneryImpl {
 
     fn master_capabilities(&self) -> &VistaCapabilities {
         &self.inner.master_capabilities
+    }
+
+    fn demanded_columns(&self) -> Option<Vec<String>> {
+        self.inner.demand.clone()
     }
 }

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -92,6 +92,11 @@ pub(crate) struct TableSceneryState {
     /// **skip the detail pass** even on a two-pass table. The list pass still
     /// runs (rows carry id + title columns); per-row hydration never fires.
     pub(crate) titles_only: bool,
+    /// The columns this view declared it shows (its **demand**), from the
+    /// builder's `columns()`. `None` = demands everything. The Dio unions the
+    /// demands of its open sceneries to gate the augment detail pass — see
+    /// [`DioInner::demanded_columns`](crate::dio::DioInner::demanded_columns).
+    pub(crate) demand: Option<Vec<String>>,
     /// The shared per-query ordered index for this scenery's conditions/sort,
     /// keyed by [`Vista::index_key`](vantage_vista::Vista::index_key). `None` in single-pass mode.
     /// Swappable: a `set_sort` / `set_search` re-points it at the index for the

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -210,6 +210,18 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
 
     match result {
         Ok(rows) => {
+            // The gap rule: a dio-augmented row whose list values already
+            // fill every augment column (a file's own `size`) has nothing to
+            // fetch — stub it `Complete` so the detail pass skips it.
+            // Hand-rolled two-pass (`on_load_detail` lens callbacks) keeps
+            // the always-`Incomplete` stubbing: it declares no augment
+            // columns, so every row is the detail pass's business.
+            let augmented = if dio_inner.has_dio_augment() {
+                dio_inner.augmented_columns.read().unwrap().clone()
+            } else {
+                std::collections::HashSet::new()
+            };
+            let gap_aware = dio_inner.has_dio_augment() && !augmented.is_empty();
             let mut new_ids = Vec::with_capacity(rows.len());
             for (id, rec) in &rows {
                 // Never demote a record the detail pass already completed.
@@ -223,9 +235,16 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
                     Some((_, CacheStatus::Complete))
                 );
                 if !already_complete {
+                    let status = if gap_aware
+                        && !crate::dio::augment_passes::has_augment_gap(rec, &augmented)
+                    {
+                        CacheStatus::Complete
+                    } else {
+                        CacheStatus::Incomplete
+                    };
                     let _ = dio_inner
                         .cache
-                        .insert_value_with_status(id, rec, CacheStatus::Incomplete)
+                        .insert_value_with_status(id, rec, status)
                         .await;
                 }
                 new_ids.push(id.clone());
@@ -335,6 +354,18 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
         return;
     };
     if !dio_inner.has_dio_augment() && dio_inner.lens.callbacks.on_load_detail.is_none() {
+        return;
+    }
+    // The DEMAND gate: a dio-owned augment fetches only while some open
+    // scenery demands an augmented column. A tree of folder names never pays
+    // for folder sizes; opening the listing beside it (which demands `size`)
+    // is what starts the fetches, and closing it stops them. Rows stay
+    // `Incomplete` — a later demanding viewport hydrates them.
+    if dio_inner.has_dio_augment() && !dio_inner.augment_demanded() {
+        tracing::trace!(
+            target: "vantage_diorama::augment",
+            "detail pass idle — no open view demands an augment column",
+        );
         return;
     }
     // A predicate/sort on an *augmented* column can't be evaluated until rows are

--- a/vantage-diorama/tests/augment.rs
+++ b/vantage-diorama/tests/augment.rs
@@ -441,3 +441,367 @@ async fn changed_master_row_refetches_its_augment() {
     })
     .await;
 }
+
+// ---------------------------------------------------------------------------
+// Reconcile must not flap augmented columns (live_folder regression): the
+// LIST row itself carries a cheap `size` (0 for folders) that the augment
+// overwrites. A refresh whose list fields are otherwise unchanged must keep
+// the augmented value and fetch NOTHING; a genuinely-changed row (its
+// `modified` moved) refetches — and only that row.
+// ---------------------------------------------------------------------------
+
+/// Get-only detail shell that counts fetches, so tests can assert an
+/// unchanged row issued zero refetches across refreshes.
+mod counting {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use ciborium::Value as CborValue;
+    use indexmap::IndexMap;
+    use vantage_core::Result;
+    use vantage_types::Record;
+    use vantage_vista::capabilities::VistaCapabilities;
+    use vantage_vista::metadata::VistaMetadata;
+    use vantage_vista::reference::Reference;
+    use vantage_vista::source::TableShell;
+    use vantage_vista::{Column, Vista};
+
+    pub struct CountingDetailShell {
+        pub rows: Arc<Mutex<IndexMap<String, Record<CborValue>>>>,
+        pub gets: Arc<AtomicUsize>,
+        metadata: VistaMetadata,
+        capabilities: VistaCapabilities,
+    }
+
+    impl CountingDetailShell {
+        pub fn new(rows: IndexMap<String, Record<CborValue>>) -> Self {
+            let metadata = VistaMetadata::new()
+                .with_column(Column::new("id", "String").with_flag("id"))
+                .with_column(Column::new("size", "String"))
+                .with_id_column("id");
+            Self {
+                rows: Arc::new(Mutex::new(rows)),
+                gets: Arc::new(AtomicUsize::new(0)),
+                metadata,
+                capabilities: VistaCapabilities::default(),
+            }
+        }
+    }
+
+    #[async_trait]
+    #[allow(clippy::ptr_arg)]
+    impl TableShell for CountingDetailShell {
+        fn columns(&self) -> &IndexMap<String, Column> {
+            &self.metadata.columns
+        }
+        fn references(&self) -> &IndexMap<String, Reference> {
+            &self.metadata.references
+        }
+        fn id_column(&self) -> Option<&str> {
+            self.metadata.id_column.as_deref()
+        }
+        async fn list_vista_values(
+            &self,
+            _vista: &Vista,
+        ) -> Result<IndexMap<String, Record<CborValue>>> {
+            Ok(IndexMap::new()) // get-only
+        }
+        async fn get_vista_value(
+            &self,
+            _vista: &Vista,
+            id: &String,
+        ) -> Result<Option<Record<CborValue>>> {
+            self.gets.fetch_add(1, Ordering::SeqCst);
+            Ok(self.rows.lock().unwrap().get(id).cloned())
+        }
+        async fn get_vista_some_value(
+            &self,
+            _vista: &Vista,
+        ) -> Result<Option<(String, Record<CborValue>)>> {
+            Ok(None)
+        }
+        fn capabilities(&self) -> &VistaCapabilities {
+            &self.capabilities
+        }
+        fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+            Some(Box::new(Self {
+                rows: self.rows.clone(),
+                gets: self.gets.clone(),
+                metadata: self.metadata.clone(),
+                capabilities: self.capabilities.clone(),
+            }))
+        }
+        fn driver_name(&self) -> &'static str {
+            "counting-detail"
+        }
+    }
+}
+
+#[tokio::test]
+async fn refresh_with_unchanged_list_rows_keeps_augment_and_fetches_nothing() {
+    use std::sync::atomic::Ordering;
+    use vantage_dataset::prelude::WritableValueSet;
+
+    let tmp = TempDir::new().unwrap();
+
+    // The live_folder listing shape: FOLDER rows leave the augment column
+    // unfilled (their recursive size is the augment's job); the FILE row
+    // carries its own size from the list — no gap, nothing to fetch.
+    let master_shell = MockShell::new()
+        .with_record("logs", record(&[("id", "logs"), ("modified", "t1")]))
+        .with_record("tmp", record(&[("id", "tmp"), ("modified", "t1")]))
+        .with_record(
+            "run.log",
+            record(&[("id", "run.log"), ("modified", "t1"), ("size", "64")]),
+        )
+        .with_metadata(meta(&["id", "modified", "size"]));
+    let master_writer = Vista::new("m", Box::new(master_shell.clone()));
+
+    let mut detail_rows = indexmap::IndexMap::new();
+    detail_rows.insert(
+        "logs".to_string(),
+        record(&[("id", "logs"), ("size", "4096")]),
+    );
+    detail_rows.insert("tmp".to_string(), record(&[("id", "tmp"), ("size", "512")]));
+    let detail = counting::CountingDetailShell::new(detail_rows);
+    let gets = detail.gets.clone();
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .viewport_debounce(Duration::from_millis(1))
+            .build()
+            .expect("lens builds"),
+    );
+    let dio = lens
+        .make_dio(Vista::new("listing", Box::new(master_shell)))
+        .await
+        .expect("make_dio")
+        .augment(
+            Arc::new(VistaCatalog::new()),
+            vec![Augmentation {
+                detail: Detail::Fixed(Arc::new(Vista::new("sizes", Box::new(detail)))),
+                source: Source::Id,
+                fetch: Fetch::PerRow,
+                merge: MergeRule {
+                    columns: vec!["size".into()],
+                },
+            }],
+        );
+    let scenery = dio.table_scenery().page_size(4).open().await.unwrap();
+    // Row order shifts as reseeds re-list the cache — address rows by id.
+    let by_id = |id: &'static str, c: &'static str| {
+        let scenery = scenery.clone();
+        move || {
+            (0..scenery.row_count())
+                .filter_map(|i| scenery.row(i))
+                .find(|r| matches!(r.record.get("id"), Some(CborValue::Text(t)) if t == id))
+                .and_then(|r| match r.record.get(c) {
+                    Some(CborValue::Text(t)) => Some(t.clone()),
+                    _ => None,
+                })
+        }
+    };
+    scenery.set_viewport(0..3);
+    eventually("folder rows hydrated", || {
+        by_id("logs", "size")().as_deref() == Some("4096")
+            && by_id("tmp", "size")().as_deref() == Some("512")
+    })
+    .await;
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        2,
+        "gap rule: only the two folders fetched — the file's list-supplied size is no gap"
+    );
+    assert_eq!(
+        by_id("run.log", "size")().as_deref(),
+        Some("64"),
+        "the file keeps its own listed size"
+    );
+
+    // Two refresh "ticks" with NOTHING changed. The augmented value must
+    // survive, no row may demote, and zero detail fetches may fire.
+    for _ in 0..2 {
+        dio.refresh().await.expect("refresh");
+        scenery.set_viewport(0..3);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(
+            by_id("logs", "size")().as_deref(),
+            Some("4096"),
+            "unchanged row keeps its augmented value through refresh"
+        );
+        assert_eq!(by_id("tmp", "size")().as_deref(), Some("512"));
+    }
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        2,
+        "unchanged rows never refetch their augment"
+    );
+
+    // One folder's `modified` moves: its augment clears (the gap is open
+    // again) and ONLY that row refetches. A moved FILE row never fetches —
+    // its list row still has no gap.
+    master_writer
+        .replace_value("logs", &record(&[("id", "logs"), ("modified", "t2")]))
+        .await
+        .expect("master write");
+    master_writer
+        .replace_value(
+            "run.log",
+            &record(&[("id", "run.log"), ("modified", "t2"), ("size", "96")]),
+        )
+        .await
+        .expect("file write");
+    dio.refresh().await.expect("refresh");
+    scenery.set_viewport(0..3);
+    eventually("changed folder refetched, file re-listed", || {
+        by_id("logs", "modified")().as_deref() == Some("t2")
+            && by_id("logs", "size")().as_deref() == Some("4096")
+            && by_id("run.log", "size")().as_deref() == Some("96")
+    })
+    .await;
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        3,
+        "exactly the changed folder refetched; its sibling and the file stayed cold"
+    );
+    assert_eq!(by_id("tmp", "size")().as_deref(), Some("512"));
+}
+
+/// A row's column by id, order-independent (reseeds re-list the cache).
+fn col_by_id(s: &Arc<dyn TableScenery>, id: &str, c: &str) -> Option<String> {
+    (0..s.row_count())
+        .filter_map(|i| s.row(i))
+        .find(|r| matches!(r.record.get("id"), Some(CborValue::Text(t)) if t == id))
+        .and_then(|r| match r.record.get(c) {
+            Some(CborValue::Text(t)) => Some(t.clone()),
+            _ => None,
+        })
+}
+
+/// DEMAND gates the detail pass: a view demanding only cheap columns never
+/// pays for the augment; opening a view that demands an augment column starts
+/// the fetches (gap rows only); closing it stops them — a later demotion
+/// leaves the augment blank until something demands it again.
+#[tokio::test]
+async fn augment_fetches_only_while_a_view_demands_augment_columns() {
+    use std::sync::atomic::Ordering;
+    use vantage_dataset::prelude::WritableValueSet;
+
+    let tmp = TempDir::new().unwrap();
+    let master_shell = MockShell::new()
+        .with_record("logs", record(&[("id", "logs"), ("modified", "t1")]))
+        .with_record("tmp", record(&[("id", "tmp"), ("modified", "t1")]))
+        .with_metadata(meta(&["id", "modified"]));
+    let master_writer = Vista::new("m", Box::new(master_shell.clone()));
+
+    let mut detail_rows = indexmap::IndexMap::new();
+    detail_rows.insert(
+        "logs".to_string(),
+        record(&[("id", "logs"), ("size", "4096")]),
+    );
+    detail_rows.insert("tmp".to_string(), record(&[("id", "tmp"), ("size", "512")]));
+    let detail = counting::CountingDetailShell::new(detail_rows);
+    let gets = detail.gets.clone();
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .viewport_debounce(Duration::from_millis(1))
+            .build()
+            .expect("lens builds"),
+    );
+    let dio = lens
+        .make_dio(Vista::new("listing", Box::new(master_shell)))
+        .await
+        .expect("make_dio")
+        .augment(
+            Arc::new(VistaCatalog::new()),
+            vec![Augmentation {
+                detail: Detail::Fixed(Arc::new(Vista::new("sizes", Box::new(detail)))),
+                source: Source::Id,
+                fetch: Fetch::PerRow,
+                merge: MergeRule {
+                    columns: vec!["size".into()],
+                },
+            }],
+        );
+
+    // A tree-shaped view: demands only cheap columns. Gap rows exist, a
+    // viewport is held — and still nothing fetches.
+    let tree = dio
+        .table_scenery()
+        .page_size(4)
+        .columns(["id", "modified"])
+        .open()
+        .await
+        .unwrap();
+    tree.set_viewport(0..2);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        0,
+        "no open view demands an augment column — the detail pass stays idle"
+    );
+    assert!(col_by_id(&tree, "logs", "size").is_none());
+
+    // A listing opens beside it, demanding `size`: fetches begin.
+    let listing = dio
+        .table_scenery()
+        .page_size(4)
+        .columns(["id", "size", "modified"])
+        .open()
+        .await
+        .unwrap();
+    listing.set_viewport(0..2);
+    eventually("augment lands once demanded", || {
+        col_by_id(&listing, "logs", "size").as_deref() == Some("4096")
+            && col_by_id(&listing, "tmp", "size").as_deref() == Some("512")
+    })
+    .await;
+    assert_eq!(gets.load(Ordering::SeqCst), 2, "one fetch per gap row");
+
+    // The listing closes: demand drains. A demoted row KEEPS its stale
+    // augment value (stale-while-refetch — the display never blanks once
+    // filled) and nothing refetches it while nobody demands the column.
+    drop(listing);
+    master_writer
+        .replace_value("logs", &record(&[("id", "logs"), ("modified", "t2")]))
+        .await
+        .expect("master write");
+    dio.refresh().await.expect("refresh");
+    tree.set_viewport(0..2);
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        2,
+        "demand drained — the demoted row does not refetch"
+    );
+    assert_eq!(
+        col_by_id(&tree, "logs", "size").as_deref(),
+        Some("4096"),
+        "the demoted row keeps its stale value until re-demanded"
+    );
+
+    // Demand returns: the stale row refetches.
+    let listing = dio
+        .table_scenery()
+        .page_size(4)
+        .columns(["id", "size", "modified"])
+        .open()
+        .await
+        .unwrap();
+    listing.set_viewport(0..2);
+    // The stale value already reads "4096", so the wait must be on the FETCH
+    // COUNTER — the visible value merely stops being stale when it lands.
+    eventually("re-demanded row refetches", || {
+        gets.load(Ordering::SeqCst) == 3
+    })
+    .await;
+    assert_eq!(
+        col_by_id(&listing, "logs", "size").as_deref(),
+        Some("4096"),
+        "refetched value replaces the stale one in place"
+    );
+}

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.4 — 2026-07-05
+
+- Listing rows leave a FOLDER's `size` unfilled (absent) instead of reporting 0:
+  a folder's recursive size is the augment's to fill (diorama's gap rule fetches
+  exactly those rows), and consumers render the absence as blank, never a lying
+  zero. File rows keep carrying their own size. Requires vantage-diorama 0.6.16.
+
 ## 0.6.3 — 2026-07-05
 
 - `LiveFolderSim::size_augment()` — the folder-size vista packaged as a dio-level

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.6.15", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.6.16", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"

--- a/vantage-faker/src/live_folder.rs
+++ b/vantage-faker/src/live_folder.rs
@@ -398,6 +398,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn listing_leaves_folder_size_unfilled_for_the_augment() {
+        let sim = LiveFolderSim::new(LiveFolderConfig {
+            backfill: Duration::from_secs(3600),
+            error_pct_per_sec: 100.0, // guarantee files exist
+            ..LiveFolderConfig::default()
+        });
+
+        // Root rows are day FOLDERS: size must be absent (the augment's gap),
+        // never a lying 0.
+        let (root, _tx) = sim.listing_vista("root", "");
+        let rows = root.list_values().await.unwrap();
+        assert!(!rows.is_empty());
+        for (_, rec) in &rows {
+            assert_eq!(rec.get("kind").and_then(|v| v.as_text()), Some("folder"));
+            assert!(rec.get("size").is_none(), "folder rows leave size unfilled");
+        }
+
+        // A FILE row carries its own size from the listing.
+        let file_path = sim
+            .snapshot()
+            .into_iter()
+            .find(|(_, e)| e.kind == EntryKind::File)
+            .map(|(p, _)| p)
+            .expect("backfill produced files");
+        let parent = file_path.rsplit_once('/').map(|(p, _)| p).unwrap_or("");
+        let (listing, _tx) = sim.listing_vista("parent", parent);
+        let rows = listing.list_values().await.unwrap();
+        let file_row = rows
+            .values()
+            .find(|r| r.get("kind").and_then(|v| v.as_text()) == Some("file"))
+            .expect("parent folder lists the file");
+        assert!(
+            file_row.get("size").is_some(),
+            "file rows carry their own size"
+        );
+    }
+
+    #[tokio::test]
     async fn size_augment_hydrates_listing_rows_over_one_dio() {
         use std::sync::Arc;
 

--- a/vantage-faker/src/live_folder/listing_shell.rs
+++ b/vantage-faker/src/live_folder/listing_shell.rs
@@ -74,10 +74,16 @@ fn entry_to_record(path_so_far: &str, name: &str, entry: &Entry) -> Record<CborV
             .to_string(),
         ),
     );
-    r.insert(
-        "size".to_string(),
-        CborValue::Integer((entry.size as i64).into()),
-    );
+    // Files carry their own size; a FOLDER's recursive size is not the
+    // listing's to answer — the column stays unfilled (the gap a dio-level
+    // augment exists to fill from the size vista). Consumers render the
+    // absence as blank, never a lying 0.
+    if entry.kind == EntryKind::File {
+        r.insert(
+            "size".to_string(),
+            CborValue::Integer((entry.size as i64).into()),
+        );
+    }
     r.insert(
         "created".to_string(),
         CborValue::Text(format_ts(entry.created)),


### PR DESCRIPTION
Live-tested against the vantage-ui finder over the live_folder sim.

**vantage-diorama 0.6.16**
- Augment-owned columns excluded from refresh change-comparison — kills the 0→value→0 flap (every hydrated row demoted every tick).
- Gap rule: augment fetches only rows where the list leaves an augment column absent/null; list-complete rows (a file's own size) never touch the detail source.
- Column demand: sceneries declare `columns()` at open (None = everything); the Dio's demand is the union over open sceneries, and the detail pass runs only while it intersects the augment columns. Full trigger: demand ∧ gap ∧ visibility.
- Stale-while-refetch: a demoted row keeps its augmented values while the refetch flies — staleness lives in `CacheStatus::Incomplete`, so hot rows tick up in place instead of strobing blank. Blank is reserved for never-filled.
- Observability: `vantage_diorama::augment` events for completion (now with `dio=` — two series on one key with different dio values exposes duplicate-consumer bugs at a glance), no-detail, and demote-with-reason.

**vantage-faker 0.6.4**
- live_folder listings emit absent (not 0) `size` for folders — the augment's to fill; files keep their own sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for smarter folder listings that distinguish files and folders more consistently.
  * View columns can now be requested more selectively, reducing unnecessary background loading.

* **Bug Fixes**
  * Improved refresh behavior so augmented values no longer disappear or flap during reloading.
  * Folder rows now stay blank for size until that information is available, while file sizes continue to display normally.
  * Detail loading now stops when no open view needs augmented columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->