### PR TITLE
Path B live push: Postgres LISTEN/NOTIFY demo + vista ordering & identity-keyed watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "learn-10"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "rand 0.8.6",
+ "sqlx",
+ "tokio",
+ "tower-http",
+ "vantage-api-adapters",
+ "vantage-core",
+ "vantage-dataset",
+ "vantage-diorama",
+ "vantage-sql",
+ "vantage-types",
+ "vantage-vista",
+]
+
+[[package]]
 name = "learn-2"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "vantage-types", "learn-1", "learn-2", "learn-3", "learn-4", "learn-5", "learn-6", "learn-7",
     "learn-8",
     "learn-9",
+    "learn-10",
     "vantage-vista",
     "vantage-vista-factory",
     "vantage-diorama",

--- a/learn-10/.gitignore
+++ b/learn-10/.gitignore
@@ -1,0 +1,3 @@
+/target
+products.db
+products.db-*

--- a/learn-10/Cargo.toml
+++ b/learn-10/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "learn-10"
+version = "0.1.0"
+edition = "2024"
+publish = false
+default-run = "learn-10"
+
+[dependencies]
+vantage-api-adapters = { path = "../vantage-api-adapters", features = ["axum"] }
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["fs"] }
+vantage-sql = { path = "../vantage-sql", features = ["postgres", "vista"] }
+vantage-diorama = { path = "../vantage-diorama" }
+vantage-vista = { path = "../vantage-vista" }
+vantage-dataset = { path = "../vantage-dataset" }
+vantage-types = { path = "../vantage-types" }
+vantage-core = { path = "../vantage-core" }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres"] }
+rand = "0.8"

