### PR TITLE
Implicit references: review fixes — write-strip, FK-field idiom hops, patch rejection, factory dotted routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/docs4/src/mda.md
+++ b/docs4/src/mda.md
@@ -180,7 +180,8 @@ let orders = Order::sqlite_table(db)
     .with_active_columns(&["id", "client.name", "client.bakery.name"])?;
 // SELECT id,
 //   (SELECT name FROM client WHERE client.id = client_order.client_id) AS "client.name",
-//   (SELECT name FROM bakery WHERE bakery.id = client.bakery_id …)     AS "client.bakery.name"
+//   (SELECT (SELECT name FROM bakery WHERE bakery.id = client.bakery_id)
+//      FROM client WHERE client.id = client_order.client_id)           AS "client.bakery.name"
 // FROM client_order
 ```
 
@@ -195,11 +196,14 @@ is built, so mistakes surface immediately rather than at fetch time:
 
 - an unknown column or relation is a **build-time error**;
 - a `has_many` hop is rejected (traversal is `has_one`-only — a to-many field is a set, not a value);
-- a backend that can lower neither a subquery nor an idiom path (MongoDB, CSV, REST) refuses dotted
-  names up front; same-datasource only.
+- a backend that can lower neither a subquery nor an idiom path (e.g. MongoDB, CSV, REST) refuses
+  dotted names up front; same-datasource only.
 
-Imported columns are read-only: they are flagged `calculated` for consumers and stripped from every
-write payload, so a read-modify-save round-trip never tries to persist `client.name` as a real field.
+Imported columns are read-only: they are flagged `calculated` for consumers, stripped from
+full-record write payloads (insert, replace, generated-id insert) so a read-modify-save round-trip
+never tries to persist `client.name` as a real field, and rejected outright in a `patch` — a partial
+payload naming a read-only column is explicit intent, and silently dropping it would turn the patch
+into a successful no-op.
 This is the declarative counterpart to the manual `with_expression` + `get_subquery_as` recipe above —
 reach for `with_expression` when you need an arbitrary expression, and a dotted column when you just
 want a related field.

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,16 +1,20 @@
 # Changelog
 
+## 0.6.12 — 2026-07-21
+
+- Implicit-references review fixes: vista factories flag computed columns
+  (implicit-reference imports, expression, lazy) `calculated` in metadata.
+  Quicksearch skips imported columns — the dotted identifier is not a real
+  field in a WHERE clause (SQLite would degrade it to a string literal and
+  match wrong rows; Postgres/MySQL would error at fetch time).
+
 ## 0.6.11 — 2026-07-21
 
 - SQLite / Postgres / MySQL advertise `TableSource::supports_traversal`, so
   implicit references (`Table::with_active_columns`) lower into nested
   correlated scalar subqueries on their existing `related_correlated_condition`
   — no native-path override needed. The vista factories advertise
-  `can_traverse_in_columns` and flag computed columns (implicit-reference
-  imports, expression, lazy) `calculated` in metadata. Quicksearch skips
-  imported columns — in a WHERE clause the dotted identifier is not a real
-  field (SQLite would degrade it to a string literal and match wrong rows;
-  Postgres/MySQL would error at fetch time).
+  `can_traverse_in_columns`.
 
 ## 0.6.10 — 2026-07-16
 

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -6,7 +6,11 @@
   implicit references (`Table::with_active_columns`) lower into nested
   correlated scalar subqueries on their existing `related_correlated_condition`
   — no native-path override needed. The vista factories advertise
-  `can_traverse_in_columns`.
+  `can_traverse_in_columns` and flag computed columns (implicit-reference
+  imports, expression, lazy) `calculated` in metadata. Quicksearch skips
+  imported columns — in a WHERE clause the dotted identifier is not a real
+  field (SQLite would degrade it to a string literal and match wrong rows;
+  Postgres/MySQL would error at fetch time).
 
 ## 0.6.10 — 2026-07-16
 

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -143,6 +143,9 @@ impl TableSource for MysqlDB {
         let conditions: Vec<Expression<AnyMysqlType>> = table
             .columns()
             .values()
+            // Imported implicit-reference columns exist only as projection
+            // aliases — a WHERE on the dotted identifier errors at fetch time.
+            .filter(|col| !table.is_imported_column(col.name()))
             .map(|col| {
                 let p = pattern.clone();
                 mysql_expr!("{} LIKE {} ESCAPE '$'", (ident(col.name())), p)

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -347,6 +347,11 @@ where
         // before calling `Vista::add_order`.
         let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string())
             .with_flag(vista_flags::ORDERABLE);
+        // Computed columns (implicit-reference imports, expression, lazy)
+        // are read-only for consumers.
+        if table.is_calculated_column(name) {
+            vc = vc.with_flag(vista_flags::CALCULATED);
+        }
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -161,6 +161,9 @@ impl TableSource for PostgresDB {
         let conditions: Vec<Expression<AnyPostgresType>> = table
             .columns()
             .values()
+            // Imported implicit-reference columns exist only as projection
+            // aliases — a WHERE on the dotted identifier errors at fetch time.
+            .filter(|col| !table.is_imported_column(col.name()))
             .map(|col| {
                 let p = pattern.clone();
                 postgres_expr!("{}::text LIKE {} ESCAPE '$'", (ident(col.name())), p)

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -355,6 +355,11 @@ where
         // before calling `Vista::add_order`.
         let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string())
             .with_flag(vista_flags::ORDERABLE);
+        // Computed columns (implicit-reference imports, expression, lazy)
+        // are read-only for consumers.
+        if table.is_calculated_column(name) {
+            vc = vc.with_flag(vista_flags::CALCULATED);
+        }
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -136,6 +136,10 @@ impl TableSource for SqliteDB {
         let conditions: Vec<Expression<AnySqliteType>> = table
             .columns()
             .values()
+            // Imported implicit-reference columns exist only as projection
+            // aliases; in a WHERE clause the dotted identifier degrades to a
+            // string literal and silently matches wrong rows.
+            .filter(|col| !table.is_imported_column(col.name()))
             .map(|col| {
                 let p = pattern.clone();
                 sqlite_expr!("{} LIKE {} ESCAPE '$'", (ident(col.name())), p)

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -392,11 +392,17 @@ where
 {
     let mut metadata = VistaMetadata::new();
     for (name, col) in table.columns() {
-        // SQLite can ORDER BY any column server-side. Every column gets
+        // SQLite can ORDER BY any column server-side — including computed
+        // ones, which resolve via their output alias. Every column gets
         // the ORDERABLE flag at construction; consumers branch on it
         // before calling `Vista::add_order`.
         let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string())
             .with_flag(vista_flags::ORDERABLE);
+        // Computed columns (implicit-reference imports, expression, lazy)
+        // are read-only for consumers.
+        if table.is_calculated_column(name) {
+            vc = vc.with_flag(vista_flags::CALCULATED);
+        }
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }

--- a/vantage-sql/tests/sqlite/8_implicit_references.rs
+++ b/vantage-sql/tests/sqlite/8_implicit_references.rs
@@ -5,7 +5,7 @@
 //! into a nested correlated scalar subquery. Uses a self-contained in-memory
 //! database so the write-strip case can insert.
 
-use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
+use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
 use vantage_expressions::ExprDataSource;
 #[allow(unused_imports)]
 use vantage_sql::sqlite::SqliteType;
@@ -107,7 +107,10 @@ async fn one_hop_projects_correlated_subquery() {
     assert!(preview.contains("client.name"), "alias missing: {preview}");
     assert!(preview.contains("client_id"), "base col missing: {preview}");
     // A correlated subquery over the client table, not a join.
-    assert!(preview.contains("client"), "no client ref: {preview}");
+    assert!(
+        preview.contains(r#""client"."id" = "client_order"."client_id""#),
+        "no correlated subquery: {preview}"
+    );
 
     let rows = orders.list_values().await.unwrap();
     assert_eq!(rows.len(), 2);
@@ -206,4 +209,126 @@ async fn imported_columns_are_stripped_on_write() {
         stored.get("client.name").map(ToString::to_string),
         Some("'Marty'".to_string())
     );
+}
+
+/// The generated-id insert path (`insert_return_id_value`, which the typed
+/// entity insert funnels through) must strip imported columns just like the
+/// explicit-id path — otherwise a round-tripped record fails the INSERT.
+#[tokio::test]
+async fn imported_columns_are_stripped_on_insert_return_id() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_active_columns(&["id", "client_id", "client.name"])
+        .unwrap();
+
+    let mut rec: Record<AnySqliteType> = Record::new();
+    // Explicit id: the TEXT primary key has no DEFAULT, so a generated id
+    // would come back NULL — irrelevant to what this test pins down.
+    rec.insert("id".to_string(), AnySqliteType::from("o9".to_string()));
+    rec.insert(
+        "client_id".to_string(),
+        AnySqliteType::from("c1".to_string()),
+    );
+    rec.insert(
+        "client.name".to_string(),
+        AnySqliteType::from("should be dropped".to_string()),
+    );
+
+    // Succeeds only if the imported column is stripped on this path too.
+    let id = orders.insert_return_id_value(&rec).await.unwrap();
+    let stored = orders.get_value(id).await.unwrap().unwrap();
+    assert_eq!(
+        stored.get("client.name").map(ToString::to_string),
+        Some("'Marty'".to_string())
+    );
+}
+
+/// A patch is explicit intent per key: patching a read-only imported column
+/// is rejected loudly instead of silently no-opping.
+#[tokio::test]
+async fn patch_on_imported_column_errors() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_active_columns(&["id", "client_id", "client.name"])
+        .unwrap();
+
+    let mut patch: Record<AnySqliteType> = Record::new();
+    patch.insert(
+        "client.name".to_string(),
+        AnySqliteType::from("nope".to_string()),
+    );
+    let err = orders.patch_value("o1", &patch).await.unwrap_err();
+    assert!(
+        err.to_string().contains("read-only"),
+        "unexpected error: {err}"
+    );
+
+    // Sanity: patching a real column still works.
+    let mut ok_patch: Record<AnySqliteType> = Record::new();
+    ok_patch.insert(
+        "client_id".to_string(),
+        AnySqliteType::from("c1".to_string()),
+    );
+    orders.patch_value("o1", &ok_patch).await.unwrap();
+}
+
+/// The active set restricts projection: a declared column left out of the set
+/// is absent from both the query and the returned rows.
+#[tokio::test]
+async fn inactive_columns_are_not_projected() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_active_columns(&["id", "client_id"])
+        .unwrap();
+
+    let preview = orders.select().preview();
+    assert!(
+        !preview.contains("is_deleted"),
+        "inactive column projected: {preview}"
+    );
+
+    let rows = orders.list_values().await.unwrap();
+    for row in rows.values() {
+        assert!(row.get("is_deleted").is_none());
+        assert!(row.get("client_id").is_some());
+    }
+}
+
+/// The id column is always projected, even when the active set omits it —
+/// consumers key rows by it.
+#[tokio::test]
+async fn id_column_is_always_projected() {
+    let db = setup().await;
+    let orders = order_table(db).with_active_columns(&["client_id"]).unwrap();
+
+    let rows = orders.list_values().await.unwrap();
+    assert_eq!(rows.len(), 2);
+    for row in rows.values() {
+        assert!(row.get("id").is_some(), "id missing from row: {row:?}");
+    }
+}
+
+/// A column registered only as an expression (no column def) can be named in
+/// the active set and stays projected.
+#[tokio::test]
+async fn expression_only_column_can_be_activated() {
+    let db = setup().await;
+    let orders = order_table(db)
+        .with_expression("client_upper", |_| sqlite_expr!("UPPER(client_id)"))
+        .with_active_columns(&["id", "client_upper"])
+        .unwrap();
+
+    let preview = orders.select().preview();
+    assert!(
+        preview.contains("client_upper"),
+        "expression column dropped: {preview}"
+    );
+
+    let rows = orders.list_values().await.unwrap();
+    for row in rows.values() {
+        assert_eq!(
+            row.get("client_upper").map(ToString::to_string),
+            Some("'C1'".to_string())
+        );
+    }
 }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -6,8 +6,15 @@
   SurrealQL idiom path via the new `TableSource::traversal_path_expr` hook —
   each segment escaped on its own so `batch.golf_course.name` traverses the
   record links rather than looking up one `⟨batch.golf_course.name⟩` literal
-  field. Multi-hop comes for free. The vista factory advertises
-  `can_traverse_in_columns`.
+  field. Multi-hop comes for free. The idiom descends each hop's *link field*
+  (a relation named `owner` over a link field `batch` lowers to `batch.name`).
+  The vista factory advertises `can_traverse_in_columns`, routes dotted spec
+  columns (`batch.name:`) through the traversal import (a build-time-validated
+  implicit reference instead of a dead ⟨batch.name⟩ literal lookup), and flags
+  computed columns `calculated` in metadata — imported ones are additionally
+  not orderable, since the dotted name is a projection alias, not a field.
+  Quicksearch skips imported columns (the escaped dotted identifier would
+  silently never match).
 
 ## 0.6.5 — 2026-07-20
 

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,20 +1,26 @@
 # Changelog
 
+## 0.6.7 — 2026-07-21
+
+- Implicit-references review fixes: the idiom path descends each hop's *link
+  field* (a relation named `owner` over a link field `batch` lowers to
+  `batch.name`), not the relation's registry name — which could validate at
+  build yet query a nonexistent field.
+- The vista factory routes dotted spec columns (`batch.name:`) through the
+  traversal import — a build-time-validated implicit reference instead of a
+  dead ⟨batch.name⟩ literal lookup — and flags computed columns `calculated`
+  in metadata; imported ones are additionally not orderable (the dotted name
+  is a projection alias, not a field). Quicksearch skips imported columns
+  (the escaped dotted identifier would silently never match).
+
 ## 0.6.6 — 2026-07-21
 
 - Implicit references (`Table::with_active_columns`) lower into a native
   SurrealQL idiom path via the new `TableSource::traversal_path_expr` hook —
   each segment escaped on its own so `batch.golf_course.name` traverses the
   record links rather than looking up one `⟨batch.golf_course.name⟩` literal
-  field. Multi-hop comes for free. The idiom descends each hop's *link field*
-  (a relation named `owner` over a link field `batch` lowers to `batch.name`).
-  The vista factory advertises `can_traverse_in_columns`, routes dotted spec
-  columns (`batch.name:`) through the traversal import (a build-time-validated
-  implicit reference instead of a dead ⟨batch.name⟩ literal lookup), and flags
-  computed columns `calculated` in metadata — imported ones are additionally
-  not orderable, since the dotted name is a projection alias, not a field.
-  Quicksearch skips imported columns (the escaped dotted identifier would
-  silently never match).
+  field. Multi-hop comes for free. The vista factory advertises
+  `can_traverse_in_columns`.
 
 ## 0.6.5 — 2026-07-20
 

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.6"
+version = "0.6.7"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -144,6 +144,10 @@ impl TableSource for SurrealDB {
         let parts: Vec<Expression<AnySurrealType>> = table
             .columns()
             .values()
+            // Imported implicit-reference columns exist only as projection
+            // aliases; the escaped dotted identifier addresses a nonexistent
+            // field and would silently never match.
+            .filter(|col| !table.is_imported_column(col.name()))
             .map(|col| {
                 let needle = search_value.to_lowercase();
                 crate::surreal_expr!(

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -265,6 +265,19 @@ pub(crate) fn build_surreal_table(
     }
 
     let table = table.with_contained_specs(&spec.contained, build_column)?;
+
+    // A dotted spec column (`batch.name`) is an implicit reference — route it
+    // through `with_active_columns` so it becomes a validated traversal import.
+    // Left as a literal column it would project a single-escaped ⟨batch.name⟩
+    // field lookup: a dead column that renders NONE in every row. The active
+    // set must then name every column, so pass the full declared set.
+    let table = if spec.columns.keys().any(|n| n.contains('.')) {
+        let names: Vec<String> = table.columns().keys().cloned().collect();
+        let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        table.with_active_columns(&name_refs)?
+    } else {
+        table
+    };
     Ok(table)
 }
 
@@ -468,9 +481,21 @@ where
 {
     let mut metadata = VistaMetadata::new();
     for (name, col) in table.columns() {
-        // SurrealDB sorts on any field; flag every column ORDERABLE.
-        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string())
-            .with_flag(vista_flags::ORDERABLE);
+        let mut vc = VistaColumn::new(name.clone(), col.get_type().to_string());
+        // SurrealDB sorts on any physical field; flag those ORDERABLE. An
+        // imported implicit-reference column exists only as a projection
+        // alias — ordering by its dotted name would address a nonexistent
+        // field and silently not sort, so it gets CALCULATED instead.
+        if table.is_imported_column(name) {
+            vc = vc.with_flag(vista_flags::CALCULATED);
+        } else {
+            vc = vc.with_flag(vista_flags::ORDERABLE);
+            // expr:/lazy computed columns stay orderable (they order by
+            // their projected alias) but are read-only for consumers.
+            if table.is_calculated_column(name) {
+                vc = vc.with_flag(vista_flags::CALCULATED);
+            }
+        }
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }
@@ -537,6 +562,81 @@ mod tests {
         // path — so traversal survives.
         let reserved = db.traversal_path_expr(&["SELECT"], "name").unwrap();
         assert_eq!(reserved.preview(), "⟨SELECT⟩.name");
+    }
+
+    /// A dotted spec column routes through the traversal import: the idiom
+    /// descends the relation's **link field** (here `batch`), not its registry
+    /// name (`owner`), the flat dotted alias is escaped as a single
+    /// identifier, and metadata flags the column `calculated` (not orderable —
+    /// the dotted name is a projection alias, not a sortable field).
+    #[test]
+    fn factory_routes_dotted_spec_column_through_traversal() {
+        let batch_yaml = r#"
+name: batch
+columns:
+  id: { type: string, flags: [id] }
+  name: { type: string }
+"#;
+        let tag_yaml = r#"
+name: tag
+columns:
+  id: { type: string, flags: [id] }
+  status: { type: string }
+  batch: { type: string }
+  owner.name: { type: string }
+references:
+  owner:
+    table: batch
+    kind: has_one
+    foreign_key: batch
+"#;
+        let resolver = registry_resolver(vec![("batch".to_string(), parse(batch_yaml))]);
+        let table =
+            build_surreal_table(&parse(tag_yaml), test_db(), Some(resolver)).expect("build tag");
+
+        let preview = table.select().preview();
+        println!("QUERY: {preview}");
+        assert!(
+            preview.contains("batch.name"),
+            "idiom must descend the link field `batch`: {preview}"
+        );
+        assert!(
+            preview.contains("⟨owner.name⟩"),
+            "dotted alias must be a single escaped identifier: {preview}"
+        );
+        assert!(
+            !preview.contains("(owner.name)"),
+            "relation name must not be used as the idiom path: {preview}"
+        );
+
+        let metadata = metadata_from_table(&table);
+        let col = metadata.columns.get("owner.name").expect("metadata column");
+        assert!(
+            col.flags.iter().any(|f| f == vista_flags::CALCULATED),
+            "imported column must be flagged calculated: {:?}",
+            col.flags
+        );
+        assert!(
+            !col.flags.iter().any(|f| f == vista_flags::ORDERABLE),
+            "imported column must not be orderable: {:?}",
+            col.flags
+        );
+        let status = metadata.columns.get("status").expect("status column");
+        assert!(status.flags.iter().any(|f| f == vista_flags::ORDERABLE));
+    }
+
+    /// A dotted spec column naming an unknown relation fails the build —
+    /// the factory propagates `with_active_columns`' build-time error instead
+    /// of leaving a dead literal column.
+    #[test]
+    fn factory_rejects_dotted_spec_column_with_unknown_relation() {
+        let yaml = r#"
+name: tag
+columns:
+  id: { type: string, flags: [id] }
+  nope.name: { type: string }
+"#;
+        assert!(build_surreal_table(&parse(yaml), test_db(), None).is_err());
     }
 
     #[cfg(feature = "rhai")]

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -11,11 +11,20 @@
   support are all build-time errors, never fetch-time surprises. SQL backends
   lower each hop into a nested correlated scalar subquery; a backend may
   override the new `TableSource::traversal_path_expr` hook to emit a native path
-  instead (SurrealDB does). Imported columns are stripped from insert/replace/
-  patch payloads so a read-modify-save round-trip never persists them.
+  instead (SurrealDB does). Imported columns are stripped from full-record
+  write payloads (insert, replace, and the generated-id insert path) so a
+  read-modify-save round-trip never persists them; a `patch` naming an
+  imported column is rejected with an explicit read-only error instead of
+  silently no-opping.
 - New `TableSource::supports_traversal` / `traversal_path_expr` hooks (default
   `false` / `None`); `Table::select_expression` extracted from `select_column`
-  so a traversal expression can nest.
+  so a traversal expression can nest. `traversal_path_expr` receives each
+  hop's foreign-key/link *field* (not the relation's registry name), so a
+  relation named differently from its link column still lowers correctly.
+- Expression-only columns (registered via `with_expression` with no column
+  def) can be named in the active set; `Table::is_imported_column` /
+  `is_calculated_column` accessors let driver factories flag computed columns
+  `calculated` in vista metadata.
 
 ## 0.6.11 — 2026-07-20
 

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.13 — 2026-07-21
+
+- Implicit-references review fixes: the generated-id insert path
+  (`insert_return_id_value`, which typed-entity inserts funnel through) strips
+  imported columns like the other write paths; a `patch` naming an imported
+  column is rejected with an explicit read-only error instead of silently
+  no-opping; expression-only columns (registered via `with_expression` with no
+  column def) can be named in an active set.
+- `traversal_path_expr` receives each hop's foreign-key/link *field* (not the
+  relation's registry name), so a relation named differently from its link
+  column still lowers correctly on native-path backends.
+- New `Table::is_imported_column` / `is_calculated_column` accessors let driver
+  factories flag computed columns `calculated` in vista metadata.
+
 ## 0.6.12 — 2026-07-21
 
 - `Table::with_active_columns(&["id", "client.name", "client.bakery.name"])` —
@@ -11,20 +25,11 @@
   support are all build-time errors, never fetch-time surprises. SQL backends
   lower each hop into a nested correlated scalar subquery; a backend may
   override the new `TableSource::traversal_path_expr` hook to emit a native path
-  instead (SurrealDB does). Imported columns are stripped from full-record
-  write payloads (insert, replace, and the generated-id insert path) so a
-  read-modify-save round-trip never persists them; a `patch` naming an
-  imported column is rejected with an explicit read-only error instead of
-  silently no-opping.
+  instead (SurrealDB does). Imported columns are stripped from insert/replace/
+  patch payloads so a read-modify-save round-trip never persists them.
 - New `TableSource::supports_traversal` / `traversal_path_expr` hooks (default
   `false` / `None`); `Table::select_expression` extracted from `select_column`
-  so a traversal expression can nest. `traversal_path_expr` receives each
-  hop's foreign-key/link *field* (not the relation's registry name), so a
-  relation named differently from its link column still lowers correctly.
-- Expression-only columns (registered via `with_expression` with no column
-  def) can be named in the active set; `Table::is_imported_column` /
-  `is_calculated_column` accessors let driver factories flag computed columns
-  `calculated` in vista metadata.
+  so a traversal expression can nest.
 
 ## 0.6.11 — 2026-07-20
 

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/table/base.rs
+++ b/vantage-table/src/table/base.rs
@@ -183,11 +183,32 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
     /// payload. They are read-only, expression-backed projections that no
     /// backend can honestly store; a round-trip (read → modify → save) would
     /// otherwise carry them back, and a SCHEMALESS store would create a literal
-    /// `country.name` field. Called before invariants on every write path.
+    /// `country.name` field. Called before invariants on the full-record write
+    /// paths (insert, insert-returning-id, replace); `patch_value` instead
+    /// rejects imported keys outright, since a partial payload is explicit
+    /// intent per key.
     pub(super) fn strip_imported_columns(&self, record: &mut vantage_types::Record<T::Value>) {
         for name in &self.imported_columns {
             record.shift_remove(name);
         }
+    }
+
+    /// Whether `name` is an imported implicit-reference column
+    /// (`"country.name"`) — an expression-backed traversal projection that is
+    /// read-only and must never be persisted, ordered, or searched as if it
+    /// were a physical field.
+    pub fn is_imported_column(&self, name: &str) -> bool {
+        self.imported_columns.contains(name)
+    }
+
+    /// Whether `name` is computed rather than stored: an imported
+    /// implicit-reference column, a server-side expression column, or a lazy
+    /// (post-fetch) computed column. Driver factories flag such columns
+    /// `calculated` in vista metadata so consumers render them read-only.
+    pub fn is_calculated_column(&self, name: &str) -> bool {
+        self.imported_columns.contains(name)
+            || self.expressions.contains_key(name)
+            || self.lazy_expressions.contains_key(name)
     }
 
     /// Snapshot the table's relations as Vista references (name, target type,

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -602,6 +602,15 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         Ok(reference.cardinality())
     }
 
+    /// Look up the foreign-key/link field for a registered relation. For a
+    /// `has_one` this is the source-side column carrying the link — the field
+    /// a backend-native traversal (e.g. a SurrealDB idiom path) descends
+    /// through, which need not match the relation's registry name.
+    pub fn ref_foreign_key(&self, relation: &str) -> Result<String> {
+        let (reference, _) = self.lookup_ref(relation)?;
+        Ok(reference.foreign_key().to_string())
+    }
+
     /// List all registered relations with their cardinality.
     pub fn ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.refs

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -187,18 +187,19 @@ where
     ///     .with_active_columns(&["id", "client.name", "client.bakery.name"])?;
     /// // SELECT id,
     /// //   (SELECT name FROM client WHERE client.id = client_order.client_id) AS "client.name",
-    /// //   (SELECT name FROM bakery WHERE bakery.id = client.bakery_id …)     AS "client.bakery.name"
+    /// //   (SELECT (SELECT name FROM bakery WHERE bakery.id = client.bakery_id)
+    /// //      FROM client WHERE client.id = client_order.client_id)           AS "client.bakery.name"
     /// // FROM client_order
     /// ```
     ///
