### PR TITLE
surrealdb/api-client: expr/lazy computed columns, id coercion, cold-cache seed notify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.7 — 2026-07-20
+
+- `lazy:` computed columns on REST tables, behind the new `rhai` feature — a
+  Rhai script runs per returned record via `vantage-vista`'s shared
+  lazy-expression evaluator. The windowed fetch path (`fetch_window`) applies
+  them directly, since it bypasses `list_values` where they'd normally run.
+
 ## 0.6.6 — 2026-07-16
 
 - GraphQL CBOR bridges and the REST HTTP→CBOR boundary use the shared `vantage-types`

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.6"
+version = "0.6.7"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
+
+[features]
+# `lazy:` computed columns on REST tables — Rhai scripts run per returned
+# record via vantage-vista's shared lazy-expression evaluator.
+rhai = ["vantage-vista/rhai"]
 
 [dependencies]
 async-trait = "0.1"

--- a/vantage-api-client/src/rest/vista/factory.rs
+++ b/vantage-api-client/src/rest/vista/factory.rs
@@ -229,6 +229,9 @@ impl RestApiVistaFactory {
             if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
                 table.add_title_field(name);
             }
+            if let Some(code) = &col_spec.lazy {
+                add_lazy_column(&mut table, name, code)?;
+            }
         }
 
         if !table.columns().contains_key(&id_column) {
@@ -241,6 +244,35 @@ impl RestApiVistaFactory {
 
         Ok(table)
     }
+}
+
+/// Lower a column's `lazy:` script onto the table — a Rhai closure run in
+/// Rust on each returned record (`row` in scope), never sent to the API.
+/// The REST carrier is already CBOR, so no per-value conversion is needed.
+#[cfg(feature = "rhai")]
+fn add_lazy_column(table: &mut Table<RestApi, EmptyEntity>, name: &str, code: &str) -> Result<()> {
+    let script = vantage_vista::lazy_value_closure(code.to_string());
+    table.add_lazy_expression(
+        name,
+        Arc::new(move |record| {
+            let row = record.clone();
+            let script = script.clone();
+            Box::pin(async move { script(&row) })
+        }),
+    );
+    Ok(())
+}
+
+#[cfg(not(feature = "rhai"))]
+fn add_lazy_column(
+    _table: &mut Table<RestApi, EmptyEntity>,
+    name: &str,
+    _code: &str,
+) -> Result<()> {
+    Err(error!(
+        "column declares a `lazy:` script but vantage-api-client was built without the `rhai` feature",
+        column = name
+    ))
 }
 
 /// Pick the id column from an `id_column:` field or the first column

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -155,7 +155,14 @@ impl TableShell for RestApiTableShell {
                 self.table.conditions(),
             )
             .await?;
-        Ok(records.into_iter().collect())
+        // This path fetches straight from the API layer (windowed), so the
+        // table's `list_values` never runs — apply lazy computed columns
+        // here or `lazy:` cells stay empty in the lazily-scrolled grid.
+        let mut records: Vec<(String, Record<CborValue>)> = records.into_iter().collect();
+        for (_, rec) in records.iter_mut() {
+            self.table.apply_lazy_expressions(rec).await?;
+        }
+        Ok(records)
     }
 
     fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.20 — 2026-07-20
