### PR TITLE
Implicit references — dotted active columns traverse has_one relations (VAN-102)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "bson",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/bakery_model3/examples/implicit-references.rs
+++ b/bakery_model3/examples/implicit-references.rs
@@ -1,0 +1,89 @@
+//! Implicit references — dotted active columns (VAN-102).
+//!
+//! A dotted name in `with_active_columns` traverses declared `has_one`
+//! relations and imports the target's field as a read-only column, aliased
+//! under the literal dotted name. `order.client.name` is one hop;
+//! `order.client.bakery.name` is two. SQL lowers each into a nested correlated
+//! scalar subquery; SurrealDB (see the closing note) lowers into a native
+//! idiom path.
+//!
+//! Run: `cargo run -p bakery_model3 --example implicit-references`
+
+use bakery_model3::*;
+use vantage_core::Result;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_expressions::{ExprDataSource, Expressive};
+use vantage_sql::sqlite_expr;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // A self-contained in-memory database, seeded to mirror the model:
+    //   client_order.client_id -> client.id,  client.bakery_id -> bakery.id
+    let db = SqliteDB::connect("sqlite::memory:")
+        .await
+        .map_err(|e| vantage_core::error!("connect failed", details = e.to_string()))?;
+
+    db.execute(&sqlite_expr!(
+        "CREATE TABLE bakery (id TEXT PRIMARY KEY, name TEXT NOT NULL, profit_margin INTEGER NOT NULL DEFAULT 0)"
+    ))
+    .await?;
+    db.execute(&sqlite_expr!(
+        "CREATE TABLE client (id TEXT PRIMARY KEY, name TEXT NOT NULL, bakery_id TEXT)"
+    ))
+    .await?;
+    db.execute(&sqlite_expr!(
+        "CREATE TABLE client_order (id TEXT PRIMARY KEY, client_id TEXT, is_deleted BOOLEAN NOT NULL DEFAULT 0)"
+    ))
+    .await?;
+
+    db.execute(&sqlite_expr!(
+        "INSERT INTO bakery (id, name) VALUES ({}, {})",
+        "b1",
+        "Sunrise Bakery"
+    ))
+    .await?;
+    db.execute(&sqlite_expr!(
+        "INSERT INTO client (id, name, bakery_id) VALUES ({}, {}, {})",
+        "c1",
+        "Marty",
+        "b1"
+    ))
+    .await?;
+    db.execute(&sqlite_expr!(
+        "INSERT INTO client_order (id, client_id) VALUES ({}, {}), ({}, {})",
+        "o1",
+        "c1",
+        "o2",
+        "c1"
+    ))
+    .await?;
+
+    // Plain names restrict projection; dotted names traverse has_one relations.
+    let orders = Order::sqlite_table(db).with_active_columns(&[
+        "id",
+        "client_id",
+        "client.name",        // one hop:  client_order -> client
+        "client.bakery.name", // two hops: client_order -> client -> bakery
+    ])?;
+
+    println!("-[ lowered SQL ]------------------------------------");
+    println!("{}\n", orders.select().expr().preview());
+
+    println!("-[ rows ]-------------------------------------------");
+    for row in orders.list_values().await?.values() {
+        // Flat keys, literally the dotted names.
+        let get = |k: &str| row.get(k).map(|v| format!("{v}")).unwrap_or_default();
+        println!(
+            "  order {}: client.name={}, client.bakery.name={}",
+            get("id"),
+            get("client.name"),
+            get("client.bakery.name"),
+        );
+    }
+
+    // The same call against `Order::surreal_table(db)` lowers `client.name` and
+    // `client.bakery.name` into SurrealQL idiom paths (each segment escaped
+    // separately) instead of nested subqueries.
+
+    Ok(())
+}

--- a/docs4/src/mda.md
+++ b/docs4/src/mda.md
@@ -169,6 +169,43 @@ These fields appear in `ReadableValueSet` results alongside physical columns.
 
 ---
 
+## Implicit references — dotted columns
+
+Surfacing a related row's field is common enough that it has a declarative form. A **dotted name** in
+`with_active_columns` traverses declared `has_one` relations and imports the target's field as a
+read-only column, aliased under the literal dotted name — no hand-written expression:
+
+```rust
+let orders = Order::sqlite_table(db)
+    .with_active_columns(&["id", "client.name", "client.bakery.name"])?;
+// SELECT id,
+//   (SELECT name FROM client WHERE client.id = client_order.client_id) AS "client.name",
+//   (SELECT name FROM bakery WHERE bakery.id = client.bakery_id …)     AS "client.bakery.name"
+// FROM client_order
+```
+
+`client.name` is one hop; `client.bakery.name` recurses through two. Each backend lowers the
+traversal into its own query — SQL nests correlated scalar subqueries, SurrealDB emits a native idiom
+path (`client.name`, each segment escaped separately). The row comes back with a **flat key** equal to
+the dotted name (`row.get("client.bakery.name")`).
+
+A plain (non-dotted) entry simply restricts projection to that column — `with_active_columns` is also
+how you narrow a wide table to the columns you actually read. Everything is validated when the table
+is built, so mistakes surface immediately rather than at fetch time:
+
+- an unknown column or relation is a **build-time error**;
+- a `has_many` hop is rejected (traversal is `has_one`-only — a to-many field is a set, not a value);
+- a backend that can lower neither a subquery nor an idiom path (MongoDB, CSV, REST) refuses dotted
+  names up front; same-datasource only.
+
+Imported columns are read-only: they are flagged `calculated` for consumers and stripped from every
+write payload, so a read-modify-save round-trip never tries to persist `client.name` as a real field.
+This is the declarative counterpart to the manual `with_expression` + `get_subquery_as` recipe above —
+reach for `with_expression` when you need an arbitrary expression, and a dotted column when you just
+want a related field.
+
+---
+
 ## Connection management
 
 The model crate owns database connections. `bakery_model3` uses a `OnceLock<SurrealDB>` pattern for

--- a/docs4/src/new-persistence/step9-contained-relations.md
+++ b/docs4/src/new-persistence/step9-contained-relations.md
@@ -34,7 +34,7 @@ Almost all of it is backend-agnostic and already done:
   The closure builds the contained record's schema — same shape as `with_one`'s `build_target`,
   same type system, evaluated lazily. `vista_contained()` surfaces these as `ContainedSpec`s.
 