-    /// A non-dotted entry restricts projection to that existing column
-    /// (exactly today's declared columns). A dotted entry `a.b…c` resolves `a`,
-    /// `b`… as `has_one` relations and `c` as a column on the final target.
-    /// Everything is validated here, so every failure is a **build-time** error,
-    /// never a fetch-time surprise: unknown column, unknown relation, a
-    /// `has_many` hop, or a backend that cannot lower traversal into its query
-    /// (MongoDB, CSV, REST, CMD). Same-datasource only; cross-datasource
-    /// traversal is a Diorama augmentation concern.
+    /// A non-dotted entry restricts projection to an existing column or
+    /// expression column (exactly today's declared set). A dotted entry `a.b…c`
+    /// resolves `a`, `b`… as `has_one` relations and `c` as a column on the
+    /// final target. Everything is validated here, so every failure is a
+    /// **build-time** error, never a fetch-time surprise: unknown column,
+    /// unknown relation, a `has_many` hop, or a backend that cannot lower
+    /// traversal into its query (e.g. MongoDB, CSV, REST). Same-datasource
+    /// only; cross-datasource traversal is a Diorama augmentation concern.
     pub fn with_active_columns(mut self, cols: &[&str]) -> Result<Self>
     where
         T: 'static,
@@ -224,7 +225,7 @@ where
                 }
 
                 // Validate the has_one chain and that the final column exists.
-                let target = self.resolve_has_one_target(hops)?;
+                let (target, fk_hops) = self.resolve_has_one_target(hops)?;
                 if !target.columns().contains_key(column) {
                     return Err(error!(
                         "implicit reference target has no such column",
@@ -232,9 +233,15 @@ where
                     ));
                 }
 
-                // Lower to an expression: native path (SurrealDB idiom) first,
-                // else the generic nested correlated-subquery chain.
-                let expr = match self.data_source().traversal_path_expr(hops, column) {
+                // Lower to an expression: native path first, else the generic
+                // nested correlated-subquery chain. The native path receives
+                // the foreign-key/link *fields*, not the relation names — a
+                // SurrealDB idiom path traverses record-link fields, and a
+                // relation is free to be named differently from its FK
+                // (`with_one("owner", "client", …)` must lower to
+                // `client.name`, not the nonexistent `owner.name`).
+                let fk_refs: Vec<&str> = fk_hops.iter().map(String::as_str).collect();
+                let expr = match self.data_source().traversal_path_expr(&fk_refs, column) {
                     Some(e) => e,
                     None => self.traverse_rest_generic(hops, column)?,
                 };
@@ -250,7 +257,10 @@ where
                     .get_or_insert_with(Default::default)
                     .insert(dotted);
             } else {
-                if !self.columns.contains_key(col) {
+                // Expression columns registered via `with_expression` alone
+                // (no column def) are projectable too — activating them must
+                // work, or an active set would silently drop them for good.
+                if !self.columns.contains_key(col) && !self.expressions.contains_key(col) {
                     return Err(error!("unknown active column", column = col));
                 }
                 self.active_columns
@@ -296,9 +306,12 @@ where
         }
     }
 
-    /// Walk a chain of `has_one` hops and return the final target table,
-    /// erroring at build time on an unknown relation or a `has_many` hop.
-    fn resolve_has_one_target(&self, hops: &[&str]) -> Result<Table<T, EmptyEntity>>
+    /// Walk a chain of `has_one` hops and return the final target table along
+    /// with each hop's foreign-key/link field (in hop order), erroring at
+    /// build time on an unknown relation or a `has_many` hop. The FK fields
+    /// feed the backend-native path lowering, which traverses fields — the
+    /// relation *names* only address the refs registry.
+    fn resolve_has_one_target(&self, hops: &[&str]) -> Result<(Table<T, EmptyEntity>, Vec<String>)>
     where
         T: 'static,
         E: 'static,
@@ -312,11 +325,14 @@ where
                 relation = *head
             ));
         }
+        let fk = self.ref_foreign_key(head)?;
         let target: Table<T, EmptyEntity> = self.get_ref_target_erased(head)?;
         if tail.is_empty() {
-            Ok(target)
+            Ok((target, vec![fk]))
         } else {
-            target.resolve_has_one_target(tail)
+            let (final_target, mut fks) = target.resolve_has_one_target(tail)?;
+            fks.insert(0, fk);
+            Ok((final_target, fks))
         }
     }
 }
@@ -351,6 +367,11 @@ where
     /// may extend the query in place (joins referencing the base tables) or wrap
     /// it as a subquery (to filter/sort on a computed alias). Conditions already
     /// baked into the base select are not re-applied.
+    ///
+    /// Implicit references are **not** inherited: the derived table starts with
+    /// no active set, and listing an imported dotted column in `columns` copies
+    /// only its bare definition (no traversal expression, no read-only
+    /// tracking). Re-declare traversals on the derived table if needed.
     pub fn derive_from<E2: Entity<V> + 'static>(
         source: &Table<T, E2>,
         alias: impl Into<String>,

--- a/vantage-table/src/table/sets/insertable_value_set.rs
+++ b/vantage-table/src/table/sets/insertable_value_set.rs
@@ -24,6 +24,7 @@ where
         let erased = self.as_entity_erased();
         let mut record = record.clone();
         run_before(self.before_insert_hooks(), &mut record, erased).await?;
+        self.strip_imported_columns(&mut record);
         enforce_invariants(&mut record, self.invariants())?;
         let id = self
             .data_source()

--- a/vantage-table/src/table/sets/writable_value_set.rs
+++ b/vantage-table/src/table/sets/writable_value_set.rs
@@ -66,6 +66,16 @@ where
         partial: &Record<Self::Value>,
     ) -> Result<Record<Self::Value>> {
         let id = id.into();
+        // A patch is explicit intent per key — unlike a full-record round-trip
+        // there is nothing incidental to strip, so a read-only imported column
+        // in the payload is an error, not a silent drop (stripping it could
+        // even leave an empty patch that "succeeds" while changing nothing).
+        if let Some(name) = partial.keys().find(|k| self.is_imported_column(k)) {
+            return Err(vantage_core::error!(
+                "cannot patch read-only implicit-reference column",
+                column = name.as_str()
+            ));
+        }
         let erased = self.as_entity_erased();
         let mut partial = partial.clone();
         run_before(self.before_update_hooks(), &mut partial, erased).await?;

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -281,11 +281,13 @@ pub trait TableSource: DataSource + Clone + 'static {
 
     /// Build a correlated condition: `target_table.target_field = source_table.source_column`.
     ///
-    /// Used by `get_subquery_as` for embedding correlated subqueries inside SELECT
-    /// expressions (e.g. `(SELECT COUNT(*) FROM order WHERE order.client_id = client.id)`).
-    ///
-    /// SQL backends produce table-qualified equality; non-SQL backends may not support
-    /// correlated subqueries and should leave the default (which panics).
+    /// Used by `get_subquery_as` / `get_subquery_erased` for embedding correlated
+    /// subqueries inside SELECT expressions (e.g.
+    /// `(SELECT COUNT(*) FROM order WHERE order.client_id = client.id)`), and by
+    /// the generic implicit-reference lowering. SQL and SurrealDB backends
+    /// produce table-qualified equality; backends without correlated subqueries
+    /// leave the default (which panics — they must also keep
+    /// [`supports_traversal`](Self::supports_traversal) `false`).
     fn related_correlated_condition(
         &self,
         target_table: &str,
@@ -300,7 +302,7 @@ pub trait TableSource: DataSource + Clone + 'static {
     /// Whether this backend can lower a dotted active column
     /// (`"country.name"`) into its own query — a nested correlated subquery for
     /// SQL, a native idiom path for SurrealDB. Backends that can build neither
-    /// (MongoDB, CSV, REST, CMD) leave the default `false`, and
+    /// (e.g. MongoDB, CSV, REST) leave the default `false`, and
     /// [`Table::with_active_columns`](crate::table::Table::with_active_columns)
     /// rejects dotted names against them at build time rather than at fetch time.
     fn supports_traversal(&self) -> bool {
@@ -310,9 +312,11 @@ pub trait TableSource: DataSource + Clone + 'static {
     /// Build a backend-native path expression for a dotted active column,
     /// tried before the generic correlated-subquery chain.
     ///
-    /// `hops` names the `has_one` relations to traverse and `column` the final
-    /// field. The default returns `None`, so backends fall back to the generic
-    /// chain built on [`related_correlated_condition`](Self::related_correlated_condition).
+    /// `hops` holds each traversed relation's **foreign-key/link field** (not
+    /// its registry name — a relation named `owner` over a link field `client`
+    /// must lower to `client.…`), and `column` the final field. The default
+    /// returns `None`, so backends fall back to the generic chain built on
+    /// [`related_correlated_condition`](Self::related_correlated_condition).
     /// SurrealDB overrides this to emit an idiom path (`batch.golf_course.name`,
     /// each segment escaped separately); multi-hop comes for free. The returned
     /// expression is unaliased — `select()` aliases it to the dotted name.

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -7,7 +7,9 @@
   Consumers render it read-only and exclude it from forms and write payloads.
 - `VistaCapabilities::can_traverse_in_columns` — whether a backend can lower a
   dotted column (`country.name`) into its own query. SQL and SurrealDB shells
-  advertise `true`; CSV/Mongo/REST leave it `false`.
+  advertise `true`; CSV/Mongo/REST leave it `false`. Readable by name via
+  `capability_flag` and the rhai capabilities map (which also gained the
+  previously missing `can_fetch_window` arm).
 
 ## 0.6.12 — 2026-07-20
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.14 — 2026-07-21
+
+- `can_traverse_in_columns` — and the previously missing `can_fetch_window` —
+  are readable by name via `capability_flag` and the rhai capabilities map.
+- `flags::CALCULATED` doc matched to actual behavior (applied by driver
+  factories via `Table::is_calculated_column`).
+
 ## 0.6.13 — 2026-07-21
 
 - `flags::CALCULATED` (`"calculated"`) — a read-only, source-computed column
@@ -7,9 +14,7 @@
   Consumers render it read-only and exclude it from forms and write payloads.
 - `VistaCapabilities::can_traverse_in_columns` — whether a backend can lower a
   dotted column (`country.name`) into its own query. SQL and SurrealDB shells
-  advertise `true`; CSV/Mongo/REST leave it `false`. Readable by name via
-  `capability_flag` and the rhai capabilities map (which also gained the
-  previously missing `can_fetch_window` arm).
+  advertise `true`; CSV/Mongo/REST leave it `false`.
 
 ## 0.6.12 — 2026-07-20
 

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/flags.rs
+++ b/vantage-vista/src/flags.rs
@@ -11,7 +11,9 @@ pub const SEARCHABLE: &str = "searchable";
 pub const ORDERABLE: &str = "orderable";
 pub const MANDATORY: &str = "mandatory";
 pub const HIDDEN: &str = "hidden";
-/// Read-only, source-computed column: an implicit-reference traversal
-/// (`country.name`), an `expr:` script, or a lazy computed column. Consumers
-/// render it read-only and exclude it from forms and write payloads.
+/// Read-only computed column: an implicit-reference traversal
+/// (`country.name`), an `expr:` script, or a lazy computed column — flagged by
+/// driver factories via `Table::is_calculated_column`. Consumers should render
+/// it read-only and exclude it from forms and write payloads; the data layer
+/// enforces the same on writes (imported columns are stripped or rejected).
 pub const CALCULATED: &str = "calculated";

--- a/vantage-vista/src/rhai/introspect.rs
+++ b/vantage-vista/src/rhai/introspect.rs
@@ -28,6 +28,7 @@ pub(crate) fn capabilities_map(vista: &Vista) -> RhaiMap {
     put("can_traverse_to_record", c.can_traverse_to_record);
     put("can_traverse_to_set", c.can_traverse_to_set);
     put("can_build_ref_via_script", c.can_build_ref_via_script);
+    put("can_traverse_in_columns", c.can_traverse_in_columns);
     m
 }
 

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -513,9 +513,11 @@ pub trait TableShell: Send + Sync + 'static {
             "can_set_page_size" => caps.can_set_page_size,
             "can_fetch_page" => caps.can_fetch_page,
             "can_fetch_next" => caps.can_fetch_next,
+            "can_fetch_window" => caps.can_fetch_window,
             "can_traverse_to_record" => caps.can_traverse_to_record,
             "can_traverse_to_set" => caps.can_traverse_to_set,
             "can_build_ref_via_script" => caps.can_build_ref_via_script,
+            "can_traverse_in_columns" => caps.can_traverse_in_columns,
             _ => false,
         }
     }


### PR DESCRIPTION
Follow-up to #347 (VAN-102) addressing a multi-agent review of the merged implementation.

## Critical fixes
- **`insert_return_id_value` now strips imported columns** — the generated-id insert path (which typed-entity inserts funnel through) previously carried `client.name` to the backend: unknown-column failure on SQL, a literal dotted field persisted on SCHEMALESS SurrealDB. Test added.
- **SurrealDB idiom paths now descend link *fields*, not relation names** — `with_one("owner", "batch", …)` validated Ok at build but queried the nonexistent `owner.name` (NONE per row). `resolve_has_one_target` collects each hop's FK field and `traversal_path_expr` receives those. Test uses a relation named differently from its link field.
- **`patch_value` rejects imported columns** with an explicit read-only error — previously a patch naming only an imported column silently no-opped with `Ok` on SurrealDB.

## Spec completion
- The surreal vista factory routes dotted spec columns (`owner.name:`) through `with_active_columns` — the YAML surface previously bypassed the feature entirely, producing dead ⟨owner.name⟩ literal lookups. Build errors propagate.
- All four factories flag computed columns `calculated` in metadata; surreal imported columns are additionally not `orderable` (ordering by the dotted alias silently didn't sort).

## Other
- Quicksearch skips imported columns in all four backends (SQLite degraded the dotted identifier to a string literal and matched wrong rows).
- Expression-only columns (`with_expression` with no column def) can be named in an active set.
- `can_traverse_in_columns` readable via `capability_flag` and the rhai capabilities map; added the previously missing `can_fetch_window` arm.
- Doc fixes: two-hop SQL sample nesting, strip/flag claims matched to behavior, stale trait docs; changelog updates in all four crates.
- New tests: 5 sqlite (generated-id strip, patch rejection, projection exclusion, id auto-projection, expression-only activation) + 2 surreal factory (dotted routing + calculated flag, unknown-relation rejection); fixed a vacuous assert.

Known remaining (documented, out of scope): `derive_from` does not inherit implicit references; the vantage-ui `read_path` exact-key-first fallback ships separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-hop dotted-column traversal/activation across supported data sources.
  * Expression-only columns can be activated and included in results.
  * Metadata now marks calculated and imported traversal columns with clearer capability/flag behavior (including read-only handling for forms and writes).
* **Bug Fixes**
  * Search/Quicksearch now skips imported columns to avoid incorrect matches and backend errors.
  * Imported columns are stripped on all write paths (including generated-id insert); patching imported/read-only columns now returns an explicit error.
  * Invalid dotted-column traversal/spec references fail early.
* **Documentation**
  * Expanded guidance on dotted-column implicit references and correlated traversal behavior.
* **Tests**
  * Added/strengthened coverage for dotted imported columns, active-set projection, and patch/insert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->