--- a/learn-10/frontend/index.html
+++ b/learn-10/frontend/index.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>The Vantage Bar — live inventory</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <style>
+      body {
+        background:
+          radial-gradient(1200px 600px at 15% -10%, #1e293b 0%, transparent 60%),
+          radial-gradient(1000px 500px at 100% 0%, #172554 0%, transparent 55%),
+          #0b1120;
+      }
+      @keyframes flash { 0% { transform: scale(1.35); opacity: 0.35 } 100% { transform: scale(1); opacity: 1 } }
+      .flash { animation: flash 0.5s ease-out }
+      @keyframes livedot { 0%,100% { opacity: 1 } 50% { opacity: 0.25 } }
+      .livedot { animation: livedot 1.4s ease-in-out infinite }
+      @keyframes arrive { from { opacity: 0; transform: scale(0.9) translateY(-8px) } to { opacity: 1; transform: none } }
+      .arrive { animation: arrive 0.35s cubic-bezier(.22,.61,.36,1) }
+      @keyframes dispose { to { opacity: 0; transform: scale(0.8) translateY(14px); filter: saturate(0.2) } }
+      .disposing { animation: dispose 0.5s ease-in forwards; pointer-events: none }
+      .card { transition: box-shadow .3s ease, border-color .3s ease, transform .3s ease }
+      .bar { transition: width .5s cubic-bezier(.22,.61,.36,1), background-color .4s ease }
+    </style>
+  </head>
+  <body class="min-h-screen text-slate-100 antialiased">
+    <div id="root"></div>
+    <script type="text/babel">
+      const { useEffect, useState, useRef } = React;
+      const FULL = 12; // a full crate, for the stock bar scale
+      const money = (c) => `$${(c / 100).toFixed(2)}`;
+
+      function tone(stock) {
+        if (stock <= 0) return { bar: "#475569", ring: "border-slate-700", label: "text-slate-500" };
+        if (stock <= 3) return { bar: "#f43f5e", ring: "border-rose-500/40", label: "text-rose-300" };
+        if (stock <= 7) return { bar: "#f59e0b", ring: "border-amber-500/40", label: "text-amber-300" };
+        return { bar: "#10b981", ring: "border-emerald-500/40", label: "text-emerald-300" };
+      }
+
+      function Card({ p }) {
+        const t = tone(p.stock);
+        const pct = Math.max(0, Math.min(1, p.stock / FULL)) * 100;
+        const hover = p.disposing ? "" : "hover:-translate-y-0.5 hover:shadow-xl";
+        return (
+          <div className={`card relative rounded-2xl border ${t.ring} bg-white/5 backdrop-blur p-5 shadow-lg ${hover} ${p.disposing ? "disposing" : "arrive"}`}>
+            {p.disposing && (
+              <div className="absolute inset-0 grid place-items-center rounded-2xl bg-slate-950/40">
+                <span className="rounded-full border border-rose-400/50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-rose-300">
+                  sold out
+                </span>
+              </div>
+            )}
+            <div className="flex items-baseline justify-between gap-3">
+              <h3 className="text-lg font-semibold tracking-tight truncate">{p.name}</h3>
+              <span className="text-sm font-medium text-slate-300 tabular-nums">{money(p.price)}</span>
+            </div>
+            <div className="mt-4 h-2.5 w-full rounded-full bg-white/10 overflow-hidden">
+              <div className="bar h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: t.bar }} />
+            </div>
+            <div className="mt-2 flex items-center justify-between text-sm">
+              <span key={p.stock} className={`flash font-semibold tabular-nums ${t.label}`}>
+                {p.stock > 0 ? `${p.stock} in stock` : "sold out"}
+              </span>
+              <span className="text-slate-500">of {FULL}</span>
+            </div>
+          </div>
+        );
+      }
+
+      function App() {
+        const [items, setItems] = useState({}); // id -> object (on the shelf)
+        const [leaving, setLeaving] = useState({}); // id -> object (animating out)
+        const [live, setLive] = useState(false);
+        const bufRef = useRef("");
+
+        useEffect(() => {
+          let stop = false;
+          const timers = {};
+          async function connect() {
+            try {
+              const res = await fetch("/api/products?watch=true");
+              setLive(true);
+              const reader = res.body.getReader();
+              const dec = new TextDecoder();
+              while (!stop) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                bufRef.current += dec.decode(value, { stream: true });
+                const lines = bufRef.current.split("\n");
+                bufRef.current = lines.pop();
+                for (const line of lines) {
+                  if (!line.trim()) continue;
+                  const { type, object: o } = JSON.parse(line);
+                  if (type === "DELETED") {
+                    // A drink left the shelf — dispose of it with an animation.
+                    setItems((m) => { const n = { ...m }; delete n[o.id]; return n; });
+                    setLeaving((m) => ({ ...m, [o.id]: o }));
+                    clearTimeout(timers[o.id]);
+                    timers[o.id] = setTimeout(() => {
+                      setLeaving((m) => { const n = { ...m }; delete n[o.id]; return n; });
+                    }, 500);
+                  } else {
+                    // ADDED / MODIFIED — upsert, and cancel any pending disposal.
+                    setLeaving((m) => { if (!(o.id in m)) return m; const n = { ...m }; delete n[o.id]; return n; });
+                    setItems((m) => ({ ...m, [o.id]: o }));
+                  }
+                }
+              }
+            } catch (_) { /* fall through to reconnect */ }
+            setLive(false);
+            if (!stop) setTimeout(connect, 1000);
+          }
+          connect();
+          return () => { stop = true; Object.values(timers).forEach(clearTimeout); };
+        }, []);
+
+        const list = [
+          ...Object.values(items).map((o) => ({ ...o, disposing: false })),
+          ...Object.values(leaving).map((o) => ({ ...o, disposing: true })),
+        ].sort(
+          (a, b) =>
+            a.index - b.index ||
+            // Same slot: keep the fading card ahead of the live card that
+            // shifted into its place, so DOM order stays put and they don't
+            // swap mid-animation.
+            (a.disposing === b.disposing ? 0 : a.disposing ? -1 : 1),
+        );
+
+        return (
+          <div className="mx-auto max-w-5xl px-6 py-12">
+            <header className="mb-10 flex flex-wrap items-end justify-between gap-4">
+              <div>
+                <h1 className="text-3xl font-bold tracking-tight">🍸 The Vantage Bar</h1>
+                <p className="mt-1 text-slate-400">
+                  Live inventory over a watch stream — Postgres <code className="text-slate-300">LISTEN/NOTIFY</code>.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm">
+                <span className={`livedot inline-block h-2.5 w-2.5 rounded-full ${live ? "bg-emerald-400" : "bg-slate-500"}`} />
+                <span className={live ? "text-emerald-300" : "text-slate-400"}>{live ? "live" : "reconnecting…"}</span>
+              </div>
+            </header>
+
+            {list.length === 0 ? (
+              <p className="text-slate-500">Waiting for the shelf… (run the mutator to stock it)</p>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {list.map((p) => <Card key={p.id} p={p} />)}
+              </div>
+            )}
+
+            <footer className="mt-12 text-center text-xs text-slate-600">
+              Every card updates the moment the database changes — no polling. Served by axum; data by Vantage.
+            </footer>
+          </div>
+        );
+      }
+
+      ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+    </script>
+  </body>
+</html>

--- a/learn-10/src/bin/mutator.rs
+++ b/learn-10/src/bin/mutator.rs
@@ -1,0 +1,131 @@
+//! The bar's till — a *separate process* from the server.
+//!
+//! Run the server (`cargo run -p learn-10`) and this (`cargo run -p learn-10
+//! --bin mutator`) side by side. The server never writes to `product`; every
+//! change on screen comes from this binary, through the database, via
+//! `LISTEN/NOTIFY`. That separation is the point: it proves the UI updates
+//! because the *database* changed, not because one process poked another.
+//!
+//! It makes exactly one change at a time — a single sale (or a delivery when
+//! the shelf runs low) — with a short *random* pause between them, so updates
+//! arrive irregularly and never look like a poll on a fixed interval. Stock
+//! only ever goes down; a drink that sells its last unit leaves the shelf.
+//!
+//! Writes go through Vantage's **active-entity** API: `list_entities()` hands
+//! back drinks that carry their own id and datasource, so selling one is just
+//! `drink.stock -= 1; drink.save()` and clearing it is `drink.delete()` — no
+//! table or id threaded through the call.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use learn_10::db;
+use learn_10::product::Product;
+use rand::Rng;
+use rand::seq::SliceRandom;
+use vantage_dataset::prelude::ActiveEntitySet;
+use vantage_sql::postgres::PostgresDB;
+use vantage_sql::prelude::*;
+
+/// The bar menu deliveries are drawn from: (name, price in cents).
+const MENU: &[(&str, i64)] = &[
+    ("Negroni", 1200),
+    ("Old Fashioned", 1300),
+    ("Margarita", 1100),
+    ("Mojito", 1000),
+    ("Aperol Spritz", 950),
+    ("Dry Martini", 1400),
+    ("Manhattan", 1350),
+    ("Daiquiri", 1050),
+    ("Whiskey Sour", 1150),
+    ("Cosmopolitan", 1250),
+    ("Espresso Martini", 1300),
+    ("Paloma", 1000),
+    ("Boulevardier", 1400),
+    ("Sazerac", 1450),
+    ("Gimlet", 1100),
+];
+
+/// A fresh, full bottle arrives once this many units have been poured, so
+/// delivery simply tracks consumption and the shelf balances itself. A short
+/// bootstrap keeps a few drinks on hand so there's always something to pour.
+const UNITS_PER_DELIVERY: i64 = 12;
+const BOOTSTRAP_MIN: usize = 3;
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        e.report();
+    }
+}
+
+async fn run() -> VantageResult<()> {
+    let db = db::connect().await?;
+    db::setup(&db).await?;
+    println!("mutator running — one change at a time (Ctrl-C to stop)");
+
+    let mut sold_since_delivery: i64 = 0;
+    loop {
+        // Event-paced, not a fixed beat: a short *random* pause, so the stream
+        // is clearly event-driven rather than a timer.
+        let pause = rand::thread_rng().gen_range(200..1000);
+        tokio::time::sleep(Duration::from_millis(pause)).await;
+
+        let table = Product::table(db.clone());
+        // The whole shelf, as active entities — each knows how to save or
+        // delete itself.
+        let mut shelf = table.list_entities().await?;
+
+        // Bootstrap an empty bar, or send a fresh bottle once a bottle's worth
+        // has been poured. Otherwise pour a single unit.
+        if shelf.len() < BOOTSTRAP_MIN || sold_since_delivery >= UNITS_PER_DELIVERY {
+            if sold_since_delivery >= UNITS_PER_DELIVERY {
+                sold_since_delivery -= UNITS_PER_DELIVERY;
+            }
+            deliver(&table).await?;
+        } else {
+            // Pour one unit of a random drink; the last unit takes it off the
+            // shelf. No table or id at the call site — the entity carries both.
+            let drink = shelf.choose_mut(&mut rand::thread_rng()).unwrap();
+            if drink.stock <= 1 {
+                println!("🍸 {} sold out — off the shelf", drink.name);
+                drink.delete().await?;
+            } else {
+                drink.stock -= 1;
+                println!("🍸 sold {}: {} → {}", drink.name, drink.stock + 1, drink.stock);
+                drink.save().await?;
+            }
+            sold_since_delivery += 1;
+        }
+    }
+}
+
+/// A delivery: a named drink arrives with a full crate of stock.
+async fn deliver(table: &Table<PostgresDB, Product>) -> VantageResult<()> {
+    let (name, price, stock, id) = {
+        let mut r = rand::thread_rng();
+        let (name, price) = *MENU.choose(&mut r).unwrap();
+        let id = format!("d{}", r.gen_range(0..1_000_000_000u32));
+        (name, price, r.gen_range(10..15), id)
+    };
+    table
+        .new_entity(
+            id,
+            Product {
+                name: name.to_string(),
+                price,
+                stock,
+                created: now_millis(),
+            },
+        )
+        .save()
+        .await?;
+    println!("📦 delivery: {name} × {stock}");
+    Ok(())
+}
+
+fn now_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}

