### PR TITLE
SQLite reference binds + typed errors; kind-typed write events; VantageError accessors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "bson",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-core/CHANGELOG.md
+++ b/vantage-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.2 — 2026-07-23
+
+- `VantageError::message()` and `location()` accessors: the bare message
+  and capture site, without the context map or source chain — for UI
+  surfaces that render those parts separately (the context map is
+  already public). `Display` remains the combined one-line form.
+
 ## 0.6.1 — 2026-07-04
 
 - `VantageError::traced_debug()`: emit the same structured event as

--- a/vantage-core/Cargo.toml
+++ b/vantage-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Core error types and utilities for the Vantage data framework"

--- a/vantage-core/src/util/error.rs
+++ b/vantage-core/src/util/error.rs
@@ -231,6 +231,20 @@ impl VantageError {
         self.kind
     }
 
+    /// The bare error message, without context or source. UI surfaces
+    /// render those separately (context via the public `context` map,
+    /// source via [`std::error::Error::source`]); [`Display`](fmt::Display)
+    /// remains the combined one-line form.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// `file:line:column` where the error was created, when captured
+    /// (the [`crate::error!`] macro always captures it).
+    pub fn location(&self) -> Option<&str> {
+        self.location.as_deref()
+    }
+
     /// Classify this error as [`ErrorKind::Unsupported`] (builder).
     ///
     /// Marking no longer emits a trace on its own — chain [`traced`](Self::traced)
@@ -507,6 +521,15 @@ mod tests {
             err.to_string(),
             "Capability insert is not implemented in generic ReadOnlyDataSet"
         );
