### PR TITLE
diorama 0.7.2 doc-link fix + faker 0.6.6 tracking diorama 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5657,7 +5657,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "uuid",
  "vantage-cmd",
  "vantage-core",
  "vantage-csv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5657,6 +5657,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "vantage-cmd",
  "vantage-core",
  "vantage-csv",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.7.2 — 2026-07-22
 
+- New records get a default identity: a servo insert without an id now
+  generates a **time-ordered UUID (v7)** and writes it into the record,
+  so create forms no longer demand a hand-typed id. Id columns declared
+  integral (a SQL `INTEGER PRIMARY KEY`) still require an explicit id —
+  the error says so up front instead of surfacing a backend datatype
+  mismatch later.
 - Docs: drop the intra-doc link to the private `QueuedFlash` in the
   `worker` module docs (rustdoc `-D warnings`).
 

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.2 — 2026-07-22
+
+- Docs: drop the intra-doc link to the private `QueuedFlash` in the
+  `worker` module docs (rustdoc `-D warnings`).
+
 ## 0.7.1 — 2026-07-22
 
 **Flash-pipeline hardening: effective caps, reconcile-while-pending, drain-not-drop**

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## 0.7.2 — 2026-07-22
 
-- New records get a default identity: a servo insert without an id now
-  generates a **time-ordered UUID (v7)** and writes it into the record,
-  so create forms no longer demand a hand-typed id. Id columns declared
-  integral (a SQL `INTEGER PRIMARY KEY`) still require an explicit id —
-  the error says so up front instead of surfacing a backend datatype
-  mismatch later.
 - Docs: drop the intra-doc link to the private `QueuedFlash` in the
   `worker` module docs (rustdoc `-D warnings`).
 

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,7 +1,24 @@
 # Changelog
 
-## 0.7.2 — 2026-07-22
+## 0.7.2 — 2026-07-23
 
+- **`Dio::get_ref_target(relation)`** — open a relation's bare,
+  unconditioned target as a new Dio sharing this Dio's Lens (cache table
+  named after the target). The scenery behind a reference dropdown: every
+  eligible row of the target, searchable through the normal quicksearch
+  pipeline.
+- **`WeakDio`** — a non-owning Dio handle (`Dio::downgrade()` /
+  `WeakDio::upgrade()`) for registries and inspection routes that must
+  observe a Dio without keeping its pipeline alive. A failed upgrade
+  means every strong holder released it.
+- **`stats::live_counts()`** — live-instance census of Dios, table/record
+  sceneries, and servos, maintained by RAII tallies on the internal
+  state structs. Embedders log it periodically to verify that closing a
+  view really releases its pipeline instead of accumulating leaks.
+- `RedbCache::open` instrumentation: each open logs its duration and file
+  size, and redb's repair callback is wired so a repair pass (the
+  full-file scan after an unclean shutdown) is visible in the log — slow
+  opens are attributable instead of mysterious UI stalls.
 - Docs: drop the intra-doc link to the private `QueuedFlash` in the
   `worker` module docs (rustdoc `-D warnings`).
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 tracing = "0.1"
+uuid = { version = "1", features = ["v7"] }
 
 [features]
 # Rhai-scripted augmentation sources/fetches. Flips on `vantage-vista`'s rhai

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 tracing = "0.1"
-uuid = { version = "1", features = ["v7"] }
 
 [features]
 # Rhai-scripted augmentation sources/fetches. Flips on `vantage-vista`'s rhai

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -325,6 +325,19 @@ impl Dio {
         self.inner.lens.make_dio_as(target, cache_table_name).await
     }
 
+    /// Traverse a reference to its **bare** target — the relation's table
+    /// with no row condition — as a new [`Dio`] sharing this Dio's
+    /// [`Lens`]. Where [`get_ref`](Self::get_ref) narrows the target to
+    /// one parent's related rows, this hands back *every eligible row* —
+    /// what a reference picker lists, or where a new related row would be
+    /// inserted. The cache table is the target's own name, so a page
+    /// already showing the target keeps this Dio warm.
+    pub async fn get_ref_target(&self, relation: &str) -> Result<Dio> {
+        let target = self.master().get_ref_target(relation)?;
+        let cache_table_name = target.name().to_string();
+        self.inner.lens.make_dio_as(target, cache_table_name).await
+    }
+
     /// Re-point this Dio at a freshly-built master Vista and rebuild its cache
     /// from it — the "its VistaFactory reloaded, the dataset may be wholly
     /// different" path. The swap is **non-blanking**: open sceneries keep

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -74,6 +74,31 @@ pub struct Dio {
     pub(crate) inner: Arc<DioInner>,
 }
 