--- a/learn-10/src/db.rs
+++ b/learn-10/src/db.rs
@@ -1,0 +1,61 @@
+//! Connection + schema — Postgres only.
+//!
+//! The previous chapter migrated this app off SQLite. Having committed to one
+//! backend, the code drops every `#[cfg]` and uses Postgres directly — starting
+//! with a trigger that `NOTIFY`s on every change to `product`, which the
+//! listener in [`crate::notify`] turns into an instant cache refresh.
+
+use vantage_sql::postgres::PostgresDB;
+use vantage_sql::prelude::*;
+
+pub async fn connect() -> VantageResult<PostgresDB> {
+    let url = std::env::var("DATABASE_URL").map_err(|_| {
+        vantage_core::error!(
+            "DATABASE_URL must be set, e.g. postgres://vantage:vantage@localhost:5433/vantage"
+        )
+    })?;
+    PostgresDB::connect(&url).await.context("connect postgres")
+}
+
+/// Create the `product` table and its NOTIFY trigger if absent. The shelf
+/// starts empty; the `mutator` binary fills it with deliveries.
+pub async fn setup(db: &PostgresDB) -> VantageResult<()> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS product (
+            id      TEXT PRIMARY KEY,
+            name    TEXT NOT NULL,
+            price   BIGINT NOT NULL,
+            stock   BIGINT NOT NULL,
+            created BIGINT NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .context("create table")?;
+
+    // Announce every change on the `product_changed` channel. `FOR EACH
+    // STATEMENT` fires once per statement, not per row — one notification is
+    // enough to trigger a reconcile.
+    sqlx::query(
+        "CREATE OR REPLACE FUNCTION product_notify() RETURNS trigger AS $$
+         BEGIN PERFORM pg_notify('product_changed', ''); RETURN NULL; END;
+         $$ LANGUAGE plpgsql",
+    )
+    .execute(db.pool())
+    .await
+    .context("create notify function")?;
+    sqlx::query("DROP TRIGGER IF EXISTS product_notify_trg ON product")
+        .execute(db.pool())
+        .await
+        .context("drop trigger")?;
+    sqlx::query(
+        "CREATE TRIGGER product_notify_trg
+         AFTER INSERT OR UPDATE OR DELETE ON product
+         FOR EACH STATEMENT EXECUTE FUNCTION product_notify()",
+    )
+    .execute(db.pool())
+    .await
+    .context("create trigger")?;
+
+    Ok(())
+}