-- **The sub-Vista** is [`vantage_vista::build_contained_vista`]. It materializes the column's
+- **The sub-Vista** is `vantage_vista::build_contained_vista`. It materializes the column's
   records into an in-memory `ImTable`, serves reads from it, and on every write re-serializes the
   whole collection and calls a **writeback** closure. That writeback — patch the parent row's host
   column — is the only persistence-specific part you supply.

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.21 — 2026-07-21
+
+- The Dio shell passes `VistaCapabilities::can_traverse_in_columns` through from
+  the master vista unchanged (column traversal is lowered into the master's
+  query; the cache neither adds nor removes it).
+
 ## 0.6.20 — 2026-07-20
 
 - A detached lens `on_start` seed now announces itself once it lands

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -60,6 +60,9 @@ impl DioShell {
             can_traverse_to_record: master_caps.can_traverse_to_record,
             can_traverse_to_set: master_caps.can_traverse_to_set,
             can_build_ref_via_script: master_caps.can_build_ref_via_script,
+            // Column traversal is lowered into the master's query; the cache
+            // passes it through unchanged.
+            can_traverse_in_columns: master_caps.can_traverse_in_columns,
         };
         Self {
             dio,

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.3 — 2026-07-21
+
+- Docs: fixed rustdoc doc-comment links (`Vec<AnyMongoType>`, `MongoId::from_str`)
+  so the workspace docs book builds clean under `-D warnings`.
+
 ## 0.6.2 — 2026-07-16
 
 - `AnyMongoType`'s CBOR bridge uses the same structural bson↔cbor converters as the

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"

--- a/vantage-mongodb/src/types/value.rs
+++ b/vantage-mongodb/src/types/value.rs
@@ -28,7 +28,7 @@ impl MongoType for AnyMongoType {
     }
 }
 
