### PR TITLE
vista: get_ref_target across all reference-supporting drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5523,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5566,7 +5566,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/docs4/src/intro/step5-dio-lens.md
+++ b/docs4/src/intro/step5-dio-lens.md
@@ -525,7 +525,7 @@ the trigger differs.
 ```admonish info title="Writes, on a read-only master"
 S3's listing Vista advertises `can_insert: false`, and the facade won't pretend otherwise — by
 default. Register an **`on_write`** callback on the Lens and the write queue becomes yours:
-each queued [`WriteOp`](vantage_diorama::WriteOp) is handed to your closure, which can append to
+each queued `WriteOp` is handed to your closure, which can append to
 a journal, call a different API, or write a queue — this is exactly the introduction's
 "a read-only CSV file accepts writes by routing them into a queue". Without `on_write`, queued
 ops are applied to the master directly, and a master that can't take them surfaces

--- a/docs4/src/new-persistence/step8-vista-integration.md
+++ b/docs4/src/new-persistence/step8-vista-integration.md
@@ -389,6 +389,26 @@ fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
 }
 ```
 
+**`get_ref` has a twin: `get_ref_target`.** Where `get_ref` resolves a relation *for a known
+parent row* (join condition applied), `get_ref_target` builds the **bare** target — the same table
+with **no** condition. It has the same three-line shape, but calls the typed table's
+`get_ref_target::<EmptyEntity>(relation)` instead of `get_ref_from_row`:
+
+```rust
+fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+    let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+    let factory = SqliteVistaFactory::new(self.table.data_source().clone());
+    factory.from_table(target)
+}
+```
+
+If your `get_ref` threads a resolver or converts the row into a native type, mirror that here
+(minus the row) — the wrap is identical. **Override both or neither:** a shell that forwards
+`get_ref` but leaves `get_ref_target` on the default lets read-side traversal work while every
+edit-form reference dropdown — which calls `Dio::get_ref_target(relation)` to list the eligible
+rows to pick from — silently fails with `Unimplemented`. That split is exactly the bug the SQL and
+Mongo drivers avoid by shipping both from day one.
+
 Two notes worth dwelling on:
 
 - The result is *another* `Vista`, not the inner table. Consumers stay on the universal surface;
@@ -560,12 +580,13 @@ ignores them, which is why MongoDB's vista layer routes single-level renames thr
 `column_paths` instead. Audit your read path before relying on aliases for column renames; if the
 table layer doesn't honour them, do the renaming in the vista source.
 
-**`get_ref` is the easiest method to forget.** The default returns `Unimplemented` even though
-the typed `Table<T, E>` you wrapped has full `with_one`/`with_many` support sitting right there.
-Forwarding is three lines (see "References delegate too" above), but a test file that never
-traverses won't catch the missing override — and `Vista::get_ref` is exactly the entry point
-YAML-driven UIs and CLIs reach for first. Add a reference-traversal smoke test to every driver's
-`tests/N_vista.rs`.
+**`get_ref` and `get_ref_target` are the easiest methods to forget — and forgetting just one is
+worse than forgetting both.** The defaults return `Unimplemented` even though the typed
+`Table<T, E>` you wrapped has full `with_one`/`with_many` support sitting right there. Forwarding
+each is three lines (see "References delegate too" above), but a test file that never traverses
+won't catch a missing override — and these are exactly the entry points YAML-driven UIs and CLIs
+reach for first (`get_ref` for drill-down, `get_ref_target` for the edit-form pick-a-related-record
+dropdown). Add a smoke test that exercises **both** to every driver's `tests/N_vista.rs`.
 
 **Cursor-only backends should not advertise offset.** `PaginateKind` is a UI hint as much as a
 declaration; getting it wrong means the UI offers an offset slider that never works. If the
@@ -599,9 +620,11 @@ At this point your backend should have:
    - Read methods translate native ids → `String` and native values → `CborValue` at the boundary.
    - Write methods (where supported) translate the other way.
    - `add_eq_condition` pushes a native condition onto the wrapped `Table`.