--- a/learn-10/src/lib.rs
+++ b/learn-10/src/lib.rs
@@ -1,0 +1,6 @@
+//! Shared between the two binaries — the reactive server (`main.rs`) and the
+//! standalone `mutator` — so both talk to the same `product` table through the
+//! same model and connection code.
+
+pub mod db;
+pub mod product;

--- a/learn-10/src/main.rs
+++ b/learn-10/src/main.rs
@@ -1,0 +1,83 @@
+mod notify;
+
+use std::sync::Arc;
+
+use learn_10::db;
+use learn_10::product::Product;
+use tower_http::services::ServeDir;
+use vantage_api_adapters::axum_dio::DioRouter;
+use vantage_diorama::prelude::*;
+use vantage_sql::prelude::*;
+use vantage_vista::SortDirection;
+
+#[tokio::main]
+async fn main() {
+    if let Err(e) = run().await {
+        e.report();
+    }
+}
+
+async fn run() -> VantageResult<()> {
+    let db = db::connect().await?;
+    db::setup(&db).await?;
+
+    // Order the shelf by creation time, so a drink keeps its place as it sells
+    // and new deliveries append at the end.
+    let mut master = db.vista_factory().from_table(Product::table(db.clone()))?;
+    master.add_order("created", SortDirection::Ascending)?;
+
+    // Eager cache, and no refresh timer at all: the NOTIFY listener refreshes
+    // the instant a write lands, never on a poll.
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .on_refresh(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().clear().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .build()
+            .context("build lens")?,
+    );
+    let dio = lens.make_dio(master).await?;
+
+    // Refresh the moment Postgres says the table changed. Nothing in *this*
+    // process ever writes to `product` — the separate `mutator` binary does, so
+    // whatever you see on screen arrived over the database, not a shortcut.
+    notify::spawn(dio.clone(), db.pool().clone());
+
+    let api = DioRouter::new(dio.clone())
+        .with_column("id", "id")
+        .with_column("name", "name")
+        .with_column("price", "price")
+        .with_column("stock", "stock")
+        // Identity-keyed watch: the stream reports a sold-out drink as a
+        // `DELETED` event (by id), so the frontend can animate its removal.
+        .key_by("id")
+        .with_page_size(50)
+        .into_router();
+
+    // The API, plus the static React frontend served from `frontend/`.
+    let frontend = concat!(env!("CARGO_MANIFEST_DIR"), "/frontend");
+    let app = axum::Router::new()
+        .nest("/api/products", api)
+        .fallback_service(ServeDir::new(frontend));
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3010")
+        .await
+        .context("bind :3010")?;
+    println!("serving on http://localhost:3010  (run the mutator to fill the shelf)");
+    axum::serve(listener, app).await.context("server failed")
+}