-/// Vec<AnyMongoType> is a MongoType — used by column_table_values_expr to
+/// `Vec<AnyMongoType>` is a MongoType — used by column_table_values_expr to
 /// return a list of column values wrapped in an AnyMongoType.
 impl MongoType for Vec<AnyMongoType> {
     type Target = MongoTypeArrayMarker;
@@ -75,7 +75,7 @@ impl_from_for_any_mongo!(i32, i64, f64, bool, String, bson::oid::ObjectId);
 impl From<&str> for AnyMongoType {
     /// Converts a `&str` into an `AnyMongoType`. 24-character hex strings are
     /// treated as `ObjectId`, anything else stays a plain `String`. This mirrors
-    /// [`MongoId::from_str`] and makes id comparisons like `column.eq("68c1...")`
+    /// `MongoId::from_str` and makes id comparisons like `column.eq("68c1...")`
     /// work without an explicit `MongoId::parse` step.
     fn from(val: &str) -> Self {
         if val.len() == 24

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.11 — 2026-07-21
+
+- SQLite / Postgres / MySQL advertise `TableSource::supports_traversal`, so
+  implicit references (`Table::with_active_columns`) lower into nested
+  correlated scalar subqueries on their existing `related_correlated_condition`
+  — no native-path override needed. The vista factories advertise
+  `can_traverse_in_columns`.
+
 ## 0.6.10 — 2026-07-16
 
 - CBOR↔JSON bridge is the shared `vantage-types` walker under a local `SqlDialect`;

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -485,6 +485,10 @@ impl TableSource for MysqlDB {
         tgt_col.in_(fk_values.expr())
     }
 
+    fn supports_traversal(&self) -> bool {
+        true
+    }
+
     fn related_correlated_condition(
         &self,
         target_table: &str,

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -68,6 +68,7 @@ impl MysqlVistaFactory {
                 can_delete: !read_only,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
+                can_traverse_in_columns: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -465,6 +465,10 @@ impl TableSource for PostgresDB {
         tgt_col.in_(fk_values.expr())
     }
 
+    fn supports_traversal(&self) -> bool {
+        true
+    }
+
     fn related_correlated_condition(
         &self,
         target_table: &str,

--- a/vantage-sql/src/postgres/types/numbers.rs
+++ b/vantage-sql/src/postgres/types/numbers.rs
@@ -3,7 +3,7 @@
 //! Uses ciborium::Value (CBOR) as the underlying storage:
 //! - Integers → CborValue::Integer
 //! - Floats → CborValue::Float
-//! - Option<T> delegates to T, with Null for None
+//! - `Option<T>` delegates to `T`, with Null for None
 //!
 //! `from_cbor` accepts Text as a fallback — allows extraction from VARCHAR
 //! columns where the database returns strings instead of native numeric types.

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -73,6 +73,7 @@ impl PostgresVistaFactory {
                 can_fetch_window: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
+                can_traverse_in_columns: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-sql/src/primitives/fx.rs
+++ b/vantage-sql/src/primitives/fx.rs
@@ -8,7 +8,7 @@ use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 /// The function name is automatically uppercased. Arguments are expressions
 /// that get rendered comma-separated inside the parentheses.
 ///
-/// Prefer the [`fx!`] macro for ergonomic construction — it calls `.expr()`
+/// Prefer the `fx!` macro for ergonomic construction — it calls `.expr()`
 /// on each argument automatically.
 ///
 /// # Examples

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -414,6 +414,13 @@ impl TableSource for SqliteDB {
         tgt_col.in_(fk_values.expr())
     }
 
+    // Implicit references lower into the generic nested correlated-subquery
+    // chain built on `related_correlated_condition` below; no native path
+    // override is needed.
+    fn supports_traversal(&self) -> bool {
+        true
+    }
+
     fn related_correlated_condition(
         &self,
         target_table: &str,

--- a/vantage-sql/src/sqlite/types/numbers.rs
+++ b/vantage-sql/src/sqlite/types/numbers.rs
@@ -3,7 +3,7 @@
 //! Uses ciborium::Value (CBOR) as the underlying storage:
 //! - Integer types (i8..i64, u8..u32) → CborValue::Integer
 //! - Float types (f32, f64) → CborValue::Float
-//! - Option<T> delegates to T, with Null for None
+//! - `Option<T>` delegates to `T`, with Null for None
 //!
 //! `from_cbor` accepts Text as a fallback — allows extraction from TEXT
 //! columns where the database returns strings instead of native numeric types.

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -78,6 +78,7 @@ impl SqliteVistaFactory {
                 can_fetch_next: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
+                can_traverse_in_columns: true,
                 ..VistaCapabilities::default()
             },
             metadata,

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -24,6 +24,8 @@ mod sqlite {
     mod identifier;
     #[path = "2_insert.rs"]
     mod insert;
+    #[path = "8_implicit_references.rs"]
+    mod implicit_references;
     #[path = "5_invariants.rs"]
     mod invariants;
     #[path = "2_primitives.rs"]

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -22,10 +22,10 @@ mod sqlite {
     mod expressions;
     #[path = "2_identifier.rs"]
     mod identifier;
-    #[path = "2_insert.rs"]
-    mod insert;
     #[path = "8_implicit_references.rs"]
     mod implicit_references;
+    #[path = "2_insert.rs"]
+    mod insert;
     #[path = "5_invariants.rs"]
     mod invariants;
     #[path = "2_primitives.rs"]

--- a/vantage-sql/tests/sqlite/8_implicit_references.rs
+++ b/vantage-sql/tests/sqlite/8_implicit_references.rs
@@ -1,0 +1,203 @@
+//! Test 8: Implicit references — dotted active columns (VAN-102).
+//!
+//! A dotted name in `with_active_columns` traverses declared `has_one`
+//! relations and imports the target's field as a read-only column, lowered
+//! into a nested correlated scalar subquery. Uses a self-contained in-memory
+//! database so the write-strip case can insert.
+
+use vantage_expressions::ExprDataSource;
+use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
+#[allow(unused_imports)]
+use vantage_sql::sqlite::SqliteType;
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_sql::sqlite_expr;
+use vantage_table::table::Table;
+use vantage_types::{Record, entity};
+
+async fn setup() -> SqliteDB {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+    for ddl in [
+        "CREATE TABLE bakery (id TEXT PRIMARY KEY, name TEXT NOT NULL)",
+        "CREATE TABLE client (id TEXT PRIMARY KEY, name TEXT NOT NULL, bakery_id TEXT)",
+        "CREATE TABLE client_order (id TEXT PRIMARY KEY, client_id TEXT, is_deleted BOOLEAN NOT NULL DEFAULT 0)",
+    ] {
+        sqlx::query(ddl).execute(db.pool()).await.unwrap();
+    }
+    db.execute(&sqlite_expr!(
+        "INSERT INTO bakery (id, name) VALUES ({}, {})",
+        "b1",
+        "Sunrise Bakery"
+    ))
+    .await
+    .unwrap();
+    db.execute(&sqlite_expr!(
+        "INSERT INTO client (id, name, bakery_id) VALUES ({}, {}, {})",
+        "c1",
+        "Marty",
+        "b1"
+    ))
+    .await
+    .unwrap();
+    db.execute(&sqlite_expr!(
+        "INSERT INTO client_order (id, client_id) VALUES ({}, {}), ({}, {})",
+        "o1",
+        "c1",
+        "o2",
+        "c1"
+    ))
+    .await
+    .unwrap();
+    db
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Bakery {
+    name: String,
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Client {
+    name: String,
+    bakery_id: String,
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct ClientOrder {
+    client_id: String,
+    is_deleted: bool,
+}
+
+fn bakery_table(db: SqliteDB) -> Table<SqliteDB, Bakery> {
+    Table::new("bakery", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+}
+
+fn client_table(db: SqliteDB) -> Table<SqliteDB, Client> {
+    Table::new("client", db)
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("bakery_id")
+        .with_one("bakery", "bakery_id", bakery_table)
+        .with_many("orders", "client_id", order_table)
+}
+
+fn order_table(db: SqliteDB) -> Table<SqliteDB, ClientOrder> {
+    Table::new("client_order", db)
+        .with_id_column("id")
+        .with_column_of::<String>("client_id")
+        .with_column_of::<bool>("is_deleted")
+        .with_one("client", "client_id", client_table)
+}
+
+/// One hop: `client_order -> client.name`, lowered into a correlated subquery
+/// and aliased under the flat dotted key. Preview shows the shape; the live
+/// rows prove the correlation resolves.
+#[tokio::test]
+async fn one_hop_projects_correlated_subquery() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_active_columns(&["id", "client_id", "client.name"])
+        .unwrap();
+
+    let preview = orders.select().preview();
+    assert!(preview.contains("client.name"), "alias missing: {preview}");
+    assert!(preview.contains("client_id"), "base col missing: {preview}");
+    // A correlated subquery over the client table, not a join.
+    assert!(preview.contains("client"), "no client ref: {preview}");
+
+    let rows = orders.list_values().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    for row in rows.values() {
+        assert_eq!(
+            row.get("client.name").map(ToString::to_string),
+            Some("'Marty'".to_string())
+        );
+    }
+}
+
+/// Two hops: `client_order -> client -> bakery.name` nests one correlated
+/// subquery inside another.
+#[tokio::test]
+async fn two_hop_nests_subqueries() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_active_columns(&["id", "client.name", "client.bakery.name"])
+        .unwrap();
+
+    let preview = orders.select().preview();
+    assert!(preview.contains("client.bakery.name"), "alias missing: {preview}");
+    assert!(preview.contains("bakery"), "no bakery ref: {preview}");
+
+    let rows = orders.list_values().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    for row in rows.values() {
+        assert_eq!(
+            row.get("client.bakery.name").map(ToString::to_string),
+            Some("'Sunrise Bakery'".to_string())
+        );
+    }
+}
+
+/// A `has_many` hop is a build-time error, not a wrong query.
+#[tokio::test]
+async fn has_many_hop_errors_at_build() {
+    let db = setup().await;
+    // `orders` on client is has_many.
+    let result = client_table(db).with_active_columns(&["orders.is_deleted"]);
+    assert!(result.is_err());
+}
+
+/// An unknown relation is a build-time error.
+#[tokio::test]
+async fn unknown_relation_errors_at_build() {
+    let db = setup().await;
+    let result = order_table(db).with_active_columns(&["nope.name"]);
+    assert!(result.is_err());
+}
+
+/// An unknown column on the final target is a build-time error.
+#[tokio::test]
+async fn unknown_target_column_errors_at_build() {
+    let db = setup().await;
+    let result = order_table(db).with_active_columns(&["client.does_not_exist"]);
+    assert!(result.is_err());
+}
+
+/// An imported dotted column never reaches a write: the strip drops it before
+/// the INSERT, so a round-tripped record carrying `client.name` still inserts
+/// (otherwise SQLite would reject the unknown column).
+#[tokio::test]
+async fn imported_columns_are_stripped_on_write() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_active_columns(&["id", "client_id", "client.name"])
+        .unwrap();
+
+    let mut rec: Record<AnySqliteType> = Record::new();
+    rec.insert("client_id".to_string(), AnySqliteType::from("c1".to_string()));
+    rec.insert(
+        "client.name".to_string(),
+        AnySqliteType::from("should be dropped".to_string()),
+    );
+
+    // Succeeds only because the imported column was stripped before the INSERT;
+    // otherwise SQLite rejects the unknown `client.name` column.
+    orders.insert_value("o3", &rec).await.unwrap();
+
+    let stored = orders.get_value("o3".to_string()).await.unwrap().unwrap();
+    // The real column survived…
+    assert_eq!(
+        stored.get("client_id").map(ToString::to_string),
+        Some("'c1'".to_string())
+    );
+    // …and `client.name` reads back as the correlated value (Marty), never the
+    // literal "should be dropped" that the write attempted to smuggle in.
+    assert_eq!(
+        stored.get("client.name").map(ToString::to_string),
+        Some("'Marty'".to_string())
+    );
+}

--- a/vantage-sql/tests/sqlite/8_implicit_references.rs
+++ b/vantage-sql/tests/sqlite/8_implicit_references.rs
@@ -5,8 +5,8 @@
 //! into a nested correlated scalar subquery. Uses a self-contained in-memory
 //! database so the write-strip case can insert.
 
-use vantage_expressions::ExprDataSource;
 use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
+use vantage_expressions::ExprDataSource;
 #[allow(unused_imports)]
 use vantage_sql::sqlite::SqliteType;
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
@@ -129,7 +129,10 @@ async fn two_hop_nests_subqueries() {
         .unwrap();
 
     let preview = orders.select().preview();
-    assert!(preview.contains("client.bakery.name"), "alias missing: {preview}");
+    assert!(
+        preview.contains("client.bakery.name"),
+        "alias missing: {preview}"
+    );
     assert!(preview.contains("bakery"), "no bakery ref: {preview}");
 
     let rows = orders.list_values().await.unwrap();
@@ -178,7 +181,10 @@ async fn imported_columns_are_stripped_on_write() {
         .unwrap();
 
     let mut rec: Record<AnySqliteType> = Record::new();
-    rec.insert("client_id".to_string(), AnySqliteType::from("c1".to_string()));
+    rec.insert(
+        "client_id".to_string(),
+        AnySqliteType::from("c1".to_string()),
+    );
     rec.insert(
         "client.name".to_string(),
         AnySqliteType::from("should be dropped".to_string()),

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.6 — 2026-07-21
+
+- Implicit references (`Table::with_active_columns`) lower into a native
+  SurrealQL idiom path via the new `TableSource::traversal_path_expr` hook —
+  each segment escaped on its own so `batch.golf_course.name` traverses the
+  record links rather than looking up one `⟨batch.golf_course.name⟩` literal
+  field. Multi-hop comes for free. The vista factory advertises
+  `can_traverse_in_columns`.
+
 ## 0.6.5 — 2026-07-20
 
 - `expr:` computed columns: a column's Rhai script now lowers into a

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.5"
+version = "0.6.6"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/statements/insert/builder.rs
+++ b/vantage-surrealdb/src/statements/insert/builder.rs
@@ -37,7 +37,7 @@ impl SurrealInsert {
         self
     }
 
-    /// Bulk-load fields from a Record<AnySurrealType>.
+    /// Bulk-load fields from a `Record<AnySurrealType>`.
     pub fn with_record(mut self, record: &vantage_types::Record<AnySurrealType>) -> Self {
         for (k, v) in record.iter() {
             self.fields.insert(k.clone(), v.clone());

--- a/vantage-surrealdb/src/statements/insert/mod.rs
+++ b/vantage-surrealdb/src/statements/insert/mod.rs
@@ -1,7 +1,7 @@
 //! SurrealDB `CREATE` statement builder.
 //!
 //! Builds parameterized `CREATE table SET ...` or `CREATE table:id SET ...`
-//! expressions for execution via [`ExprDataSource::execute()`].
+//! expressions for execution via `ExprDataSource::execute()`.
 //!
 //! # Examples
 //!

--- a/vantage-surrealdb/src/statements/select/mod.rs
+++ b/vantage-surrealdb/src/statements/select/mod.rs
@@ -1,6 +1,6 @@
 //! # SurrealDB Select Query Builder
 //!
-//! Builds SELECT query for SurrealDB. Implements [`Selectable`] protocol.
+//! Builds SELECT query for SurrealDB. Implements the `Selectable` protocol.
 
 pub mod builder;
 pub mod exec;

--- a/vantage-surrealdb/src/statements/update/builder.rs
+++ b/vantage-surrealdb/src/statements/update/builder.rs
@@ -71,7 +71,7 @@ impl SurrealUpdate {
         self
     }
 
-    /// Bulk-load fields from a Record<AnySurrealType>.
+    /// Bulk-load fields from a `Record<AnySurrealType>`.
     pub fn with_record(mut self, record: &vantage_types::Record<AnySurrealType>) -> Self {
         for (k, v) in record.iter() {
             self.fields.insert(k.clone(), v.clone());

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -476,6 +476,26 @@ impl TableSource for SurrealDB {
         )
     }
 
+    fn supports_traversal(&self) -> bool {
+        true
+    }
+
+    fn traversal_path_expr(&self, hops: &[&str], column: &str) -> Option<Expression<Self::Value>> {
+        // A SurrealQL idiom path: each segment escaped on its own, joined by
+        // literal dots so SurrealDB traverses the record links
+        // (`batch.golf_course.name`). Joining first and escaping once would
+        // instead render a single ⟨batch.golf_course.name⟩ literal field — a
+        // dead lookup, not a traversal. Multi-hop comes for free.
+        let path = hops
+            .iter()
+            .copied()
+            .chain(std::iter::once(column))
+            .map(surreal_client::escape_identifier)
+            .collect::<Vec<_>>()
+            .join(".");
+        Some(Expression::new(path, vec![]))
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -88,6 +88,7 @@ impl SurrealVistaFactory {
                 can_fetch_next: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
+                can_traverse_in_columns: true,
                 // Per-reference scripted traversal only works when the script
                 // engine is compiled in; without `rhai`, any `build_script` is
                 // ignored and the FK eq-condition path still serves.
@@ -513,6 +514,29 @@ mod tests {
         let map: IndexMap<String, SurrealVistaSpec> = specs.into_iter().collect();
         let map = Arc::new(map);
         Arc::new(move |name: &str| map.get(name).cloned())
+    }
+
+    /// SurrealDB lowers an implicit reference into a native idiom path, each
+    /// segment escaped on its own so the record links are traversed
+    /// (`batch.golf_course.name`) rather than looked up as one literal field.
+    #[test]
+    fn traversal_path_expr_builds_escaped_idiom_path() {
+        use vantage_table::traits::table_source::TableSource;
+        let db = test_db();
+        assert!(db.supports_traversal());
+
+        let one = db.traversal_path_expr(&["batch"], "name").unwrap();
+        assert_eq!(one.preview(), "batch.name");
+
+        let two = db
+            .traversal_path_expr(&["batch", "golf_course"], "name")
+            .unwrap();
+        assert_eq!(two.preview(), "batch.golf_course.name");
+
+        // A reserved keyword segment is escaped independently — not the whole
+        // path — so traversal survives.
+        let reserved = db.traversal_path_expr(&["SELECT"], "name").unwrap();
+        assert_eq!(reserved.preview(), "⟨SELECT⟩.name");
     }
 
     #[cfg(feature = "rhai")]

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.6.12 — 2026-07-21
+
+- `Table::with_active_columns(&["id", "client.name", "client.bakery.name"])` —
+  **implicit references**. A plain name restricts projection to that column; a
+  dotted name traverses declared `has_one` relations and imports the target's
+  field as a read-only column aliased under the literal dotted name. Recursion
+  is supported (`a.b.c`). Everything is validated when the table is built:
+  unknown column/relation, a `has_many` hop, or a backend without traversal
+  support are all build-time errors, never fetch-time surprises. SQL backends
+  lower each hop into a nested correlated scalar subquery; a backend may
+  override the new `TableSource::traversal_path_expr` hook to emit a native path
+  instead (SurrealDB does). Imported columns are stripped from insert/replace/
+  patch payloads so a read-modify-save round-trip never persists them.
+- New `TableSource::supports_traversal` / `traversal_path_expr` hooks (default
+  `false` / `None`); `Table::select_expression` extracted from `select_column`
+  so a traversal expression can nest.
+
 ## 0.6.11 — 2026-07-20
 
 - `Table::apply_lazy_expressions` is public — a driver shell that bypasses

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/mocks/mock_table_source.rs
+++ b/vantage-table/src/mocks/mock_table_source.rs
@@ -394,6 +394,25 @@ impl TableSource for MockTableSource {
         )
     }
 
+    fn supports_traversal(&self) -> bool {
+        true
+    }
+
+    fn related_correlated_condition(
+        &self,
+        target_table: &str,
+        target_field: &str,
+        source_table: &str,
+        source_column: &str,
+    ) -> Self::Condition {
+        // Correlated equality rendered as a literal string — mirrors the
+        // table-qualified form the SQL backends emit, enough for preview tests.
+        Expression::new(
+            format!("{target_table}.{target_field} = {source_table}.{source_column}"),
+            vec![],
+        )
+    }
+
     fn column_table_values_expr<'a, E, Type: ColumnType>(
         &'a self,
         table: &Table<Self, E>,

--- a/vantage-table/src/references.rs
+++ b/vantage-table/src/references.rs
@@ -43,6 +43,13 @@ pub trait Reference: Send + Sync {
     /// applying the join condition.
     fn build_target(&self, data_source: &dyn Any) -> Box<dyn Any>;
 
+    /// Produce a fresh target table with its entity type erased to
+    /// `EmptyEntity`, wrapped in `Box<dyn Any>` for downcast to
+    /// `Table<T, EmptyEntity>`. Unlike [`build_target`](Self::build_target),
+    /// the caller need not know the concrete target entity type — used by
+    /// implicit-reference traversal, which walks relations by name.
+    fn build_target_erased(&self, data_source: &dyn Any) -> Box<dyn Any>;
+
     /// Cardinality of this relation. `HasOne` if traversing yields at most
     /// one record (the FK lives on the source); `HasMany` if it can yield
     /// any number (the FK lives on the target). Surfaced by

--- a/vantage-table/src/references/many.rs
+++ b/vantage-table/src/references/many.rs
@@ -79,6 +79,13 @@ where
         Box::new((self.build_target)(ds.clone()))
     }
 
+    fn build_target_erased(&self, data_source: &dyn Any) -> Box<dyn Any> {
+        let ds = data_source
+            .downcast_ref::<T>()
+            .expect("data source type mismatch in HasMany::build_target_erased");
+        Box::new((self.build_target)(ds.clone()).into_entity::<EmptyEntity>())
+    }
+
     fn cardinality(&self) -> vantage_vista::ReferenceKind {
         vantage_vista::ReferenceKind::HasMany
     }

--- a/vantage-table/src/references/one.rs
+++ b/vantage-table/src/references/one.rs
@@ -83,6 +83,13 @@ where
         Box::new((self.build_target)(ds.clone()))
     }
 
+    fn build_target_erased(&self, data_source: &dyn Any) -> Box<dyn Any> {
+        let ds = data_source
+            .downcast_ref::<T>()
+            .expect("data source type mismatch in HasOne::build_target_erased");
+        Box::new((self.build_target)(ds.clone()).into_entity::<EmptyEntity>())
+    }
+
     fn cardinality(&self) -> vantage_vista::ReferenceKind {
         vantage_vista::ReferenceKind::HasOne
     }

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -59,6 +59,16 @@ where
     pub(super) contained: Vec<crate::references::ContainedRelation<T>>,
     pub(super) expressions: IndexMap<String, ExpressionFn<T>>,
     pub(super) lazy_expressions: IndexMap<String, LazyExpressionFn<T>>,
+    /// When `Some`, `select()` projects only these column names (plus the id
+    /// column, always). `None` keeps the default "project every column"
+    /// behavior. The set holds both plain column names and dotted implicit
+    /// references (`"country.name"`); set via [`Self::with_active_columns`].
+    pub(super) active_columns: Option<indexmap::IndexSet<String>>,
+    /// Dotted implicit-reference columns imported by traversal
+    /// (`"country.name"`). These are read-only, expression-backed projections;
+    /// they are tracked here so write paths never persist them (a SCHEMALESS
+    /// store would otherwise create a literal `country.name` field).
+    pub(super) imported_columns: indexmap::IndexSet<String>,
     pub(super) pagination: Option<Pagination>,
     pub(super) title_field: Option<String>,
     pub(super) title_fields: Vec<String>,
@@ -97,6 +107,8 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             contained: Vec::new(),
             expressions: IndexMap::new(),
             lazy_expressions: IndexMap::new(),
+            active_columns: None,
+            imported_columns: indexmap::IndexSet::new(),
             pagination: None,
             title_field: None,
             title_fields: Vec::new(),
@@ -126,6 +138,8 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             contained: self.contained,
             expressions: self.expressions,
             lazy_expressions: self.lazy_expressions,
+            active_columns: self.active_columns,
+            imported_columns: self.imported_columns,
             pagination: self.pagination,
             title_field: self.title_field,
             title_fields: self.title_fields,
@@ -163,6 +177,17 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
             record.insert(name.clone(), value);
         }
         Ok(())
+    }
+
+    /// Drop imported implicit-reference columns (`"country.name"`) from a write
+    /// payload. They are read-only, expression-backed projections that no
+    /// backend can honestly store; a round-trip (read → modify → save) would
+    /// otherwise carry them back, and a SCHEMALESS store would create a literal
+    /// `country.name` field. Called before invariants on every write path.
+    pub(super) fn strip_imported_columns(&self, record: &mut vantage_types::Record<T::Value>) {
+        for name in &self.imported_columns {
+            record.shift_remove(name);
+        }
     }
 
     /// Snapshot the table's relations as Vista references (name, target type,

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -436,6 +436,63 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         Ok(target)
     }
 
+    /// Entity-erased [`get_subquery_as`](Self::get_subquery_as): builds the
+    /// correlated target as `Table<T, EmptyEntity>` without the caller naming
+    /// the target's concrete entity type. Used by implicit-reference traversal,
+    /// which walks relations by name and cannot know each hop's entity type.
+    pub fn get_subquery_erased(&self, relation: &str) -> Result<Table<T, EmptyEntity>> {
+        let (reference, relation_str) = self.lookup_ref(relation)?;
+
+        let source_id = self
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let mut target: Table<T, EmptyEntity> = *reference
+            .build_target_erased(self.data_source() as &dyn std::any::Any)
+            .downcast::<Table<T, EmptyEntity>>()
+            .map_err(|_| {
+                error!(
+                    "Failed to downcast related table",
+                    relation = relation_str.as_str()
+                )
+            })?;
+
+        let target_id = target
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
+
+        let (src_col, tgt_col) = reference.columns(&source_id, &target_id);
+
+        let condition = self.data_source().related_correlated_condition(
+            target.table_name(),
+            &tgt_col,
+            self.table_name(),
+            &src_col,
+        );
+        target.add_condition(condition);
+
+        Ok(target)
+    }
+
+    /// Entity-erased [`get_ref_target`](Self::get_ref_target): the bare target
+    /// (no condition) as `Table<T, EmptyEntity>`. Used to walk an
+    /// implicit-reference chain and read the final target's column definitions.
+    pub fn get_ref_target_erased(&self, relation: &str) -> Result<Table<T, EmptyEntity>> {
+        let (reference, relation_str) = self.lookup_ref(relation)?;
+        let target: Table<T, EmptyEntity> = *reference
+            .build_target_erased(self.data_source() as &dyn std::any::Any)
+            .downcast::<Table<T, EmptyEntity>>()
+            .map_err(|_| {
+                error!(
+                    "Failed to downcast related table",
+                    relation = relation_str.as_str()
+                )
+            })?;
+        Ok(target)
+    }
+
     /// Build the relation's target table with **no condition** applied.
     ///
     /// Unlike [`Self::get_ref_from_row`] / [`Self::get_ref_as`] (which select

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -125,6 +125,12 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
                 if col.flags().contains(&ColumnFlag::Hidden) {
                     vc = vc.hidden();
                 }
+                // Imported implicit-reference columns are read-only: flag them
+                // `calculated` so consumers render them read-only and keep them
+                // out of forms/write payloads (mirrors the write-side strip).
+                if self.imported_columns.contains(name) {
+                    vc = vc.with_flag(vantage_vista::flags::CALCULATED);
+                }
                 vc
             })
             .collect()
@@ -402,12 +408,6 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         relation: &str,
     ) -> Result<Table<T, E2>> {
         let (reference, relation_str) = self.lookup_ref(relation)?;
-
-        let source_id = self
-            .id_field()
-            .map(|c| c.name().to_string())
-            .unwrap_or_else(|| "id".to_string());
-
         let mut target: Table<T, E2> = *reference
             .build_target(self.data_source() as &dyn std::any::Any)
             .downcast::<Table<T, E2>>()
@@ -417,22 +417,7 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
                     relation = relation_str.as_str()
                 )
             })?;
-
-        let target_id = target
-            .id_field()
-            .map(|c| c.name().to_string())
-            .unwrap_or_else(|| "id".to_string());
-
-        let (src_col, tgt_col) = reference.columns(&source_id, &target_id);
-
-        let condition = self.data_source().related_correlated_condition(
-            target.table_name(),
-            &tgt_col,
-            self.table_name(),
-            &src_col,
-        );
-        target.add_condition(condition);
-
+        self.attach_correlated_condition(reference, &mut target);
         Ok(target)
     }
 
@@ -442,12 +427,6 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
     /// which walks relations by name and cannot know each hop's entity type.
     pub fn get_subquery_erased(&self, relation: &str) -> Result<Table<T, EmptyEntity>> {
         let (reference, relation_str) = self.lookup_ref(relation)?;
-
-        let source_id = self
-            .id_field()
-            .map(|c| c.name().to_string())
-            .unwrap_or_else(|| "id".to_string());
-
         let mut target: Table<T, EmptyEntity> = *reference
             .build_target_erased(self.data_source() as &dyn std::any::Any)
             .downcast::<Table<T, EmptyEntity>>()
@@ -457,14 +436,28 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
                     relation = relation_str.as_str()
                 )
             })?;
+        self.attach_correlated_condition(reference, &mut target);
+        Ok(target)
+    }
 
+    /// Attach the correlated join condition binding `target` back to `self`
+    /// (`target.<id> = self.<foreign_key>`). Shared by the typed and erased
+    /// subquery builders, which otherwise differ only in the target entity type
+    /// and which `build_target*` closure produced `target`.
+    fn attach_correlated_condition<E2: Entity<T::Value> + 'static>(
+        &self,
+        reference: &dyn Reference,
+        target: &mut Table<T, E2>,
+    ) {
+        let source_id = self
+            .id_field()
+            .map(|c| c.name().to_string())
+            .unwrap_or_else(|| "id".to_string());
         let target_id = target
             .id_field()
             .map(|c| c.name().to_string())
             .unwrap_or_else(|| "id".to_string());
-
         let (src_col, tgt_col) = reference.columns(&source_id, &target_id);
-
         let condition = self.data_source().related_correlated_condition(
             target.table_name(),
             &tgt_col,
@@ -472,8 +465,6 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
             &src_col,
         );
         target.add_condition(condition);
-
-        Ok(target)
     }
 
     /// Entity-erased [`get_ref_target`](Self::get_ref_target): the bare target

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -1,7 +1,7 @@
-use vantage_core::Result;
+use vantage_core::{Result, error};
 use vantage_expressions::traits::selectable::Selectable;
 use vantage_expressions::{Expression, Expressive, SelectableDataSource, expr_any};
-use vantage_types::Entity;
+use vantage_types::{EmptyEntity, Entity};
 
 use crate::{
     column::core::ColumnType,
@@ -57,6 +57,11 @@ where
             if self.lazy_expressions.contains_key(column.name()) {
                 continue;
             }
+            // With an active-column set, project only its members. The id
+            // column is always projected — consumers rely on it to key rows.
+            if !self.is_active(column.name()) {
+                continue;
+            }
             if let Some(expr_fn) = self.expressions.get(column.name()) {
                 let expr = expr_fn(self.as_entity_erased());
                 self.data_source.add_select_column(
@@ -75,7 +80,7 @@ where
 
         // Add expressions that don't correspond to any column
         for (name, expr_fn) in &self.expressions {
-            if !self.columns.contains_key(name) {
+            if !self.columns.contains_key(name) && self.is_active(name) {
                 let expr = expr_fn(self.as_entity_erased());
                 self.data_source.add_select_column(
                     &mut select,
@@ -142,12 +147,174 @@ where
         T::Column<T::AnyType>: Expressive<T::Value>,
         T::Select: Expressive<T::Value>,
     {
-        let expr = self.get_column_expr(field)?;
+        Some(self.select_expression(self.get_column_expr(field)?))
+    }
+
+    /// Wrap an arbitrary expression as a single-column subquery over this
+    /// table's source and conditions: `(SELECT <expr> FROM table WHERE …)`.
+    ///
+    /// Extracted from [`select_column`](Self::select_column) so a traversal
+    /// expression can nest one subquery inside another (multi-hop implicit
+    /// references). Fields and ordering are cleared — only `expr` is projected.
+    pub fn select_expression(&self, expr: Expression<T::Value>) -> Expression<T::Value>
+    where
+        T::Select: Expressive<T::Value>,
+    {
         let mut select = self.select_empty();
         select.clear_fields();
         select.clear_order_by();
         select.add_expression(expr);
-        Some(select.expr())
+        select.expr()
+    }
+
+    /// Whether `name` is projected by [`select`](Self::select). With no active
+    /// set every column is active; otherwise only the set's members are, plus
+    /// the id column (always projected — consumers key rows by it).
+    fn is_active(&self, name: &str) -> bool {
+        match &self.active_columns {
+            None => true,
+            Some(set) => set.contains(name) || self.id_field.as_deref() == Some(name),
+        }
+    }
+
+    /// Restrict this table to an explicit set of columns, and import **implicit
+    /// references** — dotted names that traverse declared `has_one` relations
+    /// and surface the target's field as a read-only, typed column aliased
+    /// under the literal dotted name.
+    ///
+    /// ```rust,ignore
+    /// let orders = Order::sqlite_table(db)
+    ///     .with_active_columns(&["id", "client.name", "client.bakery.name"])?;
+    /// // SELECT id,
+    /// //   (SELECT name FROM client WHERE client.id = client_order.client_id) AS "client.name",
+    /// //   (SELECT name FROM bakery WHERE bakery.id = client.bakery_id …)     AS "client.bakery.name"
+    /// // FROM client_order
+    /// ```
+    ///
+    /// A non-dotted entry restricts projection to that existing column
+    /// (exactly today's declared columns). A dotted entry `a.b…c` resolves `a`,
+    /// `b`… as `has_one` relations and `c` as a column on the final target.
+    /// Everything is validated here, so every failure is a **build-time** error,
+    /// never a fetch-time surprise: unknown column, unknown relation, a
+    /// `has_many` hop, or a backend that cannot lower traversal into its query
+    /// (MongoDB, CSV, REST, CMD). Same-datasource only; cross-datasource
+    /// traversal is a Diorama augmentation concern.
+    pub fn with_active_columns(mut self, cols: &[&str]) -> Result<Self>
+    where
+        T: 'static,
+        E: 'static,
+        T::Column<T::AnyType>: Expressive<T::Value>,
+        T::Select: Expressive<T::Value>,
+    {
+        for &col in cols {
+            let parts: Vec<&str> = col.split('.').collect();
+            if parts.iter().any(|p| p.is_empty()) {
+                return Err(error!("invalid active column name", column = col));
+            }
+
+            if parts.len() >= 2 {
+                let column = parts[parts.len() - 1];
+                let hops = &parts[..parts.len() - 1];
+
+                if !self.data_source().supports_traversal() {
+                    return Err(error!(
+                        "backend does not support implicit-reference traversal in columns",
+                        column = col
+                    ));
+                }
+
+                // Validate the has_one chain and that the final column exists.
+                let target = self.resolve_has_one_target(hops)?;
+                if !target.columns().contains_key(column) {
+                    return Err(error!(
+                        "implicit reference target has no such column",
+                        column = column
+                    ));
+                }
+
+                // Lower to an expression: native path (SurrealDB idiom) first,
+                // else the generic nested correlated-subquery chain.
+                let expr = match self.data_source().traversal_path_expr(hops, column) {
+                    Some(e) => e,
+                    None => self.traverse_rest_generic(hops, column)?,
+                };
+
+                let dotted = col.to_string();
+                if !self.columns.contains_key(&dotted) {
+                    let column_def = self.data_source.create_column::<T::AnyType>(&dotted);
+                    self.add_column(column_def);
+                }
+                self = self.with_expression(&dotted, move |_| expr.clone());
+                self.imported_columns.insert(dotted.clone());
+                self.active_columns
+                    .get_or_insert_with(Default::default)
+                    .insert(dotted);
+            } else {
+                if !self.columns.contains_key(col) {
+                    return Err(error!("unknown active column", column = col));
+                }
+                self.active_columns
+                    .get_or_insert_with(Default::default)
+                    .insert(col.to_string());
+            }
+        }
+        Ok(self)
+    }
+
+    /// Recursively lower a dotted implicit reference into nested correlated
+    /// subqueries. One hop wraps the recursion's inner expression in a
+    /// `get_subquery_as` target via [`select_expression`](Self::select_expression);
+    /// the base case projects the final column. Used only when the backend has
+    /// no native [`traversal_path_expr`](crate::prelude::TableSource::traversal_path_expr).
+    fn traverse_rest_generic(&self, hops: &[&str], column: &str) -> Result<Expression<T::Value>>
+    where
+        T: 'static,
+        E: 'static,
+        T::Column<T::AnyType>: Expressive<T::Value>,
+        T::Select: Expressive<T::Value>,
+    {
+        match hops.split_first() {
+            None => self.get_column_expr(column).ok_or_else(|| {
+                error!("implicit reference target has no such column", column = column)
+            }),
+            Some((head, tail)) => {
+                let target: Table<T, EmptyEntity> = self.get_subquery_erased(head)?;
+                let inner = target.traverse_rest_generic(tail, column)?;
+                // The base case returns a bare column; a deeper hop returns a
+                // SELECT that must be parenthesized before it can nest as a
+                // scalar inside this hop's SELECT.
+                let inner = if tail.is_empty() {
+                    inner
+                } else {
+                    expr_any!("({})", (inner))
+                };
+                Ok(target.select_expression(inner))
+            }
+        }
+    }
+
+    /// Walk a chain of `has_one` hops and return the final target table,
+    /// erroring at build time on an unknown relation or a `has_many` hop.
+    fn resolve_has_one_target(&self, hops: &[&str]) -> Result<Table<T, EmptyEntity>>
+    where
+        T: 'static,
+        E: 'static,
+    {
+        let (head, tail) = hops
+            .split_first()
+            .ok_or_else(|| error!("empty implicit reference path"))?;
+        if self.ref_cardinality(head)? != vantage_vista::ReferenceKind::HasOne {
+            return Err(error!(
+                "implicit reference hop must traverse a has_one relation",
+                relation = *head
+            ));
+        }
+        let target: Table<T, EmptyEntity> = self.get_ref_target_erased(head)?;
+        if tail.is_empty() {
+            Ok(target)
+        } else {
+            target.resolve_has_one_target(tail)
+        }
     }
 }
 

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -275,7 +275,10 @@ where
     {
         match hops.split_first() {
             None => self.get_column_expr(column).ok_or_else(|| {
-                error!("implicit reference target has no such column", column = column)
+                error!(
+                    "implicit reference target has no such column",
+                    column = column
+                )
             }),
             Some((head, tail)) => {
                 let target: Table<T, EmptyEntity> = self.get_subquery_erased(head)?;

--- a/vantage-table/src/table/sets/writable_value_set.rs
+++ b/vantage-table/src/table/sets/writable_value_set.rs
@@ -31,6 +31,7 @@ where
         let erased = self.as_entity_erased();
         let mut record = record.clone();
         run_before(self.before_insert_hooks(), &mut record, erased).await?;
+        self.strip_imported_columns(&mut record);
         enforce_invariants(&mut record, self.invariants())?;
         let result = self
             .data_source()
@@ -49,6 +50,7 @@ where
         let erased = self.as_entity_erased();
         let mut record = record.clone();
         run_before(self.before_update_hooks(), &mut record, erased).await?;
+        self.strip_imported_columns(&mut record);
         enforce_invariants(&mut record, self.invariants())?;
         let result = self
             .data_source()
@@ -67,6 +69,7 @@ where
         let erased = self.as_entity_erased();
         let mut partial = partial.clone();
         run_before(self.before_update_hooks(), &mut partial, erased).await?;
+        self.strip_imported_columns(&mut partial);
         enforce_invariants(&mut partial, self.invariants())?;
         let result = self
             .data_source()

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -297,6 +297,30 @@ pub trait TableSource: DataSource + Clone + 'static {
         unimplemented!("correlated subqueries not supported by this backend")
     }
 
+    /// Whether this backend can lower a dotted active column
+    /// (`"country.name"`) into its own query — a nested correlated subquery for
+    /// SQL, a native idiom path for SurrealDB. Backends that can build neither
+    /// (MongoDB, CSV, REST, CMD) leave the default `false`, and
+    /// [`Table::with_active_columns`](crate::table::Table::with_active_columns)
+    /// rejects dotted names against them at build time rather than at fetch time.
+    fn supports_traversal(&self) -> bool {
+        false
+    }
+
+    /// Build a backend-native path expression for a dotted active column,
+    /// tried before the generic correlated-subquery chain.
+    ///
+    /// `hops` names the `has_one` relations to traverse and `column` the final
+    /// field. The default returns `None`, so backends fall back to the generic
+    /// chain built on [`related_correlated_condition`](Self::related_correlated_condition).
+    /// SurrealDB overrides this to emit an idiom path (`batch.golf_course.name`,
+    /// each segment escaped separately); multi-hop comes for free. The returned
+    /// expression is unaliased — `select()` aliases it to the dotted name.
+    fn traversal_path_expr(&self, hops: &[&str], column: &str) -> Option<Expression<Self::Value>> {
+        let _ = (hops, column);
+        None
+    }
+
     /// Return an associated expression that, when resolved, yields all values
     /// of the given typed column from this table (respecting current conditions).
     ///

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.13 — 2026-07-21
+
+- `flags::CALCULATED` (`"calculated"`) — a read-only, source-computed column
+  (an implicit-reference traversal, an `expr:` script, or a lazy column).
+  Consumers render it read-only and exclude it from forms and write payloads.
+- `VistaCapabilities::can_traverse_in_columns` — whether a backend can lower a
+  dotted column (`country.name`) into its own query. SQL and SurrealDB shells
+  advertise `true`; CSV/Mongo/REST leave it `false`.
+
 ## 0.6.12 — 2026-07-20
 
 - `ColumnSpec::expr` / `with_expr` — a server-side computed column: a Rhai

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -60,4 +60,12 @@ pub struct VistaCapabilities {
     /// engine *and* a by-name target resolver advertise `true`; others leave
     /// it `false` and ignore any `build_script` (the FK path still works).
     pub can_build_ref_via_script: bool,
+    /// Implicit references in the column list — a dotted column name
+    /// (`country.name`) traverses `has_one` relations and imports the target's
+    /// field as a read-only, `calculated` column, lowered into the backend's
+    /// own query (a nested correlated subquery for SQL, a native idiom path for
+    /// SurrealDB). Same backend-support profile as
+    /// [`can_traverse_to_set`](Self::can_traverse_to_set): SQL and SurrealDB
+    /// advertise `true`; CSV/Mongo/REST leave it `false`.
+    pub can_traverse_in_columns: bool,
 }

--- a/vantage-vista/src/flags.rs
+++ b/vantage-vista/src/flags.rs
@@ -11,3 +11,7 @@ pub const SEARCHABLE: &str = "searchable";
 pub const ORDERABLE: &str = "orderable";
 pub const MANDATORY: &str = "mandatory";
 pub const HIDDEN: &str = "hidden";
+/// Read-only, source-computed column: an implicit-reference traversal
+/// (`country.name`), an `expr:` script, or a lazy computed column. Consumers
+/// render it read-only and exclude it from forms and write payloads.
+pub const CALCULATED: &str = "calculated";


### PR DESCRIPTION
Implements VAN-102. A dotted name in `Table::with_active_columns` traverses declared `has_one` relations and imports the target's field as a read-only, typed column aliased under the literal dotted name. A plain name simply restricts projection.

```rust
let orders = Order::sqlite_table(db)
    .with_active_columns(&["id", "client.name", "client.bakery.name"])?;
// SELECT id,
//   (SELECT name FROM client WHERE client.id = client_order.client_id) AS "client.name",
//   (SELECT (SELECT name FROM bakery WHERE bakery.id = client.bakery_id …)
//      FROM client WHERE client.id = client_order.client_id)          AS "client.bakery.name"
// FROM client_order
```

`client.name` is one hop; `client.bakery.name` recurses through two. Each backend lowers the traversal into its own query — SQL nests correlated scalar subqueries, SurrealDB emits a native idiom path (each segment escaped separately). Rows come back with a flat key equal to the dotted name.

## Scope

Framework only. The vantage-ui `read_path` change and the golf-2 YAML migration from the ticket are a deliberate follow-up.

## What's in here

- **vantage-table** — `with_active_columns`, projection gating in `select()`, the recursive traversal builder, `select_expression` extracted from `select_column`, new `TableSource::supports_traversal` / `traversal_path_expr` hooks, `Reference::build_target_erased` (so traversal can walk relations by name without knowing each hop's entity type), and stripping of imported columns from insert/replace/patch payloads.
- **vantage-sql** — SQLite/Postgres/MySQL advertise `supports_traversal`; lowering runs on the existing `related_correlated_condition`. Vista factories advertise `can_traverse_in_columns`.
- **vantage-surrealdb** — `traversal_path_expr` override emitting an escaped idiom path.
- **vantage-vista** — `flags::CALCULATED` and `VistaCapabilities::can_traverse_in_columns` (the flag VAN-93's write-back relies on).

## Validation

Everything is checked when the table is built, so mistakes are build-time errors, not fetch-time surprises: unknown column/relation, a `has_many` hop, or a backend that can lower neither a subquery nor an idiom path.

## Tests & demo

- New `bakery_model3/examples/implicit-references.rs` — prints the lowered SQL and live one-hop/two-hop rows.
- 6 SQLite integration tests (`vantage-sql/tests/sqlite/8_implicit_references.rs`): one-hop, two-hop, `has_many`/unknown-relation/unknown-column build errors, write-strip.
- SurrealDB idiom-path unit test (per-segment escaping).
- No regressions in vantage-table / vantage-vista; clippy clean; docs build.

## Docs

`docs4/src/mda.md` gains an "Implicit references — dotted columns" section. Per-crate CHANGELOG + version bumps (vantage-table 0.6.12, vantage-vista 0.6.13, vantage-surrealdb 0.6.6, vantage-sql 0.6.11, vantage-diorama 0.6.21).

Supersedes VAN-94's surfacing goal; unblocks the `calculated` flag VAN-93 needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting related fields with dotted column paths, such as `client.name` and `client.bakery.name`.
  * Related values are returned under flat dotted keys and marked read-only.
  * Added backend support for implicit references across SQLite, PostgreSQL, MySQL, and SurrealDB.
* **Bug Fixes**
  * Read-only related fields are excluded from write payloads.
  * Invalid relationships and unsupported traversal paths now report errors during query construction.
* **Documentation**
  * Added usage guidance and release notes for dotted-column traversal and backend support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->