### PR TITLE
diorama 0.7.1: effective write caps, reconcile-while-pending, drain-not-drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.7.1 — 2026-07-22
+
+**Flash-pipeline hardening: effective caps, reconcile-while-pending, drain-not-drop**
+
+- **`Dio::write_capabilities()`** — the effective write capabilities, and
+  the one gate UI chrome asks before offering add/edit/delete. Master
+  caps by default; a registered `on_flash` route lifts all three, because
+  the route — not the master — is then the writer (a read-only CSV
+  becomes editable, changes landing wherever the route sends them). The
+  facade's capability lifting now shares this one definition.
+- **Reconcile-while-pending**: a refresh carrying a master snapshot taken
+  *before* an in-flight flash can no longer clobber the staged value.
+  Rows with a flash in flight are tracked internally; the new
+  `Dio::reconcile_value` / `reconcile_values` (the cache write an
+  `on_refresh` callback should use for master-copied rows) skip them, as
+  do the augment refresh pass (including its vanished-row delete) and
+  `ChunkSink::push` (which binds the staged value to the slot instead).
+  `patched` stays the ingress for push changes — a live stream is fresh
+  by definition; snapshots may be stale, hence the guard. On confirm the
+  flash also **re-asserts** exactly the fields it wrote over anything
+  that raced into the cache mid-flight, keeping fresher values for
+  fields it never touched.
+- **Drain, not drop**: every queued flash now carries a strong handle to
+  the pipeline, so fire-and-forget writes already accepted keep the Dio
+  (master, cache, routes, event bus) alive until they land — dropping
+  every external handle no longer discards queued work. The worker then
+  exits cleanly on its own.
+
 ## 0.7.0 — 2026-07-22
 
 **Servo & ChangeFlash — the outbound half of the photography lexicon**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/augment_passes.rs