--- a/learn-10/src/notify.rs
+++ b/learn-10/src/notify.rs
@@ -1,0 +1,36 @@
+//! Postgres `LISTEN/NOTIFY` bridge.
+//!
+//! Because we own the database, we don't have to poll it. A trigger (installed
+//! in [`crate::db::setup`]) fires `NOTIFY product_changed` on every write; this
+//! task listens on that channel and refreshes the Dio the instant it hears one.
+//! No timer, no wasted queries — the cache reconciles exactly when, and only
+//! when, the data actually changed.
+
+use sqlx::PgPool;
+use sqlx::postgres::PgListener;
+use vantage_diorama::prelude::*;
+use vantage_sql::prelude::*;
+
+pub fn spawn(dio: Dio, pool: PgPool) {
+    tokio::spawn(async move {
+        if let Err(e) = run(dio, pool).await {
+            e.report();
+        }
+    });
+}
+
+async fn run(dio: Dio, pool: PgPool) -> VantageResult<()> {
+    let mut listener = PgListener::connect_with(&pool)
+        .await
+        .context("open pg listener")?;
+    listener
+        .listen("product_changed")
+        .await
+        .context("LISTEN product_changed")?;
+    println!("listening for Postgres NOTIFY on `product_changed`");
+
+    loop {
+        listener.recv().await.context("recv notification")?;
+        dio.refresh().await?;
+    }
+}