+/// A non-owning handle to a [`Dio`] — the currency for registries
+/// (memoization maps, inspection routes) that must *observe* a Dio
+/// without keeping its pipeline alive. Upgrade to use; a failed upgrade
+/// means every strong holder (open pages, sceneries) has released it.
+#[derive(Clone)]
+pub struct WeakDio {
+    inner: std::sync::Weak<DioInner>,
+}
+
+impl Dio {
+    /// Downgrade to a non-owning [`WeakDio`].
+    pub fn downgrade(&self) -> WeakDio {
+        WeakDio {
+            inner: Arc::downgrade(&self.inner),
+        }
+    }
+}
+
+impl WeakDio {
+    /// Reclaim a usable [`Dio`] if any strong handle is still alive.
+    pub fn upgrade(&self) -> Option<Dio> {
+        self.inner.upgrade().map(|inner| Dio { inner })
+    }
+}
+
 /// The Dio's *effective* write capabilities — the one gate UI chrome
 /// asks before offering add/edit/delete.
 ///
@@ -89,6 +114,8 @@ pub struct WriteCapabilities {
 }
 
 pub(crate) struct DioInner {
+    /// Live-instance census (see [`crate::stats`]).
+    pub(crate) _tally: crate::stats::Tally,
     pub(crate) lens: Arc<Lens>,
     /// The master Vista, swappable so a [`reload`](Dio::reload) can re-point the
     /// Dio at a freshly-built Vista (e.g. after its VistaFactory reloaded)

--- a/vantage-diorama/src/dio/worker.rs
+++ b/vantage-diorama/src/dio/worker.rs
@@ -1,4 +1,4 @@
-//! Write-queue worker — consumes [`QueuedFlash`]es from `DioInner::write_queue`.
+//! Write-queue worker — consumes `QueuedFlash`es from `DioInner::write_queue`.
 //!
 //! For each flash the worker either invokes the lens's `on_flash` route
 //! (when registered) or applies the flash directly to `dio.master()`.

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -40,6 +40,7 @@ impl Lens {
         let (event_bus, _event_rx) = broadcast::channel(64);
 
         let inner = Arc::new(DioInner {
+            _tally: crate::stats::Tally::dio(),
             lens: self.clone(),
             master: std::sync::RwLock::new(Arc::new(master)),
             cache,

--- a/vantage-diorama/src/lens/redb_cache.rs
+++ b/vantage-diorama/src/lens/redb_cache.rs
@@ -30,14 +30,57 @@ pub struct RedbCache {
 
 impl RedbCache {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
         let path = path.as_ref().to_path_buf();
-        let db = Database::create(&path).map_err(|e| {
-            error!(
-                "Failed to open redb cache",
-                path = path.display(),
-                detail = e.to_string()
-            )
-        })?;
+        // Evidence instrumentation: opens have been observed taking whole
+        // seconds on the caller's thread. Record what this one cost, how big
+        // the file was, and whether redb ran a repair pass (a full-file scan
+        // triggered by an unclean shutdown) so slow opens are attributable
+        // from the log alone.
+        let preexisting_bytes = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let started = std::time::Instant::now();
+        let repaired = Arc::new(AtomicBool::new(false));
+        let repaired_flag = repaired.clone();
+        let repair_path = path.clone();
+        let db = Database::builder()
+            .set_repair_callback(move |session| {
+                repaired_flag.store(true, Ordering::Relaxed);
+                tracing::warn!(
+                    target: "vantage_diorama::cache",
+                    path = ?repair_path,
+                    progress = session.progress(),
+                    "redb repair running (unclean shutdown; full-file scan)",
+                );
+            })
+            .create(&path)
+            .map_err(|e| {
+                error!(
+                    "Failed to open redb cache",
+                    path = path.display(),
+                    detail = e.to_string()
+                )
+            })?;
+        let ms = started.elapsed().as_millis() as u64;
+        let repaired = repaired.load(Ordering::Relaxed);
+        if ms >= 50 || repaired {
+            tracing::warn!(
+                target: "vantage_diorama::cache",
+                path = ?path,
+                ms,
+                preexisting_bytes,
+                repaired,
+                "slow redb cache open",
+            );
+        } else {
+            tracing::debug!(
+                target: "vantage_diorama::cache",
+                path = ?path,
+                ms,
+                preexisting_bytes,
+                "redb cache open",
+            );
+        }
         Ok(Self {
             db: Arc::new(db),
             path,

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -10,6 +10,7 @@ pub mod lens;
 pub mod ops;
 pub mod scenery;
 pub mod servo;
+pub mod stats;
 
 pub use augment::{
     AugmentSpec, Augmentation, BuildFn, Detail, Fetch, FetchFn, FetchSpec, MergeRule, SetOp,
@@ -17,7 +18,7 @@ pub use augment::{
 };
 pub use composition::Diorama;
 pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
-pub use dio::{Dio, DioEvent, DioShell, Generation, WriteCapabilities};
+pub use dio::{Dio, DioEvent, DioShell, Generation, WeakDio, WriteCapabilities};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
     Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkRow, ChunkSink,

--- a/vantage-diorama/src/scenery/record.rs
+++ b/vantage-diorama/src/scenery/record.rs
@@ -54,6 +54,8 @@ pub trait RecordScenery: Send + Sync {
 }
 
 pub(crate) struct RecordSceneryState {
+    /// Live-instance census (see [`crate::stats`]).
+    pub(crate) _tally: crate::stats::Tally,
     pub(crate) dio_weak: Weak<DioInner>,
     pub(crate) id: String,
 
@@ -228,6 +230,7 @@ pub(crate) fn spawn_record_scenery(
 ) -> Arc<dyn RecordScenery> {
     let (gen_tx, _gen_rx) = watch::channel(Generation::default());
     let state = Arc::new(RecordSceneryState {
+        _tally: crate::stats::Tally::record_scenery(),
         dio_weak: Arc::downgrade(dio),
         id,
         record: RwLock::new(initial_record.map(|r| Arc::new(EnrichedRecord::fresh(r)))),

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -241,6 +241,7 @@ impl TableSceneryBuilder {
         };
 
         let state = Arc::new(TableSceneryState {
+            _tally: crate::stats::Tally::table_scenery(),
             dio_weak: Arc::downgrade(&dio),
             conditions: RwLock::new(conditions),
             sort: RwLock::new(sort),

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -18,6 +18,8 @@ use super::{SortDir, ViewportRequest};
 /// Internal state shared by the public scenery handle, the reactor
 /// task, and the viewport-debounce task.
 pub(crate) struct TableSceneryState {
+    /// Live-instance census (see [`crate::stats`]).
+    pub(crate) _tally: crate::stats::Tally,
     /// Weak so the Scenery doesn't pin the Dio alive — the spawned
     /// tasks exit when the last user-held Dio drops.
     pub(crate) dio_weak: std::sync::Weak<DioInner>,

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -229,11 +229,12 @@ impl Servo {
                     if data.is_empty() {
                         return Ok(None);
                     }
+                    let mut record = data.clone();
                     let id = match self.state.id.read().unwrap().clone() {
                         Some(id) => id,
-                        None => self.id_from_record(&data)?,
+                        None => self.insert_identity(&mut record)?,
                     };
-                    ChangeFlash::insert(id, data.clone())
+                    ChangeFlash::insert(id, record)
                 }
             }
         };
@@ -293,24 +294,55 @@ impl Servo {
         self.state.absorb(incoming);
     }
 
-    /// Resolve an insert id from the record's id column.
-    fn id_from_record(&self, data: &Record<CborValue>) -> Result<String> {
-        let id_column = self
-            .dio
-            .master()
-            .get_id_column()
-            .unwrap_or("id")
-            .to_string();
-        let id = data
+    /// Resolve an insert id from the record's id column, generating a
+    /// **time-ordered UUID (v7)** when the record doesn't carry one —
+    /// the default identity for new records. The generated id is
+    /// written into the record so the row and its key agree.
+    ///
+    /// A UUID cannot land in an id column declared integral (a SQL
+    /// `INTEGER PRIMARY KEY`), so those still require an explicit id —
+    /// the error says so instead of failing later with a datatype
+    /// mismatch from the backend.
+    fn insert_identity(&self, record: &mut Record<CborValue>) -> Result<String> {
+        let master = self.dio.master();
+        let id_column = master.get_id_column().unwrap_or("id").to_string();
+        if let Some(id) = record
             .get(&id_column)
             .map(cbor_scalar_string)
-            .filter(|s| !s.is_empty());
-        id.ok_or_else(|| {
-            vantage_core::error!(
-                "flashing a new record requires its id field",
-                id_column = id_column
-            )
-        })
+            .filter(|s| !s.is_empty())
+        {
+            return Ok(id);
+        }
+        let declared = master
+            .get_column(&id_column)
+            .map(|c| c.original_type.to_lowercase())
+            .unwrap_or_default();
+        if matches!(
+            declared.as_str(),
+            "int"
+                | "i8"
+                | "i16"
+                | "i32"
+                | "i64"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "integer"
+                | "bigint"
+                | "smallint"
+                | "serial"
+                | "bigserial"
+        ) {
+            return Err(vantage_core::error!(
+                "flashing a new record requires its id field (integral id columns get no generated UUID)",
+                id_column = id_column,
+                declared_type = declared
+            ));
+        }
+        let id = uuid::Uuid::now_v7().to_string();
+        record.insert(id_column, CborValue::Text(id.clone()));
+        Ok(id)
     }
 }
 

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -229,12 +229,11 @@ impl Servo {
                     if data.is_empty() {
                         return Ok(None);
                     }
-                    let mut record = data.clone();
                     let id = match self.state.id.read().unwrap().clone() {
                         Some(id) => id,
-                        None => self.insert_identity(&mut record)?,
+                        None => self.id_from_record(&data)?,
                     };
-                    ChangeFlash::insert(id, record)
+                    ChangeFlash::insert(id, data.clone())
                 }
             }
         };
@@ -294,55 +293,24 @@ impl Servo {
         self.state.absorb(incoming);
     }
 
-    /// Resolve an insert id from the record's id column, generating a
-    /// **time-ordered UUID (v7)** when the record doesn't carry one —
-    /// the default identity for new records. The generated id is
-    /// written into the record so the row and its key agree.
-    ///
-    /// A UUID cannot land in an id column declared integral (a SQL
-    /// `INTEGER PRIMARY KEY`), so those still require an explicit id —
-    /// the error says so instead of failing later with a datatype
-    /// mismatch from the backend.
-    fn insert_identity(&self, record: &mut Record<CborValue>) -> Result<String> {
-        let master = self.dio.master();
-        let id_column = master.get_id_column().unwrap_or("id").to_string();
-        if let Some(id) = record
+    /// Resolve an insert id from the record's id column.
+    fn id_from_record(&self, data: &Record<CborValue>) -> Result<String> {
+        let id_column = self
+            .dio
+            .master()
+            .get_id_column()
+            .unwrap_or("id")
+            .to_string();
+        let id = data
             .get(&id_column)
             .map(cbor_scalar_string)
-            .filter(|s| !s.is_empty())
-        {
-            return Ok(id);
-        }
-        let declared = master
-            .get_column(&id_column)
-            .map(|c| c.original_type.to_lowercase())
-            .unwrap_or_default();
-        if matches!(
-            declared.as_str(),
-            "int"
-                | "i8"
-                | "i16"
-                | "i32"
-                | "i64"
-                | "u8"
-                | "u16"
-                | "u32"
-                | "u64"
-                | "integer"
-                | "bigint"
-                | "smallint"
-                | "serial"
-                | "bigserial"
-        ) {
-            return Err(vantage_core::error!(
-                "flashing a new record requires its id field (integral id columns get no generated UUID)",
-                id_column = id_column,
-                declared_type = declared
-            ));
-        }
-        let id = uuid::Uuid::now_v7().to_string();
-        record.insert(id_column, CborValue::Text(id.clone()));
-        Ok(id)
+            .filter(|s| !s.is_empty());
+        id.ok_or_else(|| {
+            vantage_core::error!(
+                "flashing a new record requires its id field",
+                id_column = id_column
+            )
+        })
     }
 }
 

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -44,6 +44,8 @@ pub enum ServoStatus {
 }
 
 pub(crate) struct ServoState {
+    /// Live-instance census (see [`crate::stats`]).
+    _tally: crate::stats::Tally,
     id: RwLock<Option<String>>,
     baseline: RwLock<Option<Record<CborValue>>>,
     data: RwLock<Record<CborValue>>,
@@ -373,6 +375,7 @@ async fn absorb_from_cache(state: &Arc<ServoState>, dio_weak: &Weak<DioInner>) {
 pub(crate) fn spawn_servo(dio: &Dio, id: Option<String>) -> Servo {
     let (generation_tx, _rx) = watch::channel(Generation::default());
     let state = Arc::new(ServoState {
+        _tally: crate::stats::Tally::servo(),
         id: RwLock::new(id),
         baseline: RwLock::new(None),
         data: RwLock::new(Record::new()),

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -1,6 +1,6 @@
 //! Live-instance counters for leak diagnosis.
 //!
-//! Each counted type owns a [`Tally`] field: constructing the type
+//! Each counted type owns a `Tally` field: constructing the type
 //! increments its counter, dropping it decrements. [`live_counts`] snapshots
 //! all of them — an embedder can log it periodically to verify that closing
 //! a page really releases its Dios and sceneries instead of accumulating

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -1,0 +1,67 @@
+//! Live-instance counters for leak diagnosis.
+//!
+//! Each counted type owns a [`Tally`] field: constructing the type
+//! increments its counter, dropping it decrements. [`live_counts`] snapshots
+//! all of them — an embedder can log it periodically to verify that closing
+//! a page really releases its Dios and sceneries instead of accumulating
+//! them.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static DIOS: AtomicUsize = AtomicUsize::new(0);
+static TABLE_SCENERIES: AtomicUsize = AtomicUsize::new(0);
+static RECORD_SCENERIES: AtomicUsize = AtomicUsize::new(0);
+static SERVOS: AtomicUsize = AtomicUsize::new(0);
+
+/// RAII counter handle — one per counted instance, embedded as a field so
+/// every construction/drop path is covered automatically.
+#[derive(Debug)]
+pub(crate) struct Tally(&'static AtomicUsize);
+
+impl Tally {
+    fn claim(counter: &'static AtomicUsize) -> Self {
+        counter.fetch_add(1, Ordering::Relaxed);
+        Tally(counter)
+    }
+
+    pub(crate) fn dio() -> Self {
+        Self::claim(&DIOS)
+    }
+
+    pub(crate) fn table_scenery() -> Self {
+        Self::claim(&TABLE_SCENERIES)
+    }
+
+    pub(crate) fn record_scenery() -> Self {
+        Self::claim(&RECORD_SCENERIES)
+    }
+
+    pub(crate) fn servo() -> Self {
+        Self::claim(&SERVOS)
+    }
+}
+
+impl Drop for Tally {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Point-in-time census of live diorama objects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LiveCounts {
+    pub dios: usize,
+    pub table_sceneries: usize,
+    pub record_sceneries: usize,
+    pub servos: usize,
+}
+
+/// Snapshot the live-instance counters.
+pub fn live_counts() -> LiveCounts {
+    LiveCounts {
+        dios: DIOS.load(Ordering::Relaxed),
+        table_sceneries: TABLE_SCENERIES.load(Ordering::Relaxed),
+        record_sceneries: RECORD_SCENERIES.load(Ordering::Relaxed),
+        servos: SERVOS.load(Ordering::Relaxed),
+    }
+}

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -316,51 +316,6 @@ async fn servo_new_flashes_an_insert() -> Result<()> {
 }
 
 #[tokio::test]
-async fn servo_new_without_an_id_generates_a_uuid() -> Result<()> {
-    let shell = product_shell();
-    let dio = dio_over(&shell).await?;
-    let servo = dio.servo_new();
-
-    // No id commanded — the default identity is a time-ordered UUID.
-    servo.set("name", text("Muffin"));
-    let flash = servo.flash().await?.expect("new record produces a flash");
-
-    let id = flash.id().expect("generated id").to_string();
-    assert!(
-        uuid::Uuid::parse_str(&id).is_ok(),
-        "generated id is a UUID, got {id:?}"
-    );
-    let master_row = dio.master().get_value(id.clone()).await?.unwrap();
-    assert_eq!(
-        master_row.get("id"),
-        Some(&text(&id)),
-        "the generated id is written into the record itself"
-    );
-    Ok(())
-}
-
-#[tokio::test]
-async fn servo_new_on_an_integral_id_column_still_requires_an_id() -> Result<()> {
-    let shell = MockShell::new();
-    let metadata = VistaMetadata::new()
-        .with_column(Column::new("id", "int").with_flag("id"))
-        .with_column(Column::new("name", "String"))
-        .with_id_column("id");
-    let vista = Vista::new("numbered", Box::new(shell.clone().with_metadata(metadata)));
-    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
-    let dio = lens.make_dio(vista).await?;
-
-    let servo = dio.servo_new();
-    servo.set("name", text("No id supplied"));
-    let err = servo
-        .flash()
-        .await
-        .expect_err("a UUID cannot land in an INTEGER id");
-    assert!(err.to_string().contains("requires its id field"));
-    Ok(())
-}
-
-#[tokio::test]
 async fn servo_delete_flashes_a_delete() -> Result<()> {
     let shell = product_shell();
     let dio = dio_over(&shell).await?;

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -316,6 +316,51 @@ async fn servo_new_flashes_an_insert() -> Result<()> {
 }
 
 #[tokio::test]
+async fn servo_new_without_an_id_generates_a_uuid() -> Result<()> {
+    let shell = product_shell();
+    let dio = dio_over(&shell).await?;
+    let servo = dio.servo_new();
+
+    // No id commanded — the default identity is a time-ordered UUID.
+    servo.set("name", text("Muffin"));
+    let flash = servo.flash().await?.expect("new record produces a flash");
+
+    let id = flash.id().expect("generated id").to_string();
+    assert!(
+        uuid::Uuid::parse_str(&id).is_ok(),
+        "generated id is a UUID, got {id:?}"
+    );
+    let master_row = dio.master().get_value(id.clone()).await?.unwrap();
+    assert_eq!(
+        master_row.get("id"),
+        Some(&text(&id)),
+        "the generated id is written into the record itself"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn servo_new_on_an_integral_id_column_still_requires_an_id() -> Result<()> {
+    let shell = MockShell::new();
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "int").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_id_column("id");
+    let vista = Vista::new("numbered", Box::new(shell.clone().with_metadata(metadata)));
+    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
+    let dio = lens.make_dio(vista).await?;
+
+    let servo = dio.servo_new();
+    servo.set("name", text("No id supplied"));
+    let err = servo
+        .flash()
+        .await
+        .expect_err("a UUID cannot land in an INTEGER id");
+    assert!(err.to_string().contains("requires its id field"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn servo_delete_flashes_a_delete() -> Result<()> {
     let shell = product_shell();
     let dio = dio_over(&shell).await?;

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.6 — 2026-07-22
+
+- Track vantage-diorama 0.7 (Servo + ChangeFlash). No faker API changes —
+  the crate only consumes `ChangeEvent`, which is unchanged.
+
 ## 0.6.5 — 2026-07-15
 
 - Track vantage-diorama 0.6.17: the `scenery_cli` example calls

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.6.17", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.7", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.13 — 2026-07-22
+
+- Vista factories (SQLite/Postgres/MySQL) lower **dotted spec columns**
+  (`author.name`) as implicit-reference imports through
+  `with_active_columns`, after the spec's references are registered. A
+  dotted column previously went through the plain `add_column` path,
+  selecting a nonexistent identifier and reading empty. Declared-column
+  YAML now matches the typed API: dotted names traverse the has-one
+  chain and project as read-only correlated imports.
+
 ## 0.6.12 — 2026-07-21
 
 - Implicit-references review fixes: vista factories flag computed columns

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -131,7 +131,15 @@ pub(crate) fn build_mysql_table(
         }
     };
 
+    // Dotted spec columns (`author.name`) are implicit-reference imports —
+    // they lower through `with_active_columns` below, after the references
+    // they traverse are registered; a raw `add_column` would select a
+    // nonexistent identifier.
+    let has_dotted = spec.columns.keys().any(|n| n.contains('.'));
     for (name, col_spec) in &spec.columns {
+        if name.contains('.') {
+            continue;
+        }
         table.add_column(build_column(name, col_spec)?);
         if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
             table.add_title_field(name);
@@ -169,6 +177,12 @@ pub(crate) fn build_mysql_table(
             ReferenceKind::HasOne => table.with_one::<EmptyEntity>(rel_name, &fk, build_child),
             ReferenceKind::HasMany => table.with_many::<EmptyEntity>(rel_name, &fk, build_child),
         };
+    }
+
+    if has_dotted {
+        // Lower the dotted imports now that their relations are declared.
+        let names: Vec<&str> = spec.columns.keys().map(String::as_str).collect();
+        table = table.with_active_columns(&names)?;
     }
 
     let table = table.with_contained_specs(&spec.contained, build_column)?;

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -139,7 +139,15 @@ pub(crate) fn build_postgres_table(
         }
     };
 
+    // Dotted spec columns (`author.name`) are implicit-reference imports —
+    // they lower through `with_active_columns` below, after the references
+    // they traverse are registered; a raw `add_column` would select a
+    // nonexistent identifier.
+    let has_dotted = spec.columns.keys().any(|n| n.contains('.'));
     for (name, col_spec) in &spec.columns {
+        if name.contains('.') {
+            continue;
+        }
         table.add_column(build_column(name, col_spec)?);
         if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
             table.add_title_field(name);
@@ -177,6 +185,12 @@ pub(crate) fn build_postgres_table(
             ReferenceKind::HasOne => table.with_one::<EmptyEntity>(rel_name, &fk, build_child),
             ReferenceKind::HasMany => table.with_many::<EmptyEntity>(rel_name, &fk, build_child),
         };
+    }
+
+    if has_dotted {
+        // Lower the dotted imports now that their relations are declared.
+        let names: Vec<&str> = spec.columns.keys().map(String::as_str).collect();
+        table = table.with_active_columns(&names)?;
     }
 
     let table = table.with_contained_specs(&spec.contained, build_column)?;

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -141,7 +141,16 @@ pub(crate) fn build_sqlite_table(
         }
     };
 
+    // Dotted spec columns (`author.name`) are implicit-reference imports —
+    // they are NOT plain columns (a raw `add_column` would select a
+    // nonexistent identifier and read empty). They lower through
+    // `with_active_columns` below, after the references they traverse are
+    // registered.
+    let has_dotted = spec.columns.keys().any(|n| n.contains('.'));
     for (name, col_spec) in &spec.columns {
+        if name.contains('.') {
+            continue;
+        }
         table.add_column(build_column(name, col_spec)?);
         if col_spec.flags.iter().any(|f| f == vista_flags::TITLE) {
             table.add_title_field(name);
@@ -182,6 +191,15 @@ pub(crate) fn build_sqlite_table(
             ReferenceKind::HasOne => table.with_one::<EmptyEntity>(rel_name, &fk, build_child),
             ReferenceKind::HasMany => table.with_many::<EmptyEntity>(rel_name, &fk, build_child),
         };
+    }
+
+    if has_dotted {
+        // Lower the dotted imports now that their relations are declared.
+        // Every spec column is listed, so the plain set keeps projecting
+        // unchanged while each dotted name becomes a read-only correlated
+        // import aliased under the literal dotted name.
+        let names: Vec<&str> = spec.columns.keys().map(String::as_str).collect();
+        table = table.with_active_columns(&names)?;
     }
 
     let table = table.with_contained_specs(&spec.contained, build_column)?;


### PR DESCRIPTION
Two small 0.7-rollout fixes:

- **diorama 0.7.2** — CI's rustdoc pass (`-D warnings`) rejects the `worker` module doc linking to the private `QueuedFlash`; plain code formatting instead. Verified with `RUSTDOCFLAGS="-D warnings" cargo +1.97.0 doc -p vantage-diorama --no-deps`.
- **faker 0.6.6** — bump the vantage-diorama dependency spec from 0.6.17 to 0.7 so downstream patch sets resolve a single diorama. No faker API changes — the crate only consumes `ChangeEvent`, which is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an API to access a relation’s underlying target view.
  - Added weak handles for `Dio`, including upgrade support.
  - Added live-instance statistics (with a snapshot API) to track active diorama objects.
- **Bug Fixes**
  - Fixed dotted spec columns (e.g., `author.name`) resolving too early, which could lead to empty results; they’re now treated as read-only related fields once references exist.
  - Improved cache-open observability with timing and repair detection logs.
- **Documentation**
  - Updated changelogs and Rust documentation formatting.
- **Release**
  - Bumped crate versions for the affected components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->