+++ b/vantage-diorama/src/dio/augment_passes.rs
@@ -176,6 +176,11 @@ pub(crate) async fn refresh(dio: &Dio) -> Result<()> {
     let augmented = dio.inner.augmented_columns.read().unwrap().clone();
 
     for (id, list_row) in &fresh {
+        // A row with a flash in flight keeps its staged value — this
+        // snapshot may predate the write. The next refresh reconciles it.
+        if dio.inner.pending_flashes.contains(id) {
+            continue;
+        }
         let gap = has_augment_gap(list_row, &augmented);
         let status = if gap {
             CacheStatus::Incomplete
@@ -216,7 +221,7 @@ pub(crate) async fn refresh(dio: &Dio) -> Result<()> {
         }
     }
     for id in existing.keys() {
-        if !fresh.contains_key(id) {
+        if !fresh.contains_key(id) && !dio.inner.pending_flashes.contains(id) {
             cache.delete_value(id).await?;
         }
     }

--- a/vantage-diorama/src/dio/impls/table_shell.rs
+++ b/vantage-diorama/src/dio/impls/table_shell.rs
@@ -164,9 +164,15 @@ impl DioShell {
     }
 
     async fn enqueue(&self, flash: ChangeFlash) -> Result<()> {
+        // The queued flash carries its own keep-alive: even if every
+        // external handle drops right after this returns, the pipeline
+        // stays alive until the write lands.
         self.dio
             .write_queue
-            .send(flash)
+            .send(crate::dio::worker::QueuedFlash {
+                flash,
+                keep_alive: self.dio.clone(),
+            })
             .await
             .map_err(|e| error!("Dio write queue closed", detail = e.to_string()))
     }

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -5,6 +5,7 @@ pub mod event_bus;
 pub mod hot_tier;
 pub mod impls;
 mod optimistic;
+pub(crate) mod pending;
 pub(crate) mod query_index;
 pub mod refresh;
 pub mod shell;
@@ -18,7 +19,7 @@ use vantage_core::Result;
 use vantage_vista::Vista;
 
 use crate::lens::{CacheTable, Lens};
-use crate::ops::{ChangeEvent, ChangeFlash};
+use crate::ops::ChangeEvent;
 use crate::scenery::record::spawn_record_scenery;
 use crate::scenery::{
     RecordScenery, RecordStatus, TableScenery, TableSceneryBuilder, ValueSceneryBuilder,
@@ -73,6 +74,20 @@ pub struct Dio {
     pub(crate) inner: Arc<DioInner>,
 }
 
+/// The Dio's *effective* write capabilities — the one gate UI chrome
+/// asks before offering add/edit/delete.
+///
+/// Defaults to the master Vista's own capabilities; registering an
+/// `on_flash` route lifts all three, because the route — not the
+/// master — is then the writer (a read-only CSV becomes editable, with
+/// changes landing wherever the route sends them).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteCapabilities {
+    pub can_insert: bool,
+    pub can_update: bool,
+    pub can_delete: bool,
+}
+
 pub(crate) struct DioInner {
     pub(crate) lens: Arc<Lens>,
     /// The master Vista, swappable so a [`reload`](Dio::reload) can re-point the
@@ -81,8 +96,12 @@ pub(crate) struct DioInner {
     pub(crate) master: std::sync::RwLock<Arc<Vista>>,
     pub(crate) cache: Arc<dyn CacheTable>,
     pub(crate) cache_table_name: String,
-    pub(crate) write_queue: mpsc::Sender<ChangeFlash>,
+    pub(crate) write_queue: mpsc::Sender<worker::QueuedFlash>,
     pub(crate) event_bus: broadcast::Sender<DioEvent>,
+    /// Rows with an optimistic flash in flight — reconcile-shaped cache
+    /// writers skip them so a stale master snapshot can't clobber a
+    /// staged value. See [`pending::PendingFlashes`].
+    pub(crate) pending_flashes: Arc<pending::PendingFlashes>,
     pub(crate) refresh_task: Mutex<Option<JoinHandle<()>>>,
     pub(crate) write_worker: Mutex<Option<JoinHandle<()>>>,
     pub(crate) hot_tier: Arc<HotTier>,
@@ -134,6 +153,19 @@ impl Drop for DioInner {
 }
 
 impl DioInner {
+    /// See [`Dio::write_capabilities`]. Lives on the inner so
+    /// [`DioShell`] can share the one definition of capability lifting.
+    pub(crate) fn write_capabilities(&self) -> WriteCapabilities {
+        let routed = self.lens.callbacks.on_flash.is_some();
+        let master = self.master.read().unwrap().clone();
+        let caps = master.capabilities();
+        WriteCapabilities {
+            can_insert: caps.can_insert || routed,
+            can_update: caps.can_update || routed,
+            can_delete: caps.can_delete || routed,
+        }
+    }
+
     /// Fetch (or lazily create) the [`QueryIndex`](crate::dio::query_index::QueryIndex)
     /// for `key`. Repeated calls with the same key return the same `Arc`, so
     /// all sceneries on a query variant share one ordered index.
@@ -572,6 +604,50 @@ impl Dio {
     /// re-deriving their index and re-reading their full state.
     pub fn notify_dataset_changed(&self) {
         let _ = self.inner.event_bus.send(DioEvent::DatasetChanged);
+    }
+
+    /// The Dio's effective write capabilities — master caps, lifted to
+    /// fully writable when an `on_flash` route is registered. UI chrome
+    /// gates its add/edit/delete affordances on this, nothing else.
+    pub fn write_capabilities(&self) -> WriteCapabilities {
+        self.inner.write_capabilities()
+    }
+
+    /// Reconcile one row from a master snapshot into the cache —
+    /// **skipping it if a flash is in flight** for that id, so a
+    /// snapshot taken before the write can't clobber the staged value.
+    /// Returns `true` if the row was written, `false` if it was left
+    /// alone.
+    ///
+    /// This is the cache write an `on_refresh` callback should use for
+    /// rows it copied from the master. [`patched`](Self::patched) stays
+    /// the ingress for *push* changes (a live stream is authoritative
+    /// and fresh by definition); reconciles are snapshots and may be
+    /// stale — hence the guard. Emits no events; the surrounding
+    /// refresh flow announces `DatasetChanged` when it completes.
+    pub async fn reconcile_value(
+        &self,
+        id: impl Into<String>,
+        record: &Record<CborValue>,
+    ) -> Result<bool> {
+        let id = id.into();
+        if self.inner.pending_flashes.contains(&id) {
+            return Ok(false);
+        }
+        self.inner.cache.insert_value(&id, record).await?;
+        Ok(true)
+    }
+
+    /// Bulk [`reconcile_value`](Self::reconcile_value): write every row
+    /// whose id has no flash in flight.
+    pub async fn reconcile_values(
+        &self,
+        rows: impl IntoIterator<Item = (String, Record<CborValue>)>,
+    ) -> Result<()> {
+        for (id, record) in rows {
+            self.reconcile_value(id, &record).await?;
+        }
+        Ok(())
     }
 
     /// Write `record` to the cache under `id` and publish

--- a/vantage-diorama/src/dio/optimistic.rs
+++ b/vantage-diorama/src/dio/optimistic.rs
@@ -42,6 +42,11 @@ impl Dio {
             return crate::dio::worker::run_write_through(self, flash).await;
         };
 
+        // Mark the row in flight for the whole optimistic window —
+        // reconcile-shaped writers leave it alone until the guard drops
+        // (commit or rollback, every exit path).
+        let _pending = self.inner.pending_flashes.begin(id.clone());
+
         // 1. Snapshot the pre-image so a failed write can roll back exactly,
         //    and complete the flash with it for downstream routes.
         let pre = self.inner.cache.get_value(&id).await?;
@@ -55,8 +60,13 @@ impl Dio {
             .send(DioEvent::WritePending { id: id.clone() });
 
         // 3. Run the real write-through.
-        match crate::dio::worker::run_write_through(self, flash).await {
+        match crate::dio::worker::run_write_through(self, flash.clone()).await {
             Ok(()) => {
+                // Re-assert the confirmed fields over whatever raced into
+                // the cache mid-flight: a stale writer that bypassed the
+                // pending guard loses exactly the fields this flash wrote,
+                // and keeps everything else it brought.
+                reassert_confirmed(&self.inner, &flash).await?;
                 let _ = self.inner.event_bus.send(DioEvent::RecordChanged { id });
                 Ok(())
             }
@@ -107,6 +117,30 @@ impl Dio {
     /// Delete the row at `id` optimistically.
     pub async fn flash_delete(&self, id: impl Into<String>) -> Result<()> {
         self.flash(ChangeFlash::delete(id)).await
+    }
+}
+
+/// After the write-through confirms, make the cache agree with the
+/// confirmed fields. The staged value normally still stands, but a
+/// writer that bypassed [`Dio::reconcile_value`]'s pending guard may
+/// have clobbered the row mid-flight with a pre-write snapshot. Merging
+/// the flash's own fields onto the *current* row re-asserts exactly what
+/// was confirmed while keeping any fresher values that arrived for other
+/// fields.
+async fn reassert_confirmed(inner: &DioInner, flash: &ChangeFlash) -> Result<()> {
+    let Some(id) = flash.id() else {
+        return Ok(());
+    };
+    match flash.kind() {
+        FlashKind::Insert | FlashKind::Replace | FlashKind::Patch => {
+            let mut merged = inner.cache.get_value(id).await?.unwrap_or_default();
+            for (k, v) in flash.patch() {
+                merged.insert(k.clone(), v.clone());
+            }
+            inner.cache.insert_value(id, &merged).await
+        }
+        FlashKind::Delete => inner.cache.delete_value(id).await,
+        FlashKind::Clear => Ok(()),
     }
 }
 

--- a/vantage-diorama/src/dio/pending.rs
+++ b/vantage-diorama/src/dio/pending.rs
@@ -1,0 +1,58 @@
+//! Registry of rows with a flash in flight.
+//!
+//! An optimistic flash stages its value in the cache before the
+//! write-through confirms. A reconcile that runs inside that window may
+//! carry a master snapshot taken *before* the write — applying it would
+//! clobber the staged value and visibly revert the user's edit. Every
+//! reconcile-shaped cache writer consults this registry and leaves
+//! in-flight rows alone; once the flash settles (commit or rollback) the
+//! row reconciles normally again.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Shared set of in-flight row ids, counted so overlapping flashes on
+/// one id keep it protected until the last one settles.
+#[derive(Default)]
+pub(crate) struct PendingFlashes {
+    ids: Mutex<HashMap<String, usize>>,
+}
+
+impl PendingFlashes {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn contains(&self, id: &str) -> bool {
+        self.ids.lock().unwrap().contains_key(id)
+    }
+
+    /// Mark `id` in flight until the returned guard drops.
+    pub(crate) fn begin(self: &Arc<Self>, id: String) -> PendingFlashGuard {
+        *self.ids.lock().unwrap().entry(id.clone()).or_insert(0) += 1;
+        PendingFlashGuard {
+            registry: self.clone(),
+            id,
+        }
+    }
+}
+
+/// RAII marker for one in-flight flash — releases the row on drop, so
+/// every exit path of the optimistic flow (commit, rollback, panic
+/// unwind) re-opens the row for reconciliation.
+pub(crate) struct PendingFlashGuard {
+    registry: Arc<PendingFlashes>,
+    id: String,
+}
+
+impl Drop for PendingFlashGuard {
+    fn drop(&mut self) {
+        let mut ids = self.registry.ids.lock().unwrap();
+        if let Some(count) = ids.get_mut(&self.id) {
+            *count -= 1;
+            if *count == 0 {
+                ids.remove(&self.id);
+            }
+        }
+    }
+}

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -29,20 +29,19 @@ impl DioShell {
         let references = master.source.references().clone();
         let id_column = master.source.id_column().map(str::to_string);
         drop(master);
-        let cbs = &dio.lens.callbacks;
-        let has_flash_route = cbs.on_flash.is_some();
-        let has_on_event = cbs.on_event.is_some();
+        let has_on_event = dio.lens.callbacks.on_event.is_some();
+        let write_caps = dio.write_capabilities();
 
         // Capability lifting rules (architecture doc):
-        //   can_insert/update/delete = master.X OR an on_flash route registered
+        //   can_insert/update/delete = Dio::write_capabilities (master OR route)
         //   can_subscribe            = always true (Dio fans out events)
         //   can_invalidate           = master.can_invalidate OR on_event registered
         //   can_count                = always true (cache answers locally)
         let capabilities = VistaCapabilities {
             can_count: true,
-            can_insert: master_caps.can_insert || has_flash_route,
-            can_update: master_caps.can_update || has_flash_route,
-            can_delete: master_caps.can_delete || has_flash_route,
+            can_insert: write_caps.can_insert,
+            can_update: write_caps.can_update,
+            can_delete: write_caps.can_delete,
             can_subscribe: true,
             can_invalidate: master_caps.can_invalidate || has_on_event,
             // Read-side query controls reflect the cache today. Stage 5b

--- a/vantage-diorama/src/dio/worker.rs
+++ b/vantage-diorama/src/dio/worker.rs
@@ -1,13 +1,19 @@
-//! Write-queue worker — consumes [`ChangeFlash`]es from `DioInner::write_queue`.
+//! Write-queue worker — consumes [`QueuedFlash`]es from `DioInner::write_queue`.
 //!
 //! For each flash the worker either invokes the lens's `on_flash` route
 //! (when registered) or applies the flash directly to `dio.master()`.
 //! Route errors are logged via `tracing` and emitted on the event
-//! bus as [`DioEvent::WriteFailed`]; the worker keeps running until
-//! the last external Dio handle drops (at which point the sender side
-//! of the channel disappears and `recv()` returns `None`).
+//! bus as [`DioEvent::WriteFailed`].
+//!
+//! **Drain, not drop**: every queued flash carries a strong
+//! `Arc<DioInner>`, so flashes already accepted keep the whole pipeline
+//! (master, cache, routes, event bus) alive until they land — dropping
+//! the last external handle never discards queued work. Once the queue
+//! is empty and the last keep-alive drops, `DioInner` drops, its sender
+//! side disappears, `recv()` returns `None`, and the worker exits
+//! cleanly.
 
-use std::sync::Weak;
+use std::sync::Arc;
 
 use tokio::sync::mpsc;
 use vantage_core::{Result, error};
@@ -16,17 +22,21 @@ use vantage_dataset::traits::WritableValueSet;
 use crate::dio::{Dio, DioEvent, DioInner};
 use crate::ops::{ChangeFlash, FlashKind};
 
-/// The per-Dio write worker loop. Only holds a `Weak<DioInner>` so the
-/// cycle (Dio → channel → worker → Dio) breaks when external handles
-/// drop. Each iteration upgrades the Weak to build a real Dio for the
-/// callback; if upgrade fails (very narrow race: flash sent right before
-/// the last external Dio dropped), the flash is discarded.
-pub(crate) async fn write_worker_loop(inner: Weak<DioInner>, mut rx: mpsc::Receiver<ChangeFlash>) {
-    while let Some(flash) = rx.recv().await {
-        let Some(strong) = inner.upgrade() else {
-            return;
-        };
-        let dio = Dio { inner: strong };
+/// One unit of queued work: the flash plus the strong handle that keeps
+/// the pipeline alive until it lands. The temporary reference cycle
+/// (`DioInner` → sender → channel buffer → `Arc<DioInner>`) resolves as
+/// the worker drains — that transience is exactly the keep-alive
+/// guarantee.
+pub(crate) struct QueuedFlash {
+    pub(crate) flash: ChangeFlash,
+    pub(crate) keep_alive: Arc<DioInner>,
+}
+
+/// The per-Dio write worker loop. Owns nothing but the receiver; each
+/// message brings its own `Arc<DioInner>`.
+pub(crate) async fn write_worker_loop(mut rx: mpsc::Receiver<QueuedFlash>) {
+    while let Some(QueuedFlash { flash, keep_alive }) = rx.recv().await {
+        let dio = Dio { inner: keep_alive };
         let id_for_event = flash.id().map(str::to_string);
         let outcome = run_write_through(&dio, flash).await;
         if let Err(err) = outcome {

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -4,6 +4,7 @@ use ciborium::Value as CborValue;
 use vantage_core::Result;
 use vantage_types::Record;
 
+use crate::dio::pending::PendingFlashes;
 use crate::lens::cache_backend::CacheTable;
 
 /// Trait the calling Scenery implements so a `ChunkSink` can stuff a
@@ -23,6 +24,9 @@ pub trait SceneryChunkTarget: Send + Sync {
 pub struct ChunkSink {
     pub(crate) target: Weak<dyn SceneryChunkTarget>,
     pub(crate) cache: Arc<dyn CacheTable>,
+    /// Rows with a flash in flight — a chunk refetch is a reconcile, so
+    /// its (possibly pre-write) snapshot must not clobber a staged value.
+    pub(crate) pending: Arc<PendingFlashes>,
 }
 
 impl std::fmt::Debug for ChunkSink {
@@ -48,6 +52,14 @@ impl ChunkSink {
         let Some(target) = self.target.upgrade() else {
             return Err(vantage_core::error!("ChunkSink: scenery dropped"));
         };
+        // A row with a flash in flight keeps its staged value: the slot
+        // binds to what the cache holds, and the fetched (possibly
+        // pre-write) snapshot is dropped.
+        if self.pending.contains(&id) {
+            let staged = self.cache.get_value(&id).await?.unwrap_or(record);
+            target.write_chunk_row(idx, id, staged);
+            return Ok(());
+        }
         self.cache.insert_value(&id, &record).await?;
         target.write_chunk_row(idx, id, record);
         Ok(())

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -46,6 +46,7 @@ impl Lens {
             cache_table_name,
             write_queue: write_tx,
             event_bus,
+            pending_flashes: Arc::new(crate::dio::pending::PendingFlashes::new()),
             refresh_task: Mutex::new(None),
             write_worker: Mutex::new(None),
             hot_tier: Arc::new(HotTier::new()),
@@ -92,10 +93,9 @@ impl Lens {
     }
 }
 
-async fn spawn_write_worker(dio: &Dio, rx: mpsc::Receiver<crate::ops::ChangeFlash>) {
-    let inner_weak = Arc::downgrade(&dio.inner);
+async fn spawn_write_worker(dio: &Dio, rx: mpsc::Receiver<crate::dio::worker::QueuedFlash>) {
     let handle = dio.inner.lens.runtime.spawn(async move {
-        write_worker_loop(inner_weak, rx).await;
+        write_worker_loop(rx).await;
     });
     *dio.inner.write_worker.lock().await = Some(handle);
 }

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -17,7 +17,7 @@ pub use augment::{
 };
 pub use composition::Diorama;
 pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
-pub use dio::{Dio, DioEvent, DioShell, Generation};
+pub use dio::{Dio, DioEvent, DioShell, Generation, WriteCapabilities};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
     Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkRow, ChunkSink,
@@ -41,7 +41,7 @@ pub use vantage_vista::VistaCapabilities;
 /// ```
 pub mod prelude {
     pub use crate::augment::{Augmentation, Detail, Fetch, MergeRule, Source};
-    pub use crate::dio::{Dio, DioEvent, Generation};
+    pub use crate::dio::{Dio, DioEvent, Generation, WriteCapabilities};
     pub use crate::lens::{CacheBackend, CacheStatus, CacheTable, Lens, RedbCache};
     pub use crate::ops::{ChangeEvent, ChangeFlash, FlashKind};
     pub use crate::scenery::{

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -259,6 +259,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     let sink = ChunkSink {
         target: Arc::downgrade(&state) as std::sync::Weak<dyn crate::lens::SceneryChunkTarget>,
         cache: dio_inner.cache.clone(),
+        pending: dio_inner.pending_flashes.clone(),
     };
 
     let dio = Dio {

--- a/vantage-diorama/tests/flash_hardening.rs
+++ b/vantage-diorama/tests/flash_hardening.rs
@@ -1,0 +1,330 @@
+//! Tier-2 hardening of the flash pipeline:
+//!
+//! - **Effective write capabilities** — `dio.write_capabilities()` is the
+//!   one gate UI chrome asks. Master caps by default; an `on_flash` route
+//!   makes the Dio writable regardless of the master (a read-only CSV
+//!   becomes editable, changes landing wherever the route sends them).
+//! - **Reconcile-while-pending** — a refresh pulling a master snapshot
+//!   that predates an in-flight flash must not clobber it:
+//!   `dio.reconcile_values()` skips rows with a flash in flight, and a
+//!   confirmed flash re-asserts its fields over any stale write that
+//!   raced it.
+//! - **Drain, not drop** — flashes already in the queue keep the pipeline
+//!   alive: dropping every external handle still lands them.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tokio::sync::Notify;
+use vantage_core::Result;
+use vantage_dataset::traits::{ReadableValueSet, WritableValueSet};
+use vantage_diorama::{Lens, ServoStatus};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell};
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.to_string())
+}
+
+fn rec(pairs: &[(&str, &str)]) -> Record<CborValue> {
+    let mut r = Record::new();
+    for (k, v) in pairs {
+        r.insert((*k).to_string(), text(v));
+    }
+    r
+}
+
+fn metadata() -> VistaMetadata {
+    VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String").with_flag("title"))
+        .with_column(Column::new("status", "String"))
+        .with_id_column("id")
+}
+
+/// A master that can be read but not written — the mock analogue of a CSV
+/// file or a third-party read-only API.
+fn read_only_shell() -> MockShell {
+    MockShell::new()
+        .with_capabilities(VistaCapabilities {
+            can_count: true,
+            ..VistaCapabilities::default()
+        })
+        .with_record(
+            "c1",
+            rec(&[("id", "c1"), ("name", "Ada"), ("status", "lead")]),
+        )
+}
+
+fn vista_over(shell: &MockShell, name: &str) -> Vista {
+    Vista::new(name, Box::new(shell.clone().with_metadata(metadata())))
+}
+
+async fn seed_cache(dio: &vantage_diorama::Dio) -> Result<()> {
+    for (id, r) in dio.master().list_values().await? {
+        dio.cache().insert_value(&id, &r).await?;
+    }
+    Ok(())
+}
+
+// ---- effective write capabilities ------------------------------------------
+
+#[tokio::test]
+async fn write_capabilities_default_to_the_master() -> Result<()> {
+    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
+
+    let read_only = lens.make_dio(vista_over(&read_only_shell(), "csv")).await?;
+    let caps = read_only.write_capabilities();
+    assert!(!caps.can_insert && !caps.can_update && !caps.can_delete);
+
+    let writable = lens.make_dio(vista_over(&MockShell::new(), "db")).await?;
+    let caps = writable.write_capabilities();
+    assert!(caps.can_insert && caps.can_update && caps.can_delete);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_flash_route_makes_a_read_only_master_writable() -> Result<()> {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(|_dio, _flash| async move { Ok(()) })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(vista_over(&read_only_shell(), "csv")).await?;
+
+    let caps = dio.write_capabilities();
+    assert!(
+        caps.can_insert && caps.can_update && caps.can_delete,
+        "the route is the writer; the master's own caps no longer gate editing"
+    );
+    Ok(())
+}
+
+// ---- routed writes: read-only master, changes land elsewhere ----------------
+
+#[tokio::test]
+async fn routed_flash_lands_in_the_log_vista_and_never_touches_the_master() -> Result<()> {
+    let master_shell = read_only_shell();
+    let log_shell = MockShell::new();
+    let log = Arc::new(vista_over(&log_shell, "audit-log"));
+
+    let route_log = log.clone();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(move |_dio, flash| {
+                let log = route_log.clone();
+                async move {
+                    // The routing ergonomic: bind the change to the log
+                    // vista and save the merged record there.
+                    flash.active_record(log.as_ref())?.save().await?;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(vista_over(&master_shell, "csv")).await?;
+    seed_cache(&dio).await?;
+
+    let servo = dio.servo("c1").await?;
+    servo.set("status", text("won"));
+    servo.flash().await?.expect("dirty servo flashes");
+    assert!(matches!(servo.status(), ServoStatus::Tracking));
+
+    // The change landed in the log vista — the full merged record.
+    let landed = log.get_value("c1").await?.expect("routed row landed");
+    assert_eq!(landed.get("status"), Some(&text("won")));
+    assert_eq!(landed.get("name"), Some(&text("Ada")));
+
+    // The cache keeps showing the edit (until a future reconcile says
+    // otherwise) — the grid the user is looking at reflects their change.
+    let cached = dio.cache().get_value("c1").await?.unwrap();
+    assert_eq!(cached.get("status"), Some(&text("won")));
+
+    // The read-only master was never written.
+    let master_row = dio.master().get_value("c1").await?.unwrap();
+    assert_eq!(master_row.get("status"), Some(&text("lead")));
+    Ok(())
+}
+
+// ---- reconcile-while-pending ------------------------------------------------
+
+/// Lens whose route blocks on `gate`, pinning the pending window open.
+fn gated_lens(gate: Arc<Notify>) -> Arc<Lens> {
+    Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(move |_dio, _flash| {
+                let gate = gate.clone();
+                async move {
+                    gate.notified().await;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    )
+}
+
+#[tokio::test]
+async fn stale_reconcile_skips_rows_with_a_flash_in_flight() -> Result<()> {
+    let gate = Arc::new(Notify::new());
+    let lens = gated_lens(gate.clone());
+    let shell = MockShell::new()
+        .with_record("a", rec(&[("id", "a"), ("name", "one")]))
+        .with_record("b", rec(&[("id", "b"), ("name", "two")]));
+    let dio = lens.make_dio(vista_over(&shell, "items")).await?;
+    seed_cache(&dio).await?;
+
+    // Fire a patch; the gated route holds it in the pending window.
+    let dio2 = dio.clone();
+    let mut partial = Record::new();
+    partial.insert("name".to_string(), text("edited"));
+    let flight = tokio::spawn(async move { dio2.flash_patch("a", partial).await });
+
+    // Wait until the optimistic stage is visible.
+    for _ in 0..200 {
+        if dio
+            .cache()
+            .get_value("a")
+            .await?
+            .and_then(|r| r.get("name").cloned())
+            == Some(text("edited"))
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // A reconcile arrives carrying a master snapshot that predates the
+    // write: stale for "a", fresh for "b".
+    dio.reconcile_values(vec![
+        ("a".to_string(), rec(&[("id", "a"), ("name", "one")])),
+        (
+            "b".to_string(),
+            rec(&[("id", "b"), ("name", "two-updated")]),
+        ),
+    ])
+    .await?;
+
+    let a = dio.cache().get_value("a").await?.unwrap();
+    assert_eq!(
+        a.get("name"),
+        Some(&text("edited")),
+        "the in-flight row must not be clobbered by the stale snapshot"
+    );
+    let b = dio.cache().get_value("b").await?.unwrap();
+    assert_eq!(
+        b.get("name"),
+        Some(&text("two-updated")),
+        "rows with no flash in flight reconcile normally"
+    );
+
+    // Release the write; after it confirms, reconciles apply again.
+    gate.notify_one();
+    flight.await.unwrap()?;
+    dio.reconcile_values(vec![(
+        "a".to_string(),
+        rec(&[("id", "a"), ("name", "reconciled-later")]),
+    )])
+    .await?;
+    let a = dio.cache().get_value("a").await?.unwrap();
+    assert_eq!(a.get("name"), Some(&text("reconciled-later")));
+    Ok(())
+}
+
+#[tokio::test]
+async fn confirmed_flash_reasserts_its_fields_over_a_raw_stale_write() -> Result<()> {
+    let gate = Arc::new(Notify::new());
+    let lens = gated_lens(gate.clone());
+    let shell = MockShell::new().with_record(
+        "a",
+        rec(&[("id", "a"), ("name", "one"), ("status", "open")]),
+    );
+    let dio = lens.make_dio(vista_over(&shell, "items")).await?;
+    seed_cache(&dio).await?;
+
+    let dio2 = dio.clone();
+    let mut partial = Record::new();
+    partial.insert("name".to_string(), text("edited"));
+    let flight = tokio::spawn(async move { dio2.flash_patch("a", partial).await });
+    for _ in 0..200 {
+        if dio
+            .cache()
+            .get_value("a")
+            .await?
+            .and_then(|r| r.get("name").cloned())
+            == Some(text("edited"))
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // A writer that doesn't go through reconcile_values clobbers the row
+    // mid-flight with a stale snapshot (and a fresh other-field value).
+    dio.cache()
+        .insert_value(
+            "a",
+            &rec(&[("id", "a"), ("name", "one"), ("status", "closed")]),
+        )
+        .await?;
+
+    gate.notify_one();
+    flight.await.unwrap()?;
+
+    // The confirmed flash re-asserts the fields it wrote; fields it never
+    // touched keep whatever arrived meanwhile.
+    let a = dio.cache().get_value("a").await?.unwrap();
+    assert_eq!(
+        a.get("name"),
+        Some(&text("edited")),
+        "confirmed field re-asserted"
+    );
+    assert_eq!(
+        a.get("status"),
+        Some(&text("closed")),
+        "untouched field not rolled back"
+    );
+    Ok(())
+}
+
+// ---- drain, not drop --------------------------------------------------------
+
+#[tokio::test]
+async fn queued_flashes_survive_dropping_every_handle() -> Result<()> {
+    let shell = MockShell::new();
+    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
+    let dio = lens.make_dio(vista_over(&shell, "tasks")).await?;
+    let worker = dio.take_write_worker_handle().await.expect("worker handle");
+
+    // Fire-and-forget enqueues through the facade, then drop everything.
+    let facade = dio.vista();
+    facade
+        .insert_value("t1", &rec(&[("name", "first")]))
+        .await?;
+    facade
+        .insert_value("t2", &rec(&[("name", "second")]))
+        .await?;
+    drop(facade);
+    drop(dio);
+    drop(lens);
+
+    // The queued flashes keep the pipeline alive until they land; the
+    // worker then exits cleanly on its own.
+    tokio::time::timeout(Duration::from_secs(2), worker)
+        .await
+        .expect("worker exited after draining")
+        .expect("worker task completed");
+
+    assert_eq!(
+        shell.len(),
+        2,
+        "both queued writes landed after every handle dropped"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Tier 2 of the CRUD work — hardening the flash pipeline for real-world editing. Builds on #352.

## `Dio::write_capabilities()`

The one gate UI chrome asks before offering add/edit/delete. Master capabilities by default; a registered `on_flash` route lifts all three — the route is the writer, so a read-only master (CSV, third-party API) becomes editable with changes landing wherever the route sends them. The facade's existing capability lifting now shares this single definition.

Tested end-to-end with the routed scenario: read-only master + `on_flash` binding each flash via `active_record` into a log vista — the edit shows in the cache/grid, lands in the log, and the master is never written.

## Reconcile-while-pending

The race: a user saves, the optimistic stage makes the edit visible, and a background refresh pulls a master snapshot taken *before* the write — a naive reconcile clobbers the staged value and visibly reverts the edit.

- Rows with a flash in flight are tracked internally (RAII guard covering stage → write-through → commit/rollback).
- New `Dio::reconcile_value` / `reconcile_values` — the cache write an `on_refresh` callback should use for master-copied rows — skip in-flight rows. `patched` stays the ingress for push changes (a live stream is fresh by definition; snapshots may be stale, hence the guard).
- The augment refresh pass (including its vanished-row delete) and `ChunkSink::push` honor the same guard; a chunk refetch binds the staged value to the slot instead of the stale fetch.
- On confirm, the flash **re-asserts** exactly the fields it wrote over anything that raced into the cache mid-flight — fields it never touched keep whatever fresher value arrived.

## Drain, not drop

Previously the write worker held a `Weak` and discarded queued flashes once the last handle dropped. Now every queued flash carries a strong handle to the pipeline: fire-and-forget writes already accepted keep the Dio alive until they land, and the worker exits cleanly on its own once the queue closes empty. Test: enqueue via the facade, drop every handle, both writes still reach the master and the worker task completes.

## Tests

`tests/flash_hardening.rs` — 6 scenarios covering all of the above. Full suite green: 70/70 cucumber scenarios (612 steps), all integration/unit tests, clippy + fmt clean on 1.97.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added write-capability reporting for insert, update, and delete operations.
  * Added cache reconciliation helpers for single and multiple records.
  * Improved optimistic updates by preserving in-flight changes during refreshes and reconciliation.

* **Bug Fixes**
  * Queued writes now complete reliably even when external handles are released.
  * Prevented stale refresh data from overwriting pending changes.
  * Improved worker shutdown behavior after queued work is processed.

* **Documentation**
  * Added release notes for version 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->