### PR TITLE
vantage-surrealdb: fix datetime/tag values showing as raw [num,num] arrays in JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.3 — 2026-07-16
+
+- Fixed `AnySurrealType`'s JSON conversion dropping CBOR tags. `From<AnySurrealType> for
+  serde_json::Value` previously round-tripped through a plain `ciborium`/`serde` re-encode, which
+  silently discards CBOR tags — a datetime (`Tag(12, [seconds, nanos])`, SurrealDB's compact
+  encoding) surfaced as the raw `[seconds, nanos]` array instead of a timestamp, and record ids,
+  UUIDs, decimals, and durations were similarly unformatted whenever this path was hit. The
+  conversion now understands SurrealDB's tags directly, rendering the same textual form SurrealDB's
+  own JSON API produces (an RFC 3339 string for datetimes, `table:id` for record ids, etc.).
+
 ## 0.6.2 — 2026-07-16
 
 - Live subscriptions. `SurrealTableShell` implements `watch_vista` over

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.2"
+version = "0.6.3"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/types/value.rs
+++ b/vantage-surrealdb/src/types/value.rs
@@ -3,6 +3,7 @@
 //! AnySurrealType passthrough and conversions.
 
 use crate::types::{AnySurrealType, SurrealType, SurrealTypeNoneMarker};
+use base64::Engine as _;
 use ciborium::Value as CborValue;
 use serde_json::Value as JsonValue;
 use vantage_expressions::{Expression, Expressive};
@@ -54,11 +55,157 @@ impl From<JsonValue> for AnySurrealType {
 
 impl From<AnySurrealType> for JsonValue {
     fn from(val: AnySurrealType) -> Self {
-        // CBOR → bytes → JSON via serde round-trip
-        let mut buf = Vec::new();
-        ciborium::into_writer(val.value(), &mut buf).expect("CBOR serialization failed");
-        ciborium::from_reader(&buf[..]).unwrap_or(JsonValue::Null)
+        cbor_to_json(val.value())
     }
+}
+
+/// Convert a CBOR value to JSON, understanding SurrealDB's tagged types
+/// (`Tag(8)` record ids, `Tag(12)` compact datetimes, etc.) instead of
+/// letting them fall through as their raw untagged payload.
+///
+/// A plain `ciborium::into_writer` + `ciborium::from_reader` round-trip
+/// (the previous implementation) drops CBOR tags entirely — a datetime
+/// (`Tag(12, [seconds, nanos])`) decoded to the bare `[seconds, nanos]`
+/// array rather than a timestamp, and likewise for every other tagged
+/// SurrealDB type. This walks the value directly so each tag renders the
+/// same textual form SurrealDB's own JSON API would produce.
+fn cbor_to_json(value: &CborValue) -> JsonValue {
+    match value {
+        CborValue::Null => JsonValue::Null,
+        CborValue::Bool(b) => JsonValue::Bool(*b),
+        CborValue::Integer(i) => integer_to_json(*i),
+        CborValue::Float(f) => serde_json::Number::from_f64(*f)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        CborValue::Text(s) => JsonValue::String(s.clone()),
+        CborValue::Bytes(b) => {
+            JsonValue::String(base64::engine::general_purpose::STANDARD.encode(b))
+        }
+        CborValue::Array(arr) => JsonValue::Array(arr.iter().map(cbor_to_json).collect()),
+        CborValue::Map(entries) => {
+            let mut obj = serde_json::Map::with_capacity(entries.len());
+            for (k, v) in entries {
+                let key = match k {
+                    CborValue::Text(s) => s.clone(),
+                    other => format!("{other:?}"),
+                };
+                obj.insert(key, cbor_to_json(v));
+            }
+            JsonValue::Object(obj)
+        }
+
+        // RFC 3339 datetime, carried as text.
+        CborValue::Tag(0, inner) => match inner.as_ref() {
+            CborValue::Text(s) => JsonValue::String(s.clone()),
+            other => cbor_to_json(other),
+        },
+        // NONE.
+        CborValue::Tag(6, _) => JsonValue::Null,
+        // Record id: Tag(8, [table, id]) -> "table:id".
+        CborValue::Tag(8, inner) => match inner.as_ref() {
+            CborValue::Array(parts) if parts.len() == 2 => match (&parts[0], &parts[1]) {
+                (CborValue::Text(table), CborValue::Text(id)) => {
+                    JsonValue::String(format!("{table}:{id}"))
+                }
+                _ => cbor_to_json(inner),
+            },
+            other => cbor_to_json(other),
+        },
+        // UUID, carried as text.
+        CborValue::Tag(9, inner) => match inner.as_ref() {
+            CborValue::Text(s) => JsonValue::String(s.clone()),
+            other => cbor_to_json(other),
+        },
+        // Decimal, carried as text.
+        CborValue::Tag(10, inner) => match inner.as_ref() {
+            CborValue::Text(s) => JsonValue::String(s.clone()),
+            other => cbor_to_json(other),
+        },
+        // Compact datetime: Tag(12, [seconds, nanos]) -> RFC 3339 string.
+        CborValue::Tag(12, inner) => compact_datetime_to_json(inner),
+        // Duration, carried as text.
+        CborValue::Tag(13, inner) => match inner.as_ref() {
+            CborValue::Text(s) => JsonValue::String(s.clone()),
+            other => cbor_to_json(other),
+        },
+        // Compact duration: Tag(14, [seconds, nanos]) -> ISO 8601 duration.
+        CborValue::Tag(14, inner) => compact_duration_to_json(inner),
+        // UUID, carried as 16 raw bytes.
+        CborValue::Tag(37, inner) => match inner.as_ref() {
+            CborValue::Bytes(b) if b.len() == 16 => uuid::Uuid::from_slice(b)
+                .map(|u| JsonValue::String(u.to_string()))
+                .unwrap_or_else(|_| cbor_to_json(inner)),
+            other => cbor_to_json(other),
+        },
+
+        // Unrecognised tag — recurse into the payload rather than dropping
+        // it silently, matching AnySurrealType's Display fallback.
+        CborValue::Tag(_, inner) => cbor_to_json(inner),
+
+        _ => JsonValue::Null,
+    }
+}
+
+fn integer_to_json(i: ciborium::value::Integer) -> JsonValue {
+    if let Ok(v) = i64::try_from(i) {
+        return JsonValue::Number(v.into());
+    }
+    if let Ok(v) = u64::try_from(i) {
+        return JsonValue::Number(v.into());
+    }
+    let raw: i128 = i.into();
+    serde_json::Number::from_f64(raw as f64)
+        .map(JsonValue::Number)
+        .unwrap_or(JsonValue::Null)
+}
+
+/// `[seconds, nanos]` → RFC 3339 string. Falls back to the raw array (the
+/// previous, broken behaviour) only if the shape or the timestamp itself is
+/// invalid, so a malformed value is still visible rather than silently lost.
+fn compact_datetime_to_json(inner: &CborValue) -> JsonValue {
+    let CborValue::Array(parts) = inner else {
+        return cbor_to_json(inner);
+    };
+    let [CborValue::Integer(secs), CborValue::Integer(nanos)] = parts.as_slice() else {
+        return cbor_to_json(inner);
+    };
+    let (Ok(secs), Ok(nanos)) = (i64::try_from(*secs), u32::try_from(*nanos)) else {
+        return cbor_to_json(inner);
+    };
+    chrono::DateTime::from_timestamp(secs, nanos)
+        .map(|dt| JsonValue::String(dt.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)))
+        .unwrap_or_else(|| cbor_to_json(inner))
+}
+
+/// `[seconds, nanos]` → an ISO 8601 duration string (`PT1H30M`), falling
+/// back to the raw array on an unexpected shape.
+fn compact_duration_to_json(inner: &CborValue) -> JsonValue {
+    let CborValue::Array(parts) = inner else {
+        return cbor_to_json(inner);
+    };
+    let [CborValue::Integer(secs), CborValue::Integer(nanos)] = parts.as_slice() else {
+        return cbor_to_json(inner);
+    };
+    let (Ok(secs), Ok(nanos)) = (i64::try_from(*secs), u32::try_from(*nanos)) else {
+        return cbor_to_json(inner);
+    };
+    let mut out = String::from("PT");
+    let (h, rem) = (secs / 3600, secs % 3600);
+    let (m, s) = (rem / 60, rem % 60);
+    if h != 0 {
+        out.push_str(&format!("{h}H"));
+    }
+    if m != 0 {
+        out.push_str(&format!("{m}M"));
+    }
+    if s != 0 || nanos != 0 || (h == 0 && m == 0) {
+        if nanos == 0 {
+            out.push_str(&format!("{s}S"));
+        } else {
+            out.push_str(&format!("{s}.{nanos:09}S"));
+        }
+    }
+    JsonValue::String(out)
 }
 
 fn json_to_cbor(val: JsonValue) -> CborValue {
@@ -126,5 +273,99 @@ impl Expressive<AnySurrealType> for AnySurrealType {
             "{}",
             vec![vantage_expressions::ExpressiveEnum::Scalar(self.clone())],
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_datetime_becomes_rfc3339_not_a_raw_array() {
+        // Tag(12, [seconds, nanos]) — SurrealDB's compact datetime encoding.
+        // 1735689600 = 2025-01-01T00:00:00Z.
+        let cbor = CborValue::Tag(
+            12,
+            Box::new(CborValue::Array(vec![
+                CborValue::Integer(1_735_689_600i64.into()),
+                CborValue::Integer(0i64.into()),
+            ])),
+        );
+        let json = cbor_to_json(&cbor);
+        assert_eq!(json, JsonValue::String("2025-01-01T00:00:00Z".to_string()));
+    }
+
+    #[test]
+    fn compact_datetime_with_nanos() {
+        let cbor = CborValue::Tag(
+            12,
+            Box::new(CborValue::Array(vec![
+                CborValue::Integer(1_735_689_600i64.into()),
+                CborValue::Integer(500_000_000i64.into()),
+            ])),
+        );
+        let json = cbor_to_json(&cbor);
+        assert_eq!(json.as_str().unwrap(), "2025-01-01T00:00:00.500Z");
+    }
+
+    #[test]
+    fn rfc3339_datetime_tag_passes_through_as_string() {
+        let cbor = CborValue::Tag(
+            0,
+            Box::new(CborValue::Text("2025-01-01T00:00:00Z".to_string())),
+        );
+        assert_eq!(
+            cbor_to_json(&cbor),
+            JsonValue::String("2025-01-01T00:00:00Z".to_string())
+        );
+    }
+
+    #[test]
+    fn record_id_becomes_table_colon_id() {
+        let cbor = CborValue::Tag(
+            8,
+            Box::new(CborValue::Array(vec![
+                CborValue::Text("login_audit".to_string()),
+                CborValue::Text("abc123".to_string()),
+            ])),
+        );
+        assert_eq!(
+            cbor_to_json(&cbor),
+            JsonValue::String("login_audit:abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn compact_duration_becomes_iso8601() {
+        let cbor = CborValue::Tag(
+            14,
+            Box::new(CborValue::Array(vec![
+                CborValue::Integer(5400i64.into()), // 1h30m
+                CborValue::Integer(0i64.into()),
+            ])),
+        );
+        assert_eq!(cbor_to_json(&cbor), JsonValue::String("PT1H30M".to_string()));
+    }
+
+    #[test]
+    fn any_surreal_type_json_conversion_uses_cbor_to_json() {
+        let any = AnySurrealType::from_cbor(&CborValue::Tag(
+            12,
+            Box::new(CborValue::Array(vec![
+                CborValue::Integer(1_735_689_600i64.into()),
+                CborValue::Integer(0i64.into()),
+            ])),
+        ))
+        .unwrap();
+        let json: JsonValue = any.into();
+        assert_eq!(json, JsonValue::String("2025-01-01T00:00:00Z".to_string()));
+    }
+
+    #[test]
+    fn plain_values_still_convert_correctly() {
+        assert_eq!(cbor_to_json(&CborValue::Integer(42i64.into())), JsonValue::from(42));
+        assert_eq!(cbor_to_json(&CborValue::Text("hi".into())), JsonValue::from("hi"));
+        assert_eq!(cbor_to_json(&CborValue::Bool(true)), JsonValue::from(true));
+        assert_eq!(cbor_to_json(&CborValue::Null), JsonValue::Null);
     }
 }


### PR DESCRIPTION
## Summary
- `AnySurrealType`'s `From<AnySurrealType> for serde_json::Value` round-tripped through a plain `ciborium`/`serde` re-encode, which drops CBOR tags entirely.
- SurrealDB's compact datetime encoding (`Tag(12, [seconds, nanos])`) surfaced as the raw `[seconds, nanos]` array in any JSON-facing read (e.g. table grids), instead of a timestamp — reported as `at` columns in a Vantage UI audit table showing `[num, num]`.
- Replaced the round-trip with a tag-aware `cbor_to_json` converter that renders each SurrealDB tag the way SurrealDB's own JSON API would: RFC 3339 strings for datetimes, `table:id` for record ids, plain strings for UUIDs/decimals/durations, ISO 8601 for compact durations, and unknown tags recurse into their payload instead of losing it.
- vantage-surrealdb 0.6.2 → 0.6.3, changelog entry.

## Test plan
- [x] New unit tests in `vantage-surrealdb/src/types/value.rs` cover: compact datetime → RFC 3339 (the reported bug), compact datetime with sub-second precision, RFC 3339 tag pass-through, record id → `table:id`, compact duration → ISO 8601, and existing plain-value conversions.
- [x] `cargo test -p vantage-surrealdb --lib types::` passes (8/8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON conversion for SurrealDB values.
  - Preserved special values such as datetimes, durations, record IDs, UUIDs, and decimals.
  - Datetimes now use RFC 3339 formatting, durations use ISO 8601 formatting, and record IDs retain the `table:id` format.

- **Documentation**
  - Added release notes for version 0.6.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->