+
+- A detached lens `on_start` seed now announces itself once it lands
+  (`notify_dataset_changed`). The seed writes through the raw cache with
+  no events, so a scenery that opened over the still-cold cache previously
+  rendered zero rows until a manual refresh.
+
 ## 0.6.19 — 2026-07-17
 
 - Docs: qualify the `VistaChange` intra-doc link in `Dio::watch` (rustdoc

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.19"
+version = "0.6.20"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -71,10 +71,18 @@ impl Lens {
                 let dio_for_task = dio.clone();
                 let lens_for_task = self.clone();
                 self.runtime.spawn(async move {
-                    if let Some(cb) = lens_for_task.callbacks.on_start.as_ref()
-                        && let Err(e) = cb(&dio_for_task).await
-                    {
-                        tracing::error!(error = %e, "on_start callback failed");
+                    if let Some(cb) = lens_for_task.callbacks.on_start.as_ref() {
+                        match cb(&dio_for_task).await {
+                            // The detached seed writes through the raw cache
+                            // (no events), and any scenery that opened over
+                            // the still-cold cache rendered zero rows —
+                            // announce the landed dataset or those sceneries
+                            // stay blank until a manual refresh.
+                            Ok(()) => dio_for_task.notify_dataset_changed(),
+                            Err(e) => {
+                                tracing::error!(error = %e, "on_start callback failed");
+                            }
+                        }
                     }
                 });
             }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.6.5 — 2026-07-20
+
+- `expr:` computed columns: a column's Rhai script now lowers into a
+  server-side `(<expr>) AS <name>` projection, including traversal through
+  record links (e.g. `ident("batch")["name"]`). The Rhai indexer that builds
+  those paths (`t["col"]`) now escapes each segment separately instead of
+  joining them into one literal identifier, so `batch.name` renders as a
+  real traversal rather than a single escaped field name.
+- `get_table_value` (single-record reads) now runs the table's own narrowed
+  `select` instead of a bare `SELECT * FROM ONLY <id>`, so `expr:` columns
+  project on the detail read path too, not just lists.
+- A query-sourced table can key rows by a plain scalar (a `GROUP BY month`
+  aggregate's id is text like `"2025-08"`); those rows now synthesize a
+  `Thing` from the table name instead of being dropped for lacking a
+  record-id-shaped id field.
+- An `eq` condition on the id column coerces a string value (bare key or
+  `table:key`) into a `Thing` before comparing — SurrealDB compares record
+  ids by type, so a quoted string never matched. This is what lets a
+  cross-persistence relation narrow a surreal table from a plain string held
+  by another backend's row.
+
 ## 0.6.4 — 2026-07-16
 
 - CBOR→JSON conversion is the shared `vantage-types` walker under a local

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.4"
+version = "0.6.5"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/rhai_engine/constructors.rs
+++ b/vantage-surrealdb/src/rhai_engine/constructors.rs
@@ -51,9 +51,13 @@ pub fn ident_as_alias(id: Identifier, alias: &str) -> Expr {
     )
 }
 
-pub fn ident_index(id: Identifier, col: &str) -> RhaiIdent {
-    let prefix = id.expr().preview();
-    RhaiIdent(Identifier::new(format!("{}.{}", prefix, col)))
+/// Field access on an identifier (the string `[...]` indexer):
+/// `ident("batch")["name"]` → the path `batch.name`, each segment escaped
+/// separately. Joining into a single `Identifier` would render the whole
+/// path as one ⟨batch.name⟩-escaped name — a literal field lookup, not a
+/// record-link traversal.
+pub fn ident_index(id: Identifier, col: &str) -> RhaiExpr {
+    RhaiExpr(id.dot(col))
 }
 
 pub fn expr_as_alias(e: Expr, alias: &str) -> Expr {

--- a/vantage-surrealdb/src/rhai_engine/mod.rs
+++ b/vantage-surrealdb/src/rhai_engine/mod.rs
@@ -152,7 +152,7 @@ pub fn register_surreal_onto(engine: &mut rhai::Engine) {
         });
 
         // ── Indexer: t["col"] / expr["field"] ─────────────────
-        engine.register_indexer_get(|id: &mut Id, col: &str| -> Id {
+        engine.register_indexer_get(|id: &mut Id, col: &str| -> Ex {
             crate::rhai_engine::constructors::ident_index(id.0.clone(), col)
         });
         engine.register_indexer_get(|e: &mut Ex, col: &str| -> Ex {

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -23,9 +23,15 @@ use crate::thing::Thing;
 use crate::types::{AnySurrealType, SurrealType};
 
 /// Parse a CBOR map into a Record and optionally extract the ID field as a Thing.
+///
+/// The id field is usually a record id (`Tag(8)` or a `table:key` string),
+/// but a query-sourced table may key rows by a plain scalar — a `GROUP BY
+/// month` aggregate's id is the text `"2025-08"`. Those synthesize a Thing
+/// under `table_name` so every row still gets an addressable id.
 fn parse_cbor_row(
     map: Vec<(ciborium::Value, ciborium::Value)>,
     id_field_name: &str,
+    table_name: &str,
 ) -> (Option<Thing>, Record<AnySurrealType>) {
     let mut fields = IndexMap::new();
     let mut thing: Option<Thing> = None;
@@ -36,7 +42,13 @@ fn parse_cbor_row(
             _ => continue,
         };
         if key == id_field_name {
-            thing = Thing::from_cbor(v.clone());
+            thing = Thing::from_cbor(v.clone()).or_else(|| match &v {
+                ciborium::Value::Text(s) => Some(Thing::new(table_name, s.clone())),
+                ciborium::Value::Integer(i) => {
+                    Some(Thing::new(table_name, i128::from(*i).to_string()))
+                }
+                _ => None,
+            });
         }
         match AnySurrealType::from_cbor(&v) {
             Some(val) => {
@@ -175,7 +187,7 @@ impl TableSource for SurrealDB {
                 _ => continue,
             };
 
-            let (thing, record) = parse_cbor_row(map, &id_field_name);
+            let (thing, record) = parse_cbor_row(map, &id_field_name, table.table_name());
             let id = thing.ok_or_else(|| {
                 error!(
                     "list_table_values: row missing id field",
@@ -196,28 +208,39 @@ impl TableSource for SurrealDB {
     where
         E: Entity<Self::Value>,
     {
-        let query = crate::surreal_expr!("SELECT * FROM ONLY {}", (id.clone()));
-        let result = self.execute(&query).await?;
+        let id_field_name = table
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
 
-        // `SELECT ... FROM ONLY` returns NONE (Tag(6, _)) or plain Null when
-        // no row matches.
-        let value = result.into_value();
-        if matches!(value, ciborium::Value::Null | ciborium::Value::Tag(6, _)) {
+        // Narrow the table's own select rather than `SELECT * FROM ONLY <id>`
+        // — the table's select projects computed `with_expression` columns
+        // (e.g. record-link lookups), which a bare `*` fetch would silently
+        // drop from the single-record read path.
+        let id_column: Column<AnySurrealType> = Column::new(&id_field_name);
+        let narrowed = table
+            .clone()
+            .with_condition(SurrealOperation::eq(&id_column, id.clone()));
+        let mut select = narrowed.select();
+        select.limit = Some(1);
+        let result = self.execute(&select.expr()).await?;
+
+        let arr = result
+            .into_value()
+            .into_array()
+            .map_err(|_| error!("get_table_value: expected array result"))?;
+
+        let Some(item) = arr.into_iter().next() else {
             return Ok(None);
-        }
-
-        let map = value.into_map().map_err(|_| {
+        };
+        let map = item.into_map().map_err(|_| {
             error!(
                 "get_table_value: expected map result",
                 id = format!("{:?}", id)
             )
         })?;
 
-        let id_field_name = table
-            .id_field()
-            .map(|c| c.name().to_string())
-            .unwrap_or_else(|| "id".to_string());
-        let (_thing, record) = parse_cbor_row(map, &id_field_name);
+        let (_thing, record) = parse_cbor_row(map, &id_field_name, table.table_name());
         Ok(Some(record))
     }
 
@@ -252,7 +275,7 @@ impl TableSource for SurrealDB {
             _ => return Ok(None),
         };
 
-        let (thing, record) = parse_cbor_row(map, &id_field_name);
+        let (thing, record) = parse_cbor_row(map, &id_field_name, table.table_name());
         match thing {
             Some(id) => Ok(Some((id, record))),
             None => Ok(None),
@@ -333,7 +356,7 @@ impl TableSource for SurrealDB {
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
-        let (_thing, rec) = parse_cbor_row(map, &id_field);
+        let (_thing, rec) = parse_cbor_row(map, &id_field, table.table_name());
         Ok(rec)
     }
 
@@ -360,7 +383,7 @@ impl TableSource for SurrealDB {
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
-        let (_thing, rec) = parse_cbor_row(map, &id_field);
+        let (_thing, rec) = parse_cbor_row(map, &id_field, table.table_name());
         Ok(rec)
     }
 
@@ -380,7 +403,7 @@ impl TableSource for SurrealDB {
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
-        let (_thing, rec) = parse_cbor_row(map, &id_field);
+        let (_thing, rec) = parse_cbor_row(map, &id_field, table.table_name());
         Ok(rec)
     }
 
@@ -419,7 +442,7 @@ impl TableSource for SurrealDB {
         let query = Expression::new(format!("{} RETURN id", base.template), base.parameters);
         let result = self.execute(&query).await?;
         let map = extract_first_map(result)?;
-        let (thing, _rec) = parse_cbor_row(map, "id");
+        let (thing, _rec) = parse_cbor_row(map, "id", table.table_name());
         thing.ok_or_else(|| error!("insert_table_return_id_value: no id returned"))
     }
 

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -225,6 +225,9 @@ pub(crate) fn build_surreal_table(
         if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
             table.add_title_field(name);
         }
+        if let Some(code) = &col_spec.expr {
+            table = add_expr_column(table, name, code)?;
+        }
     }
 
     let id_column = resolve_id_column(spec);
@@ -262,6 +265,31 @@ pub(crate) fn build_surreal_table(
 
     let table = table.with_contained_specs(&spec.contained, build_column)?;
     Ok(table)
+}
+
+/// Lower a column's `expr:` script into a server-side computed column via
+/// `Table::with_expression` — the select then projects `(<expr>) AS <name>`
+/// instead of the bare field.
+#[cfg(feature = "rhai")]
+fn add_expr_column(
+    table: Table<SurrealDB, EmptyEntity>,
+    name: &str,
+    code: &str,
+) -> Result<Table<SurrealDB, EmptyEntity>> {
+    let expr = crate::vista::rhai_source::eval_to_expr(code)?;
+    Ok(table.with_expression(name, move |_| expr.clone()))
+}
+
+#[cfg(not(feature = "rhai"))]
+fn add_expr_column(
+    _table: Table<SurrealDB, EmptyEntity>,
+    name: &str,
+    _code: &str,
+) -> Result<Table<SurrealDB, EmptyEntity>> {
+    Err(error!(
+        "column declares an `expr:` script but vantage-surrealdb was built without the `rhai` feature",
+        column = name
+    ))
 }
 
 /// Build a query-sourced table from a `rhai:` script.
@@ -485,6 +513,84 @@ mod tests {
         let map: IndexMap<String, SurrealVistaSpec> = specs.into_iter().collect();
         let map = Arc::new(map);
         Arc::new(move |name: &str| map.get(name).cloned())
+    }
+
+    #[cfg(feature = "rhai")]
+    #[test]
+    fn expr_column_projects_into_select() {
+        let yaml = r#"
+name: tag
+columns:
+  id: { type: string, flags: [id] }
+  batch: { type: string }
+  batch_name: { type: string, expr: 'ident("batch")["name"]' }
+"#;
+        let spec = parse(yaml);
+        let table = build_surreal_table(&spec, test_db(), None).expect("build");
+        let preview = table.select().preview();
+        println!("QUERY: {preview}");
+        assert!(
+            preview.contains("batch.name") && preview.contains("AS batch_name"),
+            "expr column must project as (batch.name) AS batch_name, got: {preview}"
+        );
+    }
+
+    #[test]
+    fn has_many_traversal_condition_from_thing_and_string_ids() {
+        let batch_yaml = r#"
+name: batch
+columns:
+  id: { type: string, flags: [id] }
+  name: { type: string }
+references:
+  tags:
+    table: tag
+    kind: has_many
+    foreign_key: batch
+"#;
+        let tag_yaml = r#"
+name: tag
+columns:
+  id: { type: string, flags: [id] }
+  batch: { type: string }
+"#;
+        let batch_spec = parse(batch_yaml);
+        let tag_spec = parse(tag_yaml);
+        let resolver = registry_resolver(vec![("tag".to_string(), tag_spec)]);
+        let table =
+            build_surreal_table(&batch_spec, test_db(), Some(resolver)).expect("build batch");
+
+        // Parent row with a Tag(8) record id (what SurrealDB actually returns).
+        let thing_cbor = ciborium::Value::Tag(
+            8,
+            Box::new(ciborium::Value::Array(vec![
+                ciborium::Value::Text("batch".into()),
+                ciborium::Value::Text("0jz7".into()),
+            ])),
+        );
+        let mut row: vantage_types::Record<AnySurrealType> = vantage_types::Record::new();
+        row.insert("id".into(), AnySurrealType::from(thing_cbor));
+        let target = table
+            .get_ref_from_row::<EmptyEntity>("tags", &row)
+            .expect("traverse");
+        let q = target.select().preview();
+        println!("THING QUERY: {q}");
+        assert!(
+            q.contains("batch = batch:0jz7"),
+            "Thing id must render as a record literal, got: {q}"
+        );
+
+        // Parent row with the id as a plain string (e.g. re-parsed from text).
+        let mut row: vantage_types::Record<AnySurrealType> = vantage_types::Record::new();
+        row.insert(
+            "id".into(),
+            AnySurrealType::from(ciborium::Value::Text("batch:0jz7".into())),
+        );
+        let target = table
+            .get_ref_from_row::<EmptyEntity>("tags", &row)
+            .expect("traverse");
+        let q = target.select().preview();
+        println!("STRING QUERY: {q}");
     }
 
     #[test]

--- a/vantage-surrealdb/src/vista/rhai_source.rs
+++ b/vantage-surrealdb/src/vista/rhai_source.rs
@@ -39,3 +39,28 @@ pub(crate) fn eval_to_select(
         )
     })
 }
+
+/// Run `code`, returning the expression it builds — the vocabulary is the
+/// same as query-sourced scripts (`ident(...)`, operators, `expr("raw")`).
+/// Accepts a bare identifier result (`ident("batch")["name"]` yields an
+/// expression, `ident("x")` alone an identifier) so both shapes work.
+pub(crate) fn eval_to_expr(code: &str) -> vantage_core::Result<crate::Expr> {
+    use vantage_expressions::Expressive as _;
+    let engine = __create_engine();
+    let value = engine.eval::<rhai::Dynamic>(code).map_err(|e| {
+        vantage_core::error!(
+            "Rhai column expression failed to evaluate",
+            detail = e.to_string()
+        )
+    })?;
+    if value.is::<Ex>() {
+        return Ok(value.cast::<Ex>().into_inner());
+    }
+    if value.is::<Id>() {
+        return Ok(value.cast::<Id>().into_inner().expr());
+    }
+    Err(vantage_core::error!(
+        "Rhai column expression must evaluate to an expression or identifier",
+        got = value.type_name()
+    ))
+}

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -222,7 +222,19 @@ where
             .get(field)
             .ok_or_else(|| error!("Unknown column for eq condition", field = field))?
             .clone();
-        let surreal_value = AnySurrealType::from(value.clone());
+        // Id-column comparisons coerce a string value into a Thing —
+        // SurrealDB compares record ids by type, so a quoted string
+        // (`id = "MG78-N25S"` or `id = "tag:MG78-N25S"`) never matches.
+        // `parse_id` accepts both the bare-key and `table:key` forms.
+        // This is what lets a cross-persistence relation narrow a surreal
+        // table from a plain string held by another backend's row.
+        let id_field = self.metadata.id_column.as_deref().unwrap_or("id");
+        let surreal_value = match value {
+            CborValue::Text(s) if field == id_field => {
+                AnySurrealType::from(self.parse_id(s).to_cbor())
+            }
+            _ => AnySurrealType::from(value.clone()),
+        };
         self.table.add_condition(column.eq(surreal_value));
         Ok(())
     }

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.11 — 2026-07-20
+
+- `Table::apply_lazy_expressions` is public — a driver shell that bypasses
+  the `list_values` read path (e.g. a REST shell's windowed fetch) can now
+  apply `lazy:` columns to the rows it fetches directly.
+
 ## 0.6.10 — 2026-07-15
 
 - `Table::with_lazy_expression(name, callback)` — a column computed in Rust on

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -152,7 +152,9 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     /// Each callback borrows the record as built so far; the value it
     /// returns is inserted under the expression's name before the next
     /// callback runs. See [`Self::with_lazy_expression`].
-    pub(crate) async fn apply_lazy_expressions(
+    /// Public so driver shells that bypass the `list_values` read path
+    /// (e.g. a REST shell's windowed fetch) can still apply lazy columns.
+    pub async fn apply_lazy_expressions(
         &self,
         record: &mut vantage_types::Record<T::Value>,
     ) -> vantage_core::Result<()> {

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.12 — 2026-07-20
+
+- `ColumnSpec::expr` / `with_expr` — a server-side computed column: a Rhai
+  script evaluated once at build time into a query expression (not per-row),
+  so it can traverse record links or call backend functions and still
+  participate in the query itself. Complements the existing per-row `lazy:`.
+
 ## 0.6.11 — 2026-07-16
 
 - Rhai `cbor_to_dynamic` renders tagged values in their presentation form (record ids

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/spec.rs
+++ b/vantage-vista/src/spec.rs
@@ -97,6 +97,15 @@ pub struct ColumnSpec<C = NoExtras> {
     /// `Table::add_lazy_expression`; never part of the backend query.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lazy: Option<String>,
+    /// Rhai script for a *server-side* computed column. Evaluated once at
+    /// build time with the driver's expression vocabulary (`ident(...)`,
+    /// operators, `expr("raw")`, …) into a query expression, then lowered
+    /// via `Table::with_expression` — the backend projects it as
+    /// `(<expr>) AS <column>`. Unlike `lazy:` it participates in the
+    /// query, so it can traverse record links or call backend functions.
+    /// Computed columns are read-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expr: Option<String>,
     #[serde(flatten, default)]
     pub driver: C,
 }
@@ -108,6 +117,7 @@ impl<C: Default> ColumnSpec<C> {
             flags: Vec::new(),
             references: None,
             lazy: None,
+            expr: None,
             driver: C::default(),
         }
     }
@@ -124,6 +134,11 @@ impl<C: Default> ColumnSpec<C> {
 
     pub fn with_lazy(mut self, script: impl Into<String>) -> Self {
         self.lazy = Some(script.into());
+        self
+    }
+
+    pub fn with_expr(mut self, script: impl Into<String>) -> Self {
+        self.expr = Some(script.into());
         self
     }
 }


### PR DESCRIPTION
## Summary

Engine work backing vantage-ui's golf-2 app build (server-side/client-side computed columns, record-id handling, and a cold-cache fix), surfaced through the `vantage-ui` `[patch.crates-io]`.

- **`vantage-vista` 0.6.12** — `ColumnSpec::expr`/`with_expr`: a server-side computed column, a Rhai script evaluated once at build time into a query expression (participates in the query itself, unlike the existing per-row `lazy:`).
- **`vantage-surrealdb` 0.6.5** — lowers `expr:` into `(<expr>) AS <name>` projections, including traversal through record links; fixes the Rhai indexer (`t["col"]`) escaping each path segment separately instead of joining into one literal identifier; `get_table_value` now runs the table's own narrowed `select` so `expr:` columns also project on single-record reads; scalar-keyed rows (e.g. a `GROUP BY month` aggregate) synthesize a `Thing` instead of being dropped; an `eq` condition on the id column coerces a string value into a `Thing` before comparing.
- **`vantage-api-client` 0.6.7** — `lazy:` computed columns on REST tables behind a new `rhai` feature; the windowed fetch path applies them directly since it bypasses `list_values`.
- **`vantage-table` 0.6.11** — `apply_lazy_expressions` made `pub` so driver shells with their own read path (e.g. the REST windowed fetch above) can apply `lazy:` columns.
- **`vantage-diorama` 0.6.20** — a detached lens `on_start` seed now announces itself once landed, fixing a cold-cache render (zero rows until manual refresh) for sceneries that opened while the seed was still in flight.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql --exclude bakery_model3 --exclude vantage-mongodb --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --workspace` (with the same excludes) — all green
- [x] `cargo doc` (with the same excludes), `-D warnings` — clean
- [x] `cargo test -p vantage-surrealdb -p surreal-client --lib` (default features) and again with `--features rhai` — green (2 pre-existing DB-integration tests fail locally without a running SurrealDB, as expected; `surreal.yaml` covers those in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-side computed columns using `expr:` scripts for backend query execution.
  * Added support for per-record `lazy:` computed columns on REST tables.
  * Enabled Rhai-backed computed-column evaluation.
* **Bug Fixes**
  * Windowed REST results now correctly populate lazy computed fields.
  * Improved SurrealDB computed column projection, record-id handling, traversal behavior, and id filtering/coercion.
  * Fixed detached startup behavior to update scenery after the `on_start` seed is written.
* **Chores**
  * Updated component versions and release documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->