--- a/learn-10/src/product.rs
+++ b/learn-10/src/product.rs
@@ -1,0 +1,30 @@
+use vantage_sql::postgres::PostgresDB;
+use vantage_sql::prelude::*;
+use vantage_types::prelude::*;
+
+// Referenced by the `#[entity]` macro expansion.
+#[allow(unused_imports)]
+use vantage_sql::postgres::AnyPostgresType;
+
+/// One drink on the shelf. `created` is an epoch-millis stamp set when the
+/// delivery arrives — the shelf is ordered by it, so drinks stay put as they
+/// sell and new deliveries append at the end.
+#[entity(PostgresType)]
+#[derive(Debug, Clone, Default)]
+pub struct Product {
+    pub name: String,
+    pub price: i64,
+    pub stock: i64,
+    pub created: i64,
+}
+
+impl Product {
+    pub fn table(db: PostgresDB) -> Table<PostgresDB, Product> {
+        Table::new("product", db)
+            .with_id_column("id")
+            .with_column_of::<String>("name")
+            .with_column_of::<i64>("price")
+            .with_column_of::<i64>("stock")
+            .with_column_of::<i64>("created")
+    }
+}

--- a/vantage-api-adapters/src/axum_dio.rs
+++ b/vantage-api-adapters/src/axum_dio.rs
@@ -33,7 +33,7 @@
 //! let app = axum::Router::new().nest("/api/files", api);
 //! ```
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -89,6 +89,7 @@ pub struct DioRouter {
     dio: Dio,
     columns: Vec<(String, String)>,
     page_size: usize,
+    key_field: Option<String>,
 }
 
 impl DioRouter {
@@ -97,6 +98,7 @@ impl DioRouter {
             dio,
             columns: Vec::new(),
             page_size: 50,
+            key_field: None,
         }
     }
 
@@ -115,6 +117,18 @@ impl DioRouter {
         self
     }
 
+    /// Diff the listing watch by the value of record field `field` (a stable
+    /// row id) instead of by position. With a key set, the watch is
+    /// identity-keyed: a row that leaves the set produces a `DELETED` event, a
+    /// row that merely shifts position is not re-sent, and `ADDED`/`MODIFIED`
+    /// track the row rather than the slot. Without it, the watch keeps its
+    /// positional behaviour (index-diffed, `ADDED`/`MODIFIED` only). The field
+    /// must be exposed via [`with_column`](Self::with_column).
+    pub fn key_by(mut self, field: impl Into<String>) -> Self {
+        self.key_field = Some(field.into());
+        self
+    }
+
     /// Build the router: `GET /` and `GET /{id}`, both honouring
     /// `?watch=true`. Nest it wherever the resource should live.
     pub fn into_router(self) -> Router {
@@ -122,6 +136,7 @@ impl DioRouter {
             dio: self.dio,
             columns: Arc::from(self.columns),
             page_size: self.page_size,
+            key_field: self.key_field.map(Arc::from),
         };
         Router::new()
             .route("/", get(listing))
@@ -135,6 +150,7 @@ struct ApiState {
     dio: Dio,
     columns: Arc<[(String, String)]>,
     page_size: usize,
+    key_field: Option<Arc<str>>,
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -202,12 +218,13 @@ async fn watch_listing(st: ApiState, offset: usize, limit: usize) -> ApiResult<R
     scenery.set_viewport(offset..offset.saturating_add(limit));
     let mut generations = scenery.subscribe();
     let columns = st.columns.clone();
+    let key_field = st.key_field.clone();
 
     let stream = async_stream::stream! {
-        // Last object sent per row index — the diff base. Only rows that
-        // actually changed produce a line, so a generation bump for an
-        // unrelated row costs nothing on the wire.
-        let mut last: BTreeMap<usize, serde_json::Value> = BTreeMap::new();
+        // Diff base. Positional watches key it by row index; identity watches
+        // (a `key_by` field is set) key it by that field's value, so a removed
+        // row can be reported as `DELETED` and a shifted row isn't re-sent.
+        let mut last: BTreeMap<String, serde_json::Value> = BTreeMap::new();
         loop {
             // The index pages lazily and is shared per-query across
             // sceneries — an earlier watch may have built it shallower than
@@ -218,17 +235,38 @@ async fn watch_listing(st: ApiState, offset: usize, limit: usize) -> ApiResult<R
                 scenery.request_load_more();
             }
             let end = offset.saturating_add(limit).min(scenery.row_count());
+            let mut seen: BTreeSet<String> = BTreeSet::new();
             for idx in offset..end {
                 let Some(row) = scenery.row(idx) else { continue };
                 let object = project(idx, &row.record, &columns);
-                let kind = match last.get(&idx) {
+                // Diff key: the identity field's value, or the row index.
+                let key = match &key_field {
+                    Some(field) => match object.get(field.as_ref()).and_then(|v| v.as_str()) {
+                        Some(id) => id.to_owned(),
+                        None => continue,
+                    },
+                    None => idx.to_string(),
+                };
+                seen.insert(key.clone());
+                let kind = match last.get(&key) {
                     Some(previous) if *previous == object => None,
                     Some(_) => Some("MODIFIED"),
                     None => Some("ADDED"),
                 };
                 if let Some(kind) = kind {
-                    last.insert(idx, object.clone());
+                    last.insert(key, object.clone());
                     yield event_line(kind, object);
+                }
+            }
+            // Identity watches report rows that left the set; positional
+            // watches never do — a shrunk list simply stops emitting the tail.
+            if key_field.is_some() {
+                let gone: Vec<String> =
+                    last.keys().filter(|k| !seen.contains(*k)).cloned().collect();
+                for key in gone {
+                    if let Some(object) = last.remove(&key) {
+                        yield event_line("DELETED", object);
+                    }
                 }
             }
             // Wait for the next generation; the sender lives as long as the

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -341,7 +341,11 @@ where
 {
     let mut metadata = VistaMetadata::new();
     for (name, col) in table.columns() {
-        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        // MySQL can ORDER BY any column server-side. Every column gets
+        // the ORDERABLE flag at construction; consumers branch on it
+        // before calling `Vista::add_order`.
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string())
+            .with_flag(vista_flags::ORDERABLE);
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -63,6 +63,7 @@ impl PostgresVistaFactory {
             table,
             VistaCapabilities {
                 can_count: true,
+                can_order: true,
                 can_insert: !read_only,
                 can_update: !read_only,
                 can_delete: !read_only,
@@ -345,7 +346,11 @@ where
 {
     let mut metadata = VistaMetadata::new();
     for (name, col) in table.columns() {
-        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        // PostgreSQL can ORDER BY any column server-side. Every column gets
+        // the ORDERABLE flag at construction; consumers branch on it
+        // before calling `Vista::add_order`.
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string())
+            .with_flag(vista_flags::ORDERABLE);
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -9,15 +9,17 @@ use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
 use vantage_table::pagination::Pagination;
+use vantage_table::sorting::{OrderBy, SortDirection as TableSortDirection};
 use vantage_table::table::Table;
 use vantage_types::{EmptyEntity, Entity, Record};
 use vantage_vista::{
-    Column as VistaColumn, ContainedSpec, Reference as VistaReference, TableShell, Vista,
-    VistaCapabilities, VistaMetadata,
+    Column as VistaColumn, ContainedSpec, Reference as VistaReference, SortDirection, TableShell,
+    Vista, VistaCapabilities, VistaMetadata,
 };
 
 use crate::postgres::PostgresDB;
 use crate::postgres::operation::PostgresOperation;
+use crate::primitives::identifier::ident;
 use crate::postgres::types::AnyPostgresType;
 use crate::types::{cbor_to_json, parse_json_host};
 
@@ -198,6 +200,30 @@ where
             .clone();
         let sql_value = AnyPostgresType::untyped(value.clone());
         self.table.add_condition(column.eq(sql_value));
+        Ok(())
+    }
+
+    fn add_order(&mut self, field: &str, dir: SortDirection) -> Result<()> {
+        if !self.table.columns().contains_key(field) {
+            return Err(error!("Unknown column for add_order", field = field));
+        }
+        // Vista's add_order is replace-semantics — drop any previously-set
+        // order before pushing the new one.
+        self.table.clear_orders();
+        let expr = postgres_expr!("{}", (ident(field)));
+        let direction = match dir {
+            SortDirection::Ascending => TableSortDirection::Ascending,
+            SortDirection::Descending => TableSortDirection::Descending,
+        };
+        self.table.add_order(OrderBy {
+            expression: expr.into(),
+            direction,
+        });
+        Ok(())
+    }
+
+    fn clear_orders(&mut self) -> Result<()> {
+        self.table.clear_orders();
         Ok(())
     }
 

--- a/vantage-sql/tests/postgres/6_vista.rs
+++ b/vantage-sql/tests/postgres/6_vista.rs
@@ -547,3 +547,36 @@ fn numeric(v: Option<&CborValue>) -> Option<i64> {
         _ => None,
     }
 }
+
+#[tokio::test]
+async fn vista_add_order_ascending_descending_and_clear() -> TestResult {
+    use vantage_vista::SortDirection;
+
+    let (db, name) = setup("order").await;
+    let table = product_table(db.clone(), &name);
+    let mut vista = db.vista_factory().from_table(table)?;
+
+    // A table-sourced Postgres Vista advertises ordering and flags every column
+    // ORDERABLE, so `add_order` works without going through YAML.
+    assert!(vista.capabilities().can_order);
+
+    // sort ascending by price → a (10), b (20), c (30)
+    vista.add_order("price", SortDirection::Ascending)?;
+    let rows = vista.list_values().await?;
+    let ids: Vec<&String> = rows.keys().collect();
+    assert_eq!(ids, ["a", "b", "c"]);
+
+    // replace-semantics: switch to descending name → c (Gamma), b (Beta), a (Alpha)
+    vista.add_order("name", SortDirection::Descending)?;
+    let rows = vista.list_values().await?;
+    let ids: Vec<&String> = rows.keys().collect();
+    assert_eq!(ids, ["c", "b", "a"]);
+
+    // clear → every row still present (order unconstrained)
+    vista.clear_orders()?;
+    let rows = vista.list_values().await?;
+    let mut ids: Vec<String> = rows.keys().cloned().collect();
+    ids.sort();
+    assert_eq!(ids, ["a", "b", "c"]);
+    Ok(())
+}


### PR DESCRIPTION
Stacked on #340 (base `van-42`). Adds the Path B live-push demo and the two framework capabilities it needed.

## Demo — `learn-10`

A Postgres-only reactive app (the "commit to one backend" end of Path B): a bar inventory served over a `DioRouter` watch, with a **React frontend** and a **separate mutator** process.

- **Real `LISTEN/NOTIFY` push**: a trigger `NOTIFY`s on every `product` change; a `PgListener` task refreshes the Dio the instant a write lands — no polling timer. The server *never* writes; the standalone `mutator` binary does, so the UI provably updates over the database.
- **Active-entity mutator**: reads/writes go through Vantage's `ActiveEntity` API — `list_entities()`, `drink.stock -= 1; drink.save()`, `drink.delete()` — no hand-written SQL, no table/id threaded through the call. Deliveries track consumption (a fresh bottle every 12 units poured), so the shelf self-balances.
- **Frontend** (`frontend/index.html`, React + Tailwind via CDN, no build step): live stock bars, arrival/flash animations, and a **disposal animation** when a drink sells out.

## Framework changes

Both are general, verified, and backward-compatible.

**1. Vista `ORDERABLE` gap (`vantage-sql`).** A programmatically-built Vista (`vista_factory().from_table(...)`) couldn't be ordered — `Vista::add_order` was refused even though the backend orders any column. SQLite already flagged its columns `ORDERABLE`; Postgres and MySQL did not, and the Postgres `TableShell` lacked `can_order` + `add_order`/`clear_orders`. Fixed to match SQLite. New passing test `tests/postgres/6_vista.rs::vista_add_order_ascending_descending_and_clear`.

**2. `DioRouter` identity-keyed watch (`vantage-api-adapters`).** New opt-in `DioRouter::key_by("id")`: the listing watch diffs by a stable row id instead of by position, so a row that leaves the set is reported as a **`DELETED`** event (and a row that merely shifts isn't re-sent). Without it, the positional `ADDED`/`MODIFIED`-only behaviour is unchanged — the existing 5 adapter tests still pass and `learn-7` is unaffected.

## Verified

- Both framework changes covered by tests (pg ordering; adapter regression suite green).
- `learn-10` end-to-end on Postgres: watch streams `ADDED`/`MODIFIED`/`DELETED`; an external `psql` edit pushes through; a 45s sim produced 6 `DELETED`s matching 6 sold-outs.

## Follow-up

The Path B docs chapter for the `LISTEN/NOTIFY` step is **not** in this PR — happy to add it here or separately.

Linear: [VAN-42](https://linear.app/vantage-ui/issue/VAN-42)