-   - `get_ref` forwards reference traversal through the wrapped `Table` and re-wraps the result as
-     a fresh `Vista`. `add_raw_condition` is also overridden if the driver participates in
-     cross-backend YAML references.
+   - `get_ref` **and** `get_ref_target` forward reference traversal through the wrapped `Table` and
+     re-wrap the result as a fresh `Vista` — `get_ref` with the parent-row join condition,
+     `get_ref_target` as the bare eligible-rows target the edit-form dropdown lists. Ship both or
+     neither. `add_raw_condition` is also overridden if the driver participates in cross-backend
+     YAML references.
    - `driver_name` returns a stable short label; `get_vista_count` and `stream_vista_values` are
      overridden where the backend has a native fast path.
    - `capabilities()` returns a `VistaCapabilities` whose `true` flags exactly match the methods

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.8 — 2026-07-23
+
+- REST and GraphQL `TableShell`s implement `get_ref_target` — the bare,
+  unconditioned relation target the edit-form reference dropdown lists. REST
+  handles both YAML-declared references (the resolver-built child with no join
+  condition) and hand-coded `with_one`/`with_many` registrations; GraphQL
+  forwards through the factory like `get_ref`. Previously this path returned
+  `Unimplemented`.
+
 ## 0.6.7 — 2026-07-20
 
 - `lazy:` computed columns on REST tables, behind the new `rhai` feature — a

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.7"
+version = "0.6.8"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/graphql/vista/source.rs
+++ b/vantage-api-client/src/graphql/vista/source.rs
@@ -128,6 +128,12 @@ impl TableShell for GraphqlApiTableShell {
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = GraphqlApiVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -256,6 +256,28 @@ impl TableShell for RestApiTableShell {
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        // YAML-declared reference: the bare target is the resolver-built
+        // child with no join condition applied — the same child `get_ref`
+        // starts from before it pins the parent's key.
+        if let Some(yref) = self.yaml_refs.get(relation) {
+            let resolver = self.resolver.as_ref().ok_or_else(|| {
+                error!(
+                    "YAML reference requires a model resolver — call \
+                     `with_model_resolver` on the factory or register \
+                     the target spec via `register_yaml`",
+                    relation = relation
+                )
+            })?;
+            return resolver(&yref.target);
+        }
+
+        // Hand-coded `with_many` / `with_one` registrations on the typed table.
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = RestApiVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn capabilities(&self) -> &VistaCapabilities {
         &self.capabilities
     }

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.4 — 2026-07-23
+
+- `AwsTableShell` implements `get_ref_target`, forwarding the bare relation
+  target through the factory like `get_ref`. Fills the reference-dropdown
+  (eligible-rows) path that previously fell back to `Unimplemented`.
+
 ## 0.6.3 — 2026-07-16
 
 - CBOR↔JSON at the wire boundary uses the shared `vantage-types` walker: tagged values

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atty",
  "indexmap",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.10"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.11"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/src/vista/source.rs
+++ b/vantage-aws/src/vista/source.rs
@@ -153,6 +153,12 @@ impl TableShell for AwsTableShell {
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = crate::vista::factory::AwsVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.2 — 2026-07-23
+
+- `CmdTableShell` implements `get_ref_target` (the bare relation target via the
+  factory), matching `get_ref`. Previously the eligible-rows dropdown path
+  returned `Unimplemented`.
+
 ## 0.6.1 — unreleased
 
 - CBOR↔JSON helpers use the shared `vantage-types` walker: tagged values render their

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atty",
  "indexmap",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.10"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.11"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-cmd/src/vista/source.rs
+++ b/vantage-cmd/src/vista/source.rs
@@ -115,6 +115,11 @@ impl TableShell for CmdTableShell {
         CmdVistaFactory::new(self.table.data_source().clone()).from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        CmdVistaFactory::new(self.table.data_source().clone()).from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.2 — 2026-07-23
+
+- `CsvTableShell` implements `get_ref_target`, wrapping the bare relation target
+  through the factory like `get_ref`. Fixes the reference-dropdown
+  (eligible-rows) path that returned `Unimplemented`.
+
 ## 0.6.1 — unreleased
 
 - The CBOR bridge uses the shared `vantage-types` walker: tagged values render their

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.6.1"
+version = "0.6.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"

--- a/vantage-csv/src/vista/source.rs
+++ b/vantage-csv/src/vista/source.rs
@@ -120,6 +120,12 @@ impl TableShell for CsvTableShell {
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = crate::vista::factory::CsvVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, vantage_vista::ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.7 — 2026-07-23
+
+- `FolderListingShell` implements `get_ref_target` for the `subdir` relation —
+  the bare listing rooted at the shell's own path — so the eligible-rows
+  dropdown path no longer returns `Unimplemented`.
+
 ## 0.6.6 — 2026-07-22
 
 - Track vantage-diorama 0.7 (Servo + ChangeFlash). No faker API changes —

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atty",
  "indexmap",
@@ -2018,10 +2018,11 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.17"
+version = "0.7.3"
 dependencies = [
  "async-trait",
  "ciborium",
+ "futures",
  "indexmap",
  "redb",
  "serde",
@@ -2051,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.5"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2072,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.10"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2096,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "ciborium",
  "indexmap",
@@ -2118,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.9"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-faker/src/live_folder/listing_shell.rs
+++ b/vantage-faker/src/live_folder/listing_shell.rs
@@ -210,6 +210,24 @@ impl TableShell for FolderListingShell {
         ))
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        if relation != "subdir" {
+            return Err(error!(
+                "unknown relation",
+                relation = relation,
+                source_type = "FolderListingShell"
+            )
+            .mark_unimplemented()
+            .traced());
+        }
+        // The bare target of `subdir` (no parent row) is the listing rooted
+        // at this shell's own path — every subdirectory that could be picked.
+        Ok(Vista::new(
+            "live-folder-listing",
+            Box::new(FolderListingShell::new(self.inner.clone(), self.path.clone())),
+        ))
+    }
+
     fn capabilities(&self) -> &VistaCapabilities {
         &self.capabilities
     }

--- a/vantage-kubernetes/CHANGELOG.md
+++ b/vantage-kubernetes/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1 — 2026-07-23
+
+- `KubeTableShell` implements `get_ref_target` (the bare relation target via the
+  factory), matching `get_ref`. Fills the eligible-rows dropdown path that
+  previously returned `Unimplemented`.
+
 ## 0.1.0 — 2026-06-28
 
 Initial release — a native Kubernetes `TableSource` backend for Vantage,

--- a/vantage-kubernetes/Cargo.lock
+++ b/vantage-kubernetes/Cargo.lock
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-kubernetes"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-kubernetes/Cargo.toml
+++ b/vantage-kubernetes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-kubernetes"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-kubernetes/src/vista/source.rs
+++ b/vantage-kubernetes/src/vista/source.rs
@@ -252,6 +252,12 @@ impl TableShell for KubeTableShell {
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let factory = crate::vista::factory::KubeVistaFactory::new(self.table.data_source().clone());
+        factory.from_table(target)
+    }
+
     fn get_ref_kinds(&self) -> Vec<(String, ReferenceKind)> {
         self.table.ref_kinds()
     }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.10 — 2026-07-23
+
+- `SurrealTableShell` implements `get_ref_target` — the bare, unconditioned
+  target of a relation — mirroring `get_ref`'s factory wrap (resolver threaded).
+  Without it the edit-form reference dropdown, which lists a relation's eligible
+  rows via `Dio::get_ref_target`, failed with `Unimplemented`; row-conditioned
+  drill-down (`get_ref`) already worked.
+- Doc-comment fix: give the `register_surreal_engine!` intra-doc link an
+  explicit `crate::` path so `cargo doc --all-features` passes `-D warnings`.
+
 ## 0.6.9 — 2026-07-23
 
 - Doc-comment fix: escape a generic in module docs so `rustdoc -D

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.9"
+version = "0.6.10"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/rhai_engine/mod.rs
+++ b/vantage-surrealdb/src/rhai_engine/mod.rs
@@ -21,7 +21,7 @@ pub use types::{RhaiCase, RhaiExpr, RhaiIdent, RhaiSelect};
 /// Register the full SurrealDB query-building vocabulary onto `engine`.
 ///
 /// Shared by two entry points:
-/// - the [`register_surreal_engine!`] macro, whose `__create_engine` wraps this
+/// - the [`register_surreal_engine!`](crate::register_surreal_engine) macro, whose `__create_engine` wraps this
 ///   in a fresh `Engine` (back-compat for the standalone Rhai tests/examples and
 ///   the `rhai:` vista source);
 /// - `SurrealTableShell::register_rhai_extensions`, which layers it on top of

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -278,6 +278,15 @@ where
         factory.from_table(target)
     }
 
+    fn get_ref_target(&self, relation: &str) -> Result<Vista> {
+        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let mut factory = SurrealVistaFactory::new(self.table.data_source().clone());
+        if let Some(resolver) = &self.resolver {
+            factory = factory.with_resolver(resolver.clone());
+        }
+        factory.from_table(target)
+    }
+
     fn contained(&self) -> &IndexMap<String, ContainedSpec> {
         &self.metadata.contained
     }


### PR DESCRIPTION
The edit-form reference dropdown (introduced in Vantage UI 0.28) populates its list of eligible rows by calling `Dio::get_ref_target(relation)` — the **bare** target of a relation, with no parent-row join condition. Only `vantage-sql` and `vantage-mongodb` ever implemented the `TableShell::get_ref_target` override; every other driver that supports references (`get_ref`) left it on the trait default, which returns `Unimplemented`. So row-conditioned drill-down worked, but the pick-a-related-record dropdown silently failed.

This was first hit on a SurrealDB project (golf-2): the `tag` form’s `course_id → golf_course` and `batch` reference dropdowns logged `get_ref_target not implemented for SurrealTableShell`.

## Fix

Add the `get_ref_target` override to every reference-supporting driver, mirroring each one’s existing `get_ref` factory-wrap (minus the row condition):

| Crate | Shell | Notes |
|---|---|---|
| vantage-surrealdb 0.6.10 | `SurrealTableShell` | threads the resolver, like its `get_ref` |
| vantage-api-client 0.6.8 | `RestApiTableShell`, `GraphqlApiTableShell` | REST handles YAML-declared refs (bare resolver child) + hand-coded registrations |
| vantage-aws 0.6.4 | `AwsTableShell` | |
| vantage-cmd 0.6.2 | `CmdTableShell` | |
| vantage-csv 0.6.2 | `CsvTableShell` | |
| vantage-kubernetes 0.1.1 | `KubeTableShell` | |
| vantage-faker 0.6.7 | `FolderListingShell` | `subdir` bare target = listing at the shell’s own path |

`vantage-log-writer` and faker’s `size_shell` have no `get_ref`, so they keep the default (no references) — correct.

Also: a one-line pre-existing rustdoc broken-intra-doc-link fix in `vantage-surrealdb` (`register_surreal_engine!` link), and a `docs4` update to the datasource build guide so the `get_ref`/`get_ref_target` pair is taught as "override both or neither" — the gap kept getting missed per-driver precisely because the guide only covered `get_ref`.

## Verification

- `cargo +1.97.0 clippy` — workspace (CI command) + aws/cmd/kubernetes/faker standalone: clean.
- `cargo +1.97.0 fmt --all --check`: clean.
- `cargo +1.97.0 doc -D warnings` — workspace + surrealdb standalone: clean.
- Manually verified against the running app: the golf-2 `tag` form dropdowns now populate, and `list_logs` is clear of the `get_ref_target` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reference-selection dropdowns in edit forms now load eligible related records instead of showing an unimplemented error.
  * Relationship targets are consistently available across REST, GraphQL, AWS, command-line, CSV, file-listing, Kubernetes, and SurrealDB integrations.
  * Existing row-specific relationship navigation remains supported.

* **Documentation**
  * Clarified guidance for implementing and testing relationship traversal.

* **Chores**
  * Updated package versions and changelogs for the affected integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->