+    }
+
+    #[test]
+    fn test_message_and_location_accessors() {
+        let err = crate::error!("write failed", table = "books");
+        assert_eq!(err.message(), "write failed");
+        assert!(err.location().is_some_and(|l| l.contains("error.rs")));
+        // Display stays the combined form; the accessors expose the parts.
+        assert!(err.to_string().contains("write failed (table:"));
     }
 
     #[test]

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.7.3 — 2026-07-23
+
+- `DioEvent::WritePending` and `DioEvent::WriteReverted` carry the
+  staged flash's `kind: FlashKind`, so listeners can tell whose failure
+  a revert is. A `Servo` only enters `Pending`/`Failed` for editing
+  kinds (Patch/Replace/Insert) — a failed toolbar Delete of the same
+  record no longer reads as the edit form's "Save failed". Row statuses
+  (`PendingWrite`/`WriteFailed`) still apply to all kinds. Exhaustive
+  matches on these variants need the new field (`..` suffices).
+- `FlashKind` is `Copy`.
+
 ## 0.7.2 — 2026-07-23
 
 - **`Dio::get_ref_target(relation)`** — open a relation's bare,

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/event_bus.rs
+++ b/vantage-diorama/src/dio/event_bus.rs
@@ -30,6 +30,10 @@ pub enum DioEvent {
     /// flip the row for `id` to [`PendingWrite`](crate::RowStatus::PendingWrite).
     WritePending {
         id: String,
+        /// What the staged flash is doing — see
+        /// [`WriteReverted`](Self::WriteReverted) for why listeners filter
+        /// on this.
+        kind: crate::FlashKind,
     },
 
     /// An optimistic write failed and its cache pre-image was restored. The
@@ -40,6 +44,12 @@ pub enum DioEvent {
     WriteReverted {
         id: String,
         error: String,
+        /// What the failed flash was doing. Lets a listener decide whether
+        /// the failure is its own business: an edit form's servo reports
+        /// Patch/Replace/Insert reverts, but a failed Delete belongs to
+        /// its issuer (the confirm dialog), not to a form that happens to
+        /// display the same record.
+        kind: crate::FlashKind,
     },
 
     /// Emitted by `TableScenery` once a `set_viewport` / `request_load_more`

--- a/vantage-diorama/src/dio/optimistic.rs
+++ b/vantage-diorama/src/dio/optimistic.rs
@@ -54,10 +54,10 @@ impl Dio {
 
         // 2. Stage the optimistic value and announce it — views update now.
         stage_in_cache(&self.inner, &flash, pre.as_ref()).await?;
-        let _ = self
-            .inner
-            .event_bus
-            .send(DioEvent::WritePending { id: id.clone() });
+        let _ = self.inner.event_bus.send(DioEvent::WritePending {
+            id: id.clone(),
+            kind: *flash.kind(),
+        });
 
         // 3. Run the real write-through.
         match crate::dio::worker::run_write_through(self, flash.clone()).await {
@@ -79,6 +79,7 @@ impl Dio {
                 let _ = self.inner.event_bus.send(DioEvent::WriteReverted {
                     id,
                     error: err.to_string(),
+                    kind: *flash.kind(),
                 });
                 Err(err)
             }

--- a/vantage-diorama/src/ops/change_flash.rs
+++ b/vantage-diorama/src/ops/change_flash.rs
@@ -22,7 +22,7 @@ use vantage_types::Record;
 /// `Replace` exists because a patch-merge cannot express field removal;
 /// `Clear` (id-less, "delete every row") keeps its historical
 /// no-optimism special-casing in the pipeline.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlashKind {
     Insert,
     Replace,

--- a/vantage-diorama/src/scenery/record.rs
+++ b/vantage-diorama/src/scenery/record.rs
@@ -154,10 +154,10 @@ async fn reload_loop(state: Arc<RecordSceneryState>, mut bus: broadcast::Receive
                     tracing::error!(error = %e, "RecordScenery reload failed");
                 }
             }
-            Ok(DioEvent::WritePending { id }) if id == state.id => {
+            Ok(DioEvent::WritePending { id, .. }) if id == state.id => {
                 state.set_pending_write().await;
             }
-            Ok(DioEvent::WriteReverted { id, error }) if id == state.id => {
+            Ok(DioEvent::WriteReverted { id, error, .. }) if id == state.id => {
                 state.set_write_failed(error).await;
             }
             Ok(_) => {}

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -74,10 +74,10 @@ pub(crate) async fn reload_loop(
                     // Optimistic-write affordance: stamp just the affected row
                     // rather than reseeding the whole map. On success the
                     // trailing `RecordChanged` settles it back to `Fresh`.
-                    Ok(DioEvent::WritePending { id }) => {
+                    Ok(DioEvent::WritePending { id, .. }) => {
                         state.mark_row(&id, crate::scenery::RowStatus::PendingWrite).await;
                     }
-                    Ok(DioEvent::WriteReverted { id, error }) => {
+                    Ok(DioEvent::WriteReverted { id, error, .. }) => {
                         state
                             .mark_row(&id, crate::scenery::RowStatus::WriteFailed { error })
                             .await;

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -339,11 +339,27 @@ async fn track_loop(
             Ok(DioEvent::DatasetChanged) => {
                 absorb_from_cache(&state, &dio_weak).await;
             }
-            Ok(DioEvent::WritePending { id }) if bound(&id) => {
-                state.set_status(ServoStatus::Pending);
+            Ok(DioEvent::WritePending { id, kind }) if bound(&id) => {
+                // Same filter as the revert arm: someone else's staged
+                // delete is not this servo's write in flight.
+                if matches!(
+                    kind,
+                    crate::FlashKind::Patch | crate::FlashKind::Replace | crate::FlashKind::Insert
+                ) {
+                    state.set_status(ServoStatus::Pending);
+                }
             }
-            Ok(DioEvent::WriteReverted { id, error }) if bound(&id) => {
-                state.set_status(ServoStatus::Failed(error));
+            Ok(DioEvent::WriteReverted { id, error, kind }) if bound(&id) => {
+                // Only editing kinds are this servo's failure — a reverted
+                // Delete/Clear belongs to its issuer (the confirm dialog),
+                // and a form displaying the record must not adopt it as a
+                // save failure. The restored pre-image is absorbed either way.
+                if matches!(
+                    kind,
+                    crate::FlashKind::Patch | crate::FlashKind::Replace | crate::FlashKind::Insert
+                ) {
+                    state.set_status(ServoStatus::Failed(error));
+                }
                 absorb_from_cache(&state, &dio_weak).await;
             }
             Ok(_) => {}

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -372,3 +372,59 @@ async fn rejected_flash_reverts_and_reports_failed() -> Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn foreign_delete_failure_leaves_servo_tracking() -> Result<()> {
+    // A servo on a record is a bystander to a failed toolbar delete of
+    // that record: the revert restores the row, but the failure belongs
+    // to the delete's issuer (the confirm dialog) — not the edit form.
+    let shell = product_shell();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(|_dio, flash| async move {
+                if flash.kind() == &FlashKind::Delete {
+                    Err(vantage_core::error!("FOREIGN KEY constraint failed"))
+                } else {
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(product_vista(&shell)).await?;
+    for (id, r) in dio.master().list_values().await? {
+        dio.cache().insert_value(&id, &r).await?;
+    }
+    let servo = dio.servo("p1").await?;
+    let mut events = dio.subscribe_events();
+
+    let result = dio.flash_delete("p1").await;
+    assert!(
+        result.is_err(),
+        "the rejection surfaces to the delete caller"
+    );
+
+    // Wait until the revert has been broadcast, then let the servo's
+    // absorb task run.
+    loop {
+        match events.recv().await {
+            Ok(vantage_diorama::DioEvent::WriteReverted { id, .. }) if id == "p1" => break,
+            Ok(_) => {}
+            Err(e) => panic!("event bus closed early: {e}"),
+        }
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert!(
+        matches!(servo.status(), ServoStatus::Tracking),
+        "a failed delete must not read as the form's save failure, got {:?}",
+        servo.status()
+    );
+    assert_eq!(
+        dio.cache().get_value("p1").await?.unwrap().get("name"),
+        Some(&text("Coffee")),
+        "cache pre-image restored"
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -397,7 +397,8 @@ async fn foreign_delete_failure_leaves_servo_tracking() -> Result<()> {
         dio.cache().insert_value(&id, &r).await?;
     }
     let servo = dio.servo("p1").await?;
-    let mut events = dio.subscribe_events();
+    let mut gen_rx = servo.subscribe();
+    let g = u64::from(*gen_rx.borrow_and_update());
 
     let result = dio.flash_delete("p1").await;
     assert!(
@@ -405,16 +406,10 @@ async fn foreign_delete_failure_leaves_servo_tracking() -> Result<()> {
         "the rejection surfaces to the delete caller"
     );
 
-    // Wait until the revert has been broadcast, then let the servo's
-    // absorb task run.
-    loop {
-        match events.recv().await {
-            Ok(vantage_diorama::DioEvent::WriteReverted { id, .. }) if id == "p1" => break,
-            Ok(_) => {}
-            Err(e) => panic!("event bus closed early: {e}"),
-        }
-    }
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // The delete-kind WritePending no longer touches the servo, so the
+    // only generation bump after the delete is the revert's absorb —
+    // waiting for it proves the servo has seen the restored cache.
+    wait_for_gen(&mut gen_rx, g).await;
 
     assert!(
         matches!(servo.status(), ServoStatus::Tracking),

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_commit.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_commit.snap
@@ -1,6 +1,7 @@
 ---
 source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 63
 expression: events
 ---
-- "WritePending { id: \"a\" }"
+- "WritePending { id: \"a\", kind: Patch }"
 - "RecordChanged { id: \"a\" }"

--- a/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_rollback.snap
+++ b/vantage-diorama/tests/snapshots/event_log_snapshot@optimistic_rollback.snap
@@ -1,6 +1,7 @@
 ---
 source: vantage-diorama/tests/bdd_support/steps/assertions.rs
+assertion_line: 63
 expression: events
 ---
-- "WritePending { id: \"a\" }"
-- "WriteReverted { id: \"a\", error: \"on_flash rejected\" }"
+- "WritePending { id: \"a\", kind: Patch }"
+- "WriteReverted { id: \"a\", error: \"on_flash rejected\", kind: Patch }"

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.4 — 2026-07-23
+
+- Doc-comment fix: escape generics so `rustdoc -D warnings` passes. No
+  code change.
+
 ## 0.6.3 — 2026-07-21
 
 - Docs: fixed rustdoc doc-comment links (`Vec<AnyMongoType>`, `MongoId::from_str`)

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"

--- a/vantage-mongodb/src/mongodb/impls/table_source.rs
+++ b/vantage-mongodb/src/mongodb/impls/table_source.rs
@@ -25,7 +25,7 @@ use crate::mongodb::MongoDB;
 use crate::select::MongoSelect;
 use crate::types::{AnyMongoType, MongoType};
 
-/// Convert a bson::Document into a Record<AnyMongoType>, optionally extracting the _id.
+/// Convert a `bson::Document` into a `Record<AnyMongoType>`, optionally extracting the `_id`.
 fn doc_to_record(doc: bson::Document) -> (Option<MongoId>, Record<AnyMongoType>) {
     let mut fields = IndexMap::new();
     let mut id: Option<MongoId> = None;

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.14 — 2026-07-23
+
+- SQLite binds lower `Tag(8)` record references (`["table", id]` or
+  `"table:id"`) to their id — a numeric id binds as INTEGER, so
+  reference values from dropdowns insert cleanly into integer FK
+  columns instead of panicking `bind_by_cbor: unexpected CBOR value`.
+- Binding a value SQLite can't express is now a typed error naming the
+  parameter position and value shape — never a panic (these values come
+  straight from user forms).
+- Failed SQLite queries carry context: the SQL (truncated at 500 chars)
+  and a parameter-type summary (`?1=Text ?2=Integer …`, types only) —
+  enough to see which table/column a `datatype mismatch` points at.
+
 ## 0.6.13 — 2026-07-22
 
 - Vista factories (SQLite/Postgres/MySQL) lower **dotted spec columns**

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/postgres/impls/expr_data_source.rs
+++ b/vantage-sql/src/postgres/impls/expr_data_source.rs
@@ -94,7 +94,7 @@ async fn resolve_deferred(
     Ok(Expression::new(expr.template.clone(), resolved_params))
 }
 
-/// Flatten an Expression<AnyPostgresType> and convert `{}` placeholders to `$N`.
+/// Flatten an `Expression<AnyPostgresType>` and convert `{}` placeholders to `$N`.
 /// PostgreSQL uses $1, $2, ... for positional parameters (not ?N like SQLite).
 fn prepare_typed_query(
     expr: &Expression<AnyPostgresType>,

--- a/vantage-sql/src/postgres/row.rs
+++ b/vantage-sql/src/postgres/row.rs
@@ -218,7 +218,7 @@ fn bind_by_cbor<'q>(
     }
 }
 
-/// Convert a PgRow to Record<AnyPostgresType>.
+/// Convert a `PgRow` to `Record<AnyPostgresType>`.
 ///
 /// Each value is stored as CBOR with the type variant inferred from the
 /// PostgreSQL column type, preserving full type fidelity.

--- a/vantage-sql/src/postgres/types/chrono.rs
+++ b/vantage-sql/src/postgres/types/chrono.rs
@@ -168,7 +168,7 @@ fn parse_naive_datetime(s: &str) -> Option<NaiveDateTime> {
         .or_else(|| parse_datetime_utc(s).map(|dt| dt.naive_utc()))
 }
 
-/// Parse DateTime<Utc> from Postgres-native format first (`+00` without colon),
+/// Parse `DateTime<Utc>` from Postgres-native format first (`+00` without colon),
 /// then RFC 3339, then naive (assumed UTC).
 fn parse_datetime_utc(s: &str) -> Option<DateTime<Utc>> {
     // Postgres: "2025-01-10 12:00:00+00" — %#z accepts +00, +00:00, +0000

--- a/vantage-sql/src/postgres/types/value.rs
+++ b/vantage-sql/src/postgres/types/value.rs
@@ -275,7 +275,7 @@ fn extract_first_row(val: &AnyPostgresType) -> Option<CborValue> {
     }
 }
 
-/// Convert a CBOR Map into a Record<AnyPostgresType>.
+/// Convert a CBOR Map into a `Record<AnyPostgresType>`.
 fn cbor_map_to_record(map: Vec<(CborValue, CborValue)>) -> vantage_types::Record<AnyPostgresType> {
     map.into_iter()
         .map(|(k, v)| {

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -82,7 +82,7 @@ impl PostgresVistaFactory {
     }
 
     /// Build a `Table<PostgresDB, EmptyEntity>` from a spec, resolving any
-    /// `references:` against the attached resolver. See [`build_postgres_table`].
+    /// `references:` against the attached resolver. See `build_postgres_table`.
     pub fn table_from_spec(
         &self,
         spec: &PostgresVistaSpec,

--- a/vantage-sql/src/sqlite/impls/expr_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/expr_data_source.rs
@@ -107,7 +107,7 @@ async fn resolve_deferred(
     Ok(Expression::new(expr.template.clone(), resolved_params))
 }
 
-/// Flatten an Expression<AnySqliteType> and convert `{}` placeholders to `?N`.
+/// Flatten an `Expression<AnySqliteType>` and convert `{}` placeholders to `?N`.
 fn prepare_typed_query(
     expr: &Expression<AnySqliteType>,
 ) -> vantage_core::Result<(String, Vec<AnySqliteType>)> {

--- a/vantage-sql/src/sqlite/impls/expr_data_source.rs
+++ b/vantage-sql/src/sqlite/impls/expr_data_source.rs
@@ -3,7 +3,7 @@ use vantage_expressions::traits::expressive::DeferredFn;
 use vantage_expressions::{Expression, ExpressionFlattener, ExpressiveEnum, Flatten};
 
 use crate::sqlite::SqliteDB;
-use crate::sqlite::row::{bind_sqlite_value, row_to_record};
+use crate::sqlite::row::{bind_sqlite_value, describe_param_types, row_to_record};
 use crate::sqlite::types::AnySqliteType;
 
 impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
@@ -17,16 +17,26 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
         // 2. Flatten nested expressions + convert {} to ?N
         let (sql, params) = prepare_typed_query(&resolved)?;
 
-        // 3. Bind and execute
+        // 3. Bind and execute. Errors carry the SQL and a parameter-type
+        // summary (types only, never values) — the SQL names the table
+        // and columns, which is what failure reports need most.
         let mut query = sqlx::query(&sql);
-        for value in &params {
-            query = bind_sqlite_value(query, value);
+        for (i, value) in params.iter().enumerate() {
+            query = bind_sqlite_value(query, value).map_err(|mut e| {
+                e.context.insert("parameter".into(), (i + 1).to_string());
+                e.context.insert("sql".into(), truncate_sql(&sql));
+                e
+            })?;
         }
 
-        let rows = query
-            .fetch_all(self.pool())
-            .await
-            .map_err(|e| vantage_core::error!("SQLite query failed", details = e.to_string()))?;
+        let rows = query.fetch_all(self.pool()).await.map_err(|e| {
+            vantage_core::error!(
+                "SQLite query failed",
+                details = e.to_string(),
+                sql = truncate_sql(&sql),
+                params = describe_param_types(&params)
+            )
+        })?;
 
         // 4. Convert rows to AnySqliteType — each row becomes a CBOR Map
         let arr: Vec<CborValue> = rows
@@ -56,6 +66,18 @@ impl vantage_expressions::ExprDataSource<AnySqliteType> for SqliteDB {
                 Ok(result.unwrap_scalar())
             })
         })
+    }
+}
+
+/// SQL for error context — whole statement up to a cap, so a giant
+/// generated query can't balloon an error message.
+fn truncate_sql(sql: &str) -> String {
+    const MAX: usize = 500;
+    if sql.len() <= MAX {
+        sql.to_string()
+    } else {
+        let cut: String = sql.chars().take(MAX).collect();
+        format!("{cut}…")
     }
 }
 

--- a/vantage-sql/src/sqlite/row.rs
+++ b/vantage-sql/src/sqlite/row.rs
@@ -14,16 +14,20 @@ use vantage_types::Record;
 
 use super::types::{AnySqliteType, SqliteTypeVariants};
 
+type SqliteQuery<'q> = sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>;
+
 /// Bind an AnySqliteType to a sqlx query. Uses the variant tag to pick
 /// the right sqlx bind type — no guessing from the CBOR value format.
+/// Values the binder cannot express as a SQLite parameter come straight
+/// from user data, so they surface as errors — never a panic.
 pub(crate) fn bind_sqlite_value<'q>(
-    query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    query: SqliteQuery<'q>,
     value: &'q AnySqliteType,
-) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
+) -> vantage_core::Result<SqliteQuery<'q>> {
     let cbor = value.value();
-    match value.type_variant() {
+    Ok(match value.type_variant() {
         Some(SqliteTypeVariants::Null) => query.bind(None::<String>),
-        None => bind_by_cbor(query, cbor),
+        None => return bind_by_cbor(query, cbor),
         Some(SqliteTypeVariants::Bool) => match cbor {
             CborValue::Null => query.bind(None::<bool>),
             CborValue::Integer(i) => match i64::try_from(*i) {
@@ -74,15 +78,15 @@ pub(crate) fn bind_sqlite_value<'q>(
             CborValue::Text(s) => query.bind(s.as_bytes()),
             _ => query.bind(None::<Vec<u8>>),
         },
-    }
+    })
 }
 
 /// Bind a CBOR value without type variant — infers from the value itself.
 fn bind_by_cbor<'q>(
-    query: sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>>,
+    query: SqliteQuery<'q>,
     cbor: &'q CborValue,
-) -> sqlx::query::Query<'q, sqlx::Sqlite, sqlx::sqlite::SqliteArguments<'q>> {
-    match cbor {
+) -> vantage_core::Result<SqliteQuery<'q>> {
+    Ok(match cbor {
         CborValue::Null => query.bind(None::<String>),
         CborValue::Bool(b) => query.bind(*b),
         CborValue::Integer(i) => {
@@ -109,11 +113,103 @@ fn bind_by_cbor<'q>(
                 query.bind(None::<String>)
             }
         }
-        other => panic!(
-            "bind_by_cbor: unexpected CBOR value type {:?} — this is a bug upstream",
-            other
-        ),
+        // Record reference — Tag(8, ["table", id]) or Tag(8, "table:id").
+        // SQLite has no reference type, so the reference lowers to its id.
+        CborValue::Tag(8, inner) => return bind_reference_id(query, inner),
+        other => {
+            return Err(vantage_core::error!(
+                "cannot bind CBOR value to a SQLite parameter",
+                value = describe_cbor(other)
+            ));
+        }
+    })
+}
+
+/// Lower a `Tag(8)` record reference to its id and bind that. A numeric
+/// id binds as INTEGER so it satisfies INTEGER (and rowid) columns; a
+/// non-numeric id binds as TEXT.
+fn bind_reference_id<'q>(
+    query: SqliteQuery<'q>,
+    inner: &'q CborValue,
+) -> vantage_core::Result<SqliteQuery<'q>> {
+    let bind_id_text = |query: SqliteQuery<'q>, s: &'q str| match s.parse::<i64>() {
+        Ok(n) => query.bind(n),
+        Err(_) => query.bind(s),
+    };
+    Ok(match inner {
+        // SurrealDB string form "table:id" — everything after the first
+        // colon is the id (the whole text if there is no colon).
+        CborValue::Text(s) => {
+            let id = s.split_once(':').map(|(_, id)| id).unwrap_or(s.as_str());
+            bind_id_text(query, id)
+        }
+        CborValue::Array(parts) if parts.len() == 2 => match &parts[1] {
+            CborValue::Integer(i) => query.bind(i64::try_from(*i).ok()),
+            CborValue::Text(s) => bind_id_text(query, s.as_str()),
+            CborValue::Null => query.bind(None::<String>),
+            other => {
+                return Err(vantage_core::error!(
+                    "record reference id is not a scalar",
+                    id = describe_cbor(other)
+                ));
+            }
+        },
+        other => {
+            return Err(vantage_core::error!(
+                "record reference has an unexpected shape",
+                value = describe_cbor(other)
+            ));
+        }
+    })
+}
+
+/// Compact one-line description of a CBOR value for error context —
+/// shapes and types with values truncated, so errors stay readable and
+/// don't leak whole records.
+fn describe_cbor(v: &CborValue) -> String {
+    const MAX_TEXT: usize = 32;
+    match v {
+        CborValue::Null => "Null".into(),
+        CborValue::Bool(b) => format!("Bool({b})"),
+        CborValue::Integer(i) => format!("Integer({})", i128::from(*i)),
+        CborValue::Float(f) => format!("Float({f})"),
+        CborValue::Text(s) if s.len() <= MAX_TEXT => format!("Text({s:?})"),
+        CborValue::Text(s) => {
+            let cut: String = s.chars().take(MAX_TEXT).collect();
+            format!("Text({cut:?}…)")
+        }
+        CborValue::Bytes(b) => format!("Bytes(len {})", b.len()),
+        CborValue::Array(a) => format!("Array(len {})", a.len()),
+        CborValue::Map(m) => format!("Map(len {})", m.len()),
+        CborValue::Tag(t, inner) => format!("Tag({t}, {})", describe_cbor(inner)),
+        _ => "unknown CBOR value".into(),
     }
+}
+
+/// `?1=Text ?2=Integer …` — parameter type summary for error context.
+/// Types only, never values.
+pub(crate) fn describe_param_types(params: &[AnySqliteType]) -> String {
+    params
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let ty = match p.type_variant() {
+                Some(v) => format!("{v:?}"),
+                None => match p.value() {
+                    CborValue::Null => "Null".into(),
+                    CborValue::Bool(_) => "Bool".into(),
+                    CborValue::Integer(_) => "Integer".into(),
+                    CborValue::Float(_) => "Real".into(),
+                    CborValue::Text(_) => "Text".into(),
+                    CborValue::Bytes(_) => "Blob".into(),
+                    CborValue::Tag(t, _) => format!("Tag({t})"),
+                    _ => "?".into(),
+                },
+            };
+            format!("?{}={}", i + 1, ty)
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Convert a SqliteRow to Record<AnySqliteType>.
@@ -319,7 +415,7 @@ mod tests {
 
         let text_val = AnySqliteType::new("hello".to_string());
         let mut q = sqlx::query("INSERT INTO bind_test VALUES (?)");
-        q = bind_sqlite_value(q, &text_val);
+        q = bind_sqlite_value(q, &text_val).unwrap();
         q.execute(db.pool()).await.unwrap();
 
         let rows: Vec<SqliteRow> = sqlx::query("SELECT val FROM bind_test")
@@ -343,8 +439,8 @@ mod tests {
         let bool_val = AnySqliteType::new(true);
 
         let mut q = sqlx::query("INSERT INTO ib VALUES (?, ?)");
-        q = bind_sqlite_value(q, &int_val);
-        q = bind_sqlite_value(q, &bool_val);
+        q = bind_sqlite_value(q, &int_val).unwrap();
+        q = bind_sqlite_value(q, &bool_val).unwrap();
         q.execute(db.pool()).await.unwrap();
 
         let rows: Vec<SqliteRow> = sqlx::query("SELECT * FROM ib")

--- a/vantage-sql/src/sqlite/row.rs
+++ b/vantage-sql/src/sqlite/row.rs
@@ -212,7 +212,7 @@ pub(crate) fn describe_param_types(params: &[AnySqliteType]) -> String {
         .join(" ")
 }
 
-/// Convert a SqliteRow to Record<AnySqliteType>.
+/// Convert a `SqliteRow` to `Record<AnySqliteType>`.
 ///
 /// Each value is stored as CBOR with the type variant inferred from the
 /// SQLite column type, preserving full type fidelity.

--- a/vantage-sql/src/sqlite/types/value.rs
+++ b/vantage-sql/src/sqlite/types/value.rs
@@ -275,7 +275,7 @@ fn extract_first_row(val: &AnySqliteType) -> Option<CborValue> {
     }
 }
 
-/// Convert a CBOR Map into a Record<AnySqliteType>.
+/// Convert a CBOR Map into a `Record<AnySqliteType>`.
 fn cbor_map_to_record(map: Vec<(CborValue, CborValue)>) -> vantage_types::Record<AnySqliteType> {
     map.into_iter()
         .map(|(k, v)| {

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -87,7 +87,7 @@ impl SqliteVistaFactory {
     }
 
     /// Build a `Table<SqliteDB, EmptyEntity>` from a spec, resolving any
-    /// `references:` against the attached resolver. See [`build_sqlite_table`].
+    /// `references:` against the attached resolver. See `build_sqlite_table`.
     pub fn table_from_spec(&self, spec: &SqliteVistaSpec) -> Result<Table<SqliteDB, EmptyEntity>> {
         build_sqlite_table(spec, self.db.clone(), self.resolver.clone())
     }

--- a/vantage-sql/tests/rhai-tests/mysql/q1.sql
+++ b/vantage-sql/tests/rhai-tests/mysql/q1.sql
@@ -6,7 +6,7 @@ SELECT
 FROM
   `users` AS `u`
 WHERE
-  `u`.`active` = TRUE
+  `u`.`active` = true
   AND `u`.`department_id` != 0
 GROUP BY
   `u`.`id`,

--- a/vantage-sql/tests/rhai-tests/postgres/q1.sql
+++ b/vantage-sql/tests/rhai-tests/postgres/q1.sql
@@ -6,7 +6,7 @@ SELECT
 FROM
   "users" AS "u"
 WHERE
-  "u"."active" = TRUE
+  "u"."active" = true
   AND "u"."department_id" != 0
 GROUP BY
   "u"."id",

--- a/vantage-sql/tests/rhai_tests.rs
+++ b/vantage-sql/tests/rhai_tests.rs
@@ -34,7 +34,10 @@ mod sqlite_tests {
         let sql = result.inner.preview();
         let expected = std::fs::read_to_string("tests/rhai-tests/sqlite/q1.sql")
             .expect("Failed to read sqlite/q1.sql");
-        assert_eq!(sql.trim(), expected.trim());
+        // The pinned fixtures are pretty-printed; `preview()` renders one
+        // line. SQL is whitespace-insensitive — compare tokens.
+        let normalize = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert_eq!(normalize(&sql), normalize(&expected));
     }
 }
 
@@ -71,7 +74,10 @@ mod postgres_tests {
         let sql = result.inner.preview();
         let expected = std::fs::read_to_string("tests/rhai-tests/postgres/q1.sql")
             .expect("Failed to read postgres/q1.sql");
-        assert_eq!(sql.trim(), expected.trim());
+        // The pinned fixtures are pretty-printed; `preview()` renders one
+        // line. SQL is whitespace-insensitive — compare tokens.
+        let normalize = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert_eq!(normalize(&sql), normalize(&expected));
     }
 }
 
@@ -107,6 +113,9 @@ mod mysql_tests {
         let sql = result.inner.preview();
         let expected = std::fs::read_to_string("tests/rhai-tests/mysql/q1.sql")
             .expect("Failed to read mysql/q1.sql");
-        assert_eq!(sql.trim(), expected.trim());
+        // The pinned fixtures are pretty-printed; `preview()` renders one
+        // line. SQL is whitespace-insensitive — compare tokens.
+        let normalize = |s: &str| s.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert_eq!(normalize(&sql), normalize(&expected));
     }
 }

--- a/vantage-sql/tests/sqlite.rs
+++ b/vantage-sql/tests/sqlite.rs
@@ -4,6 +4,8 @@ mod sqlite {
     #[path = "2_associated.rs"]
     mod associated;
     mod bakery;
+    #[path = "2_bind_refs.rs"]
+    mod bind_refs;
     #[path = "1_chrono.rs"]
     mod chrono;
     #[path = "3_complex_queries.rs"]

--- a/vantage-sql/tests/sqlite/2_bind_refs.rs
+++ b/vantage-sql/tests/sqlite/2_bind_refs.rs
@@ -1,0 +1,211 @@
+//! Binding record references and malformed values.
+//!
+//! Reference dropdowns (and SurrealDB-shaped data generally) deliver
+//! record references as `Tag(8, ...)` CBOR — either `["table", id]` or
+//! `"table:id"`. SQLite has no reference type, so the binder lowers the
+//! reference to its id. A value the binder cannot lower must surface as
+//! an error that names the parameter — never a panic: these values come
+//! straight from user forms.
+
+use vantage_expressions::{ExprDataSource, Expression, ExpressiveEnum};
+use vantage_sql::sqlite::{AnySqliteType, SqliteDB};
+use vantage_types::Record;
+
+use ciborium::Value as CborValue;
+
+async fn setup() -> SqliteDB {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+
+    sqlx::query(
+        "CREATE TABLE book (
+            id INTEGER PRIMARY KEY,
+            title TEXT NOT NULL,
+            author_id INTEGER NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "CREATE TABLE note (
+            id INTEGER PRIMARY KEY,
+            owner TEXT NOT NULL
+        )",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    db
+}
+
+/// An expression whose parameters are raw CBOR without type variants —
+/// the shape `insert_table_value` produces from record data.
+fn untyped_expr(template: &str, params: Vec<CborValue>) -> Expression<AnySqliteType> {
+    Expression::new(
+        template,
+        params
+            .into_iter()
+            .map(|v| ExpressiveEnum::Scalar(AnySqliteType::untyped(v)))
+            .collect(),
+    )
+}
+
+fn records(result: AnySqliteType) -> Vec<Record<AnySqliteType>> {
+    Vec::<Record<AnySqliteType>>::try_from(result).unwrap()
+}
+
+fn reference_array(table: &str, id: CborValue) -> CborValue {
+    CborValue::Tag(
+        8,
+        Box::new(CborValue::Array(vec![
+            CborValue::Text(table.to_string()),
+            id,
+        ])),
+    )
+}
+
+// ── Tag(8) record references lower to their id ─────────────────────────────
+
+#[tokio::test]
+async fn reference_with_text_id_lowers_into_integer_column() {
+    let db = setup().await;
+
+    // The exact shape from the field report: Tag(8, ["authors", "1"]).
+    let insert = untyped_expr(
+        "INSERT INTO \"book\" (\"title\", \"author_id\") VALUES ({}, {})",
+        vec![
+            CborValue::Text("Kindred".into()),
+            reference_array("authors", CborValue::Text("1".into())),
+        ],
+    );
+    db.execute(&insert).await.unwrap();
+
+    let select = untyped_expr(
+        "SELECT author_id FROM book WHERE title = {}",
+        vec![CborValue::Text("Kindred".into())],
+    );
+    let rows = records(db.execute(&select).await.unwrap());
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["author_id"].try_get::<i64>(), Some(1));
+}
+
+#[tokio::test]
+async fn reference_with_integer_id_lowers_into_integer_column() {
+    let db = setup().await;
+
+    let insert = untyped_expr(
+        "INSERT INTO \"book\" (\"title\", \"author_id\") VALUES ({}, {})",
+        vec![
+            CborValue::Text("Dawn".into()),
+            reference_array("authors", CborValue::Integer(3.into())),
+        ],
+    );
+    db.execute(&insert).await.unwrap();
+
+    let select = untyped_expr(
+        "SELECT author_id FROM book WHERE title = {}",
+        vec![CborValue::Text("Dawn".into())],
+    );
+    let rows = records(db.execute(&select).await.unwrap());
+    assert_eq!(rows[0]["author_id"].try_get::<i64>(), Some(3));
+}
+
+#[tokio::test]
+async fn reference_in_string_form_lowers_to_id_part() {
+    let db = setup().await;
+
+    // SurrealDB string form: Tag(8, "authors:2").
+    let insert = untyped_expr(
+        "INSERT INTO \"book\" (\"title\", \"author_id\") VALUES ({}, {})",
+        vec![
+            CborValue::Text("Wild Seed".into()),
+            CborValue::Tag(8, Box::new(CborValue::Text("authors:2".into()))),
+        ],
+    );
+    db.execute(&insert).await.unwrap();
+
+    let select = untyped_expr(
+        "SELECT author_id FROM book WHERE title = {}",
+        vec![CborValue::Text("Wild Seed".into())],
+    );
+    let rows = records(db.execute(&select).await.unwrap());
+    assert_eq!(rows[0]["author_id"].try_get::<i64>(), Some(2));
+}
+
+#[tokio::test]
+async fn reference_with_non_numeric_id_lands_in_text_column() {
+    let db = setup().await;
+
+    let insert = untyped_expr(
+        "INSERT INTO \"note\" (\"owner\") VALUES ({})",
+        vec![reference_array("user", CborValue::Text("gita".into()))],
+    );
+    db.execute(&insert).await.unwrap();
+
+    let select = untyped_expr("SELECT owner FROM note", vec![]);
+    let rows = records(db.execute(&select).await.unwrap());
+    assert_eq!(rows[0]["owner"].try_get::<String>(), Some("gita".into()));
+}
+
+// ── Unbindable values error with a named parameter — never panic ───────────
+
+#[tokio::test]
+async fn unknown_tag_errors_instead_of_panicking() {
+    let db = setup().await;
+
+    let insert = untyped_expr(
+        "INSERT INTO \"note\" (\"owner\") VALUES ({})",
+        vec![CborValue::Tag(999, Box::new(CborValue::Array(vec![])))],
+    );
+    let err = db.execute(&insert).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("parameter"),
+        "should name the parameter: {msg}"
+    );
+    assert!(msg.contains("999"), "should describe the value: {msg}");
+}
+
+#[tokio::test]
+async fn bind_error_names_parameter_position() {
+    let db = setup().await;
+
+    // Second parameter is the broken one — the error must say so.
+    let insert = untyped_expr(
+        "INSERT INTO \"book\" (\"title\", \"author_id\") VALUES ({}, {})",
+        vec![CborValue::Text("ok".into()), CborValue::Map(vec![])],
+    );
+    let err = db.execute(&insert).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains('2'), "should name parameter 2: {msg}");
+}
+
+// ── Failed queries carry the SQL and a parameter-type summary ──────────────
+
+#[tokio::test]
+async fn failed_query_error_includes_sql_and_param_types() {
+    let db = setup().await;
+
+    // A non-numeric text bound to the INTEGER PRIMARY KEY (rowid) column
+    // is the classic SQLITE_MISMATCH — the id-strategy failure shape.
+    let insert = untyped_expr(
+        "INSERT INTO \"book\" (\"id\", \"title\", \"author_id\") VALUES ({}, {}, {})",
+        vec![
+            CborValue::Text("0198c5d2-not-a-rowid".into()),
+            CborValue::Text("Kindred".into()),
+            CborValue::Integer(1.into()),
+        ],
+    );
+    let err = db.execute(&insert).await.unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("INSERT INTO \\\"book\\\"") || msg.contains("INSERT INTO \"book\""),
+        "error should carry the SQL: {msg}"
+    );
+    assert!(
+        msg.contains("Text") && msg.contains("Integer"),
+        "error should summarize parameter types: {msg}"
+    );
+}

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.9 — 2026-07-23
+
+- Doc-comment fix: escape a generic in module docs so `rustdoc -D
+  warnings` passes. No code change.
+
 ## 0.6.8 — 2026-07-22
 
 - Reference narrowing coerces string-form record ids: `coerce_reference_value`

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.8"
+version = "0.6.9"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/types/value.rs
+++ b/vantage-surrealdb/src/types/value.rs
@@ -174,7 +174,7 @@ fn compact_duration_to_json(inner: CborValue) -> JsonValue {
     JsonValue::String(out)
 }
 
-/// Macro for explicit Expressive<AnySurrealType> impls on scalar types.
+/// Macro for explicit `Expressive<AnySurrealType>` impls on scalar types.
 /// Lets you pass `25i64`, `true`, `"hello"` directly to RefOperation methods.
 macro_rules! impl_expressive_for_scalar {
     ($($ty:ty),*) => {


### PR DESCRIPTION
## What

Field-reported write-path fixes (Sentry UI-30/UI-31 on vantage-ui 0.28.0) plus the delete-failure routing groundwork.

## vantage-sql 0.6.14

- `Tag(8, ["table", id])` / `Tag(8, "table:id")` record references lower to their id at bind time — numeric ids bind as INTEGER (integer FK and rowid columns), non-numeric as TEXT.
- `bind_sqlite_value`/`bind_by_cbor` return `Result`: an unbindable value is a typed error naming the parameter position and value shape, never a panic.
- Failed queries carry context: the SQL (truncated at 500 chars) and a parameter-type summary (`?1=Text ?2=Integer …`, types only).

TDD: `tests/sqlite/2_bind_refs.rs` (7 new tests, written red against the panicking build); full sqlite suite (222) green.

## vantage-diorama 0.7.3

- `DioEvent::WritePending` / `WriteReverted` carry the staged flash's `kind: FlashKind` — listeners can tell whose failure a revert is. A `Servo` only enters `Pending`/`Failed` for editing kinds (Patch/Replace/Insert): a failed toolbar Delete of the same record no longer reads as the edit form's "Save failed". Row statuses still apply to all kinds.
- `FlashKind` is `Copy`. New test: `foreign_delete_failure_leaves_servo_tracking`; event-log snapshots updated with the new field.

## vantage-core 0.6.2

- `VantageError::message()` / `location()` accessors so UI surfaces can render message, context map, and source chain as separate lines (vantage-ui's error alert box uses this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate error message and location accessors while preserving combined display output.
  * Improved SQLite record-reference binding and handling of unsupported values without panics.
  * Enhanced SQLite query errors with parameter details and relevant SQL context.
  * Added write-event context so interfaces can distinguish editing failures from unrelated operations.

* **Bug Fixes**
  * Prevented failed foreign deletes from incorrectly marking active forms as failed.
  * Preserved affected row state during optimistic write failures and rollbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->