### PR TITLE
diorama 0.6.22: CappedScenery — row-cap decorator over TableScenery (VAN-99)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.22 — 2026-07-22
+
+- New `CappedScenery` — a row-cap decorator over `TableScenery`. Every
+  consumer of the trait sees at most `cap` rows (`row_count`, `row`,
+  `estimated_total`, `has_more` all bounded); viewports clamp to the cap and
+  `request_load_more` stops at it, while refresh, sort, search, and
+  subscription delegate to the wrapped scenery. The view a UI-level `limit:`
+  produces — capping the scenery instead of the hydration viewport means a
+  master without windowed loading is never asked to serve a viewport
+  contract it can't.
+
 ## 0.6.21 — 2026-07-21
 
 - The Dio shell passes `VistaCapabilities::can_traverse_in_columns` through from

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -26,8 +26,8 @@ pub use lens::{
 };
 pub use ops::{ChangeEvent, QueryDescriptor, WriteOp};
 pub use scenery::{
-    Aggregate, CustomAggregate, EnrichedRecord, RecordScenery, RecordStatus, RowStatus,
-    RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder, ValueScenery,
+    Aggregate, CappedScenery, CustomAggregate, EnrichedRecord, RecordScenery, RecordStatus,
+    RowStatus, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder, ValueScenery,
     ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
 };
 pub use vantage_vista::VistaCapabilities;

--- a/vantage-diorama/src/scenery/mod.rs
+++ b/vantage-diorama/src/scenery/mod.rs
@@ -5,7 +5,7 @@ pub mod value;
 
 pub use enriched_record::{EnrichedRecord, RowStatus};
 pub use record::{RecordScenery, RecordStatus};
-pub use table::{RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder};
+pub use table::{CappedScenery, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder};
 pub use value::{
     Aggregate, CustomAggregate, ValueScenery, ValueSceneryBuilder, ValueStatus,
     boxed_custom_aggregate,

--- a/vantage-diorama/src/scenery/table/capped.rs
+++ b/vantage-diorama/src/scenery/table/capped.rs
@@ -1,0 +1,95 @@
+//! A row-cap decorator over a [`TableScenery`].
+//!
+//! The view a UI-level `limit:` produces: every consumer of the trait —
+//! hosted grids, observation adapters, scrollbar sizing — sees at most
+//! `cap` rows through one wrapper, instead of each consumer re-implementing
+//! the truncation. Capping the *scenery* (not the hydration viewport) also
+//! means a master without windowed loading is never asked to serve a
+//! viewport contract it can't: the underlying scenery keeps its own loading
+//! mode (eager cache seed or chunked), and the cap only bounds what is
+//! visible.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use tokio::sync::watch;
+use vantage_vista::VistaCapabilities;
+
+use crate::dio::Generation;
+use crate::scenery::enriched_record::EnrichedRecord;
+
+use super::{RowStatusSummary, SortDir, TableScenery};
+
+pub struct CappedScenery {
+    inner: Arc<dyn TableScenery>,
+    cap: usize,
+}
+
+impl CappedScenery {
+    pub fn wrap(inner: Arc<dyn TableScenery>, cap: usize) -> Arc<Self> {
+        Arc::new(Self { inner, cap })
+    }
+}
+
+impl TableScenery for CappedScenery {
+    fn row_count(&self) -> usize {
+        self.inner.row_count().min(self.cap)
+    }
+
+    fn status_summary(&self) -> RowStatusSummary {
+        self.inner.status_summary()
+    }
+
+    /// More rows exist only while the cap itself isn't reached — a capped
+    /// view is complete at `cap`, so paging affordances stop there.
+    fn has_more(&self) -> bool {
+        self.inner.row_count() < self.cap && self.inner.has_more()
+    }
+
+    fn estimated_total(&self) -> Option<usize> {
+        self.inner.estimated_total().map(|t| t.min(self.cap))
+    }
+
+    fn row(&self, idx: usize) -> Option<Arc<EnrichedRecord>> {
+        if idx < self.cap {
+            self.inner.row(idx)
+        } else {
+            None
+        }
+    }
+
+    fn set_viewport(&self, range: Range<usize>) {
+        self.inner
+            .set_viewport(range.start.min(self.cap)..range.end.min(self.cap));
+    }
+
+    fn request_load_more(&self) {
+        if self.inner.row_count() < self.cap {
+            self.inner.request_load_more();
+        }
+    }
+
+    fn request_refresh(&self) {
+        self.inner.request_refresh();
+    }
+
+    fn set_search(&self, query: Option<String>) {
+        self.inner.set_search(query);
+    }
+
+    fn set_sort(&self, column: Option<String>, dir: SortDir) {
+        self.inner.set_sort(column, dir);
+    }
+
+    fn subscribe(&self) -> watch::Receiver<Generation> {
+        self.inner.subscribe()
+    }
+
+    fn master_capabilities(&self) -> &VistaCapabilities {
+        self.inner.master_capabilities()
+    }
+
+    fn demanded_columns(&self) -> Option<Vec<String>> {
+        self.inner.demanded_columns()
+    }
+}

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -18,6 +18,7 @@
 //! on its own output.
 
 mod builder;
+mod capped;
 mod helpers;
 mod loader;
 mod reactor;
@@ -35,6 +36,7 @@ use crate::dio::Generation;
 use super::enriched_record::EnrichedRecord;
 
 pub use builder::TableSceneryBuilder;
+pub use capped::CappedScenery;
 pub(crate) use state::TableSceneryState;
 
 /// UI-side sort direction. Mirrors `vantage_vista::SortDirection` but

--- a/vantage-diorama/tests/table_scenery.rs
+++ b/vantage-diorama/tests/table_scenery.rs
@@ -7,7 +7,7 @@ use ciborium::Value as CborValue;
 use tempfile::TempDir;
 use vantage_core::Result;
 use vantage_dataset::prelude::ReadableValueSet;
-use vantage_diorama::{Lens, SortDir};
+use vantage_diorama::{Lens, SortDir, TableScenery};
 use vantage_types::Record;
 use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
 
@@ -256,5 +256,35 @@ async fn scenery_outlives_dio_handle_drop() -> Result<()> {
     // memory (just no future reloads).
     drop(dio);
     assert_eq!(scenery.row_count(), 3);
+    Ok(())
+}
+
+/// A `CappedScenery` bounds every read to the cap while delegating
+/// behaviour (refresh, sort, subscribe) to the wrapped scenery.
+#[tokio::test]
+async fn capped_scenery_bounds_the_view() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = build_lens(tmp.path().join("cache.redb")).await?;
+    let dio = lens.make_dio(seeded_master()).await?;
+
+    let scenery = dio.table_scenery().open().await?;
+    let capped = vantage_diorama::CappedScenery::wrap(scenery.clone(), 2);
+    assert_eq!(capped.row_count(), 2);
+    assert!(capped.row(1).is_some());
+    assert!(capped.row(2).is_none()); // exists beneath, hidden by the cap
+    assert!(!capped.has_more()); // the capped view is complete at the cap
+
+    // Sorting still reaches the wrapped scenery, and the cap then shows
+    // the top of the NEW order.
+    let mut gen_rx = capped.subscribe();
+    let initial = u64::from(*gen_rx.borrow_and_update());
+    capped.set_sort(Some("price".to_string()), SortDir::Asc);
+    wait_for_gen(&mut gen_rx, initial).await;
+    let r0 = capped.row(0).unwrap();
+    assert_eq!(r0.record.get("name"), Some(&cbor_text("beta"))); // price 10
+
+    // A cap wider than the data doesn't invent rows.
+    let wide = vantage_diorama::CappedScenery::wrap(scenery, 10);
+    assert_eq!(wide.row_count(), 3);
     Ok(())
 }


### PR DESCRIPTION
New `CappedScenery`: a decorator implementing `TableScenery` that bounds every read to a cap — `row_count`/`row`/`estimated_total`/`has_more` truncated, viewports clamped, `request_load_more` stops at the cap — while refresh, sort, search, and subscription delegate to the wrapped scenery.

This is the data-layer half of VAN-99: a framework grid's `limit:` previously mapped to a hydration viewport (`open_with_viewport(0..limit)`), routing snapshot/eager masters into a windowed-chunk contract they can't serve (`fire_chunk_load: SKIP`) and capping nobody's display. Capping the scenery itself means every consumer — hosted grid, observation adapter, scrollbar sizing — sees at most `cap` rows through one wrapper, and the underlying scenery keeps its own loading mode. vantage-ui consumes this in its VAN-99 fix (wraps at shape-resolve time).

Test: `capped_scenery_bounds_the_view` in `tests/table_scenery.rs` — cap bounds reads, sort reaches the wrapped scenery with the cap showing the top of the new order, a wide cap doesn't invent rows.

VAN-99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable row limits for table views.
  - Row counts, visible data, totals, and loading indicators now respect the configured cap.
  - Viewports are automatically constrained to the limit.
  - Sorting, searching, refreshing, and subscriptions continue to work within capped views.
  - Loading more rows stops once the limit is reached.

- **Bug Fixes**
  - Prevented unsupported windowed-loading requests when a table limit is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->