### PR TITLE
Filter by comparison operators (push-down + local fallback) and nulls-last sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5884,7 +5884,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.4 — 2026-07-23
+
+- `TableSceneryBuilder::where_op(col, op, value)` and the `OpCondition` type —
+  non-equality filters (`!=`, `<`, `in`, …) applied locally over the cache, the
+  fallback for operators the master vista can't push. Kept in a channel separate
+  from the equality `where_eq` path and folded into the query-variant cache key
+  so a filtered scenery gets its own ordered index. The Dio facade passes the
+  master's `can_filter_operators` through.
+- Sort now keeps empty (`None`) values **last regardless of direction**.
+  Previously blanks sorted to the top in ascending order (the direction reversal
+  flipped null placement along with everything else).
+
 ## 0.7.3 — 2026-07-23
 
 - `DioEvent::WritePending` and `DioEvent::WriteReverted` carry the

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -48,6 +48,11 @@ impl DioShell {
             // will swap in cache-aware truth for these.
             can_order: master_caps.can_order,
             can_search: master_caps.can_search,
+            // Whether operator filters (`!=`, `<`, `in`, …) can be pushed into
+            // the master's query. When false the Dio still filters locally over
+            // the cache — the caller just can't bake the condition into a
+            // distinct cached query variant.
+            can_filter_operators: master_caps.can_filter_operators,
             can_set_page_size: master_caps.can_set_page_size,
             can_fetch_page: master_caps.can_fetch_page,
             can_fetch_next: master_caps.can_fetch_next,

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -28,9 +28,9 @@ pub use lens::{
 };
 pub use ops::{ChangeEvent, ChangeFlash, FlashKind, QueryDescriptor};
 pub use scenery::{
-    Aggregate, CappedScenery, CustomAggregate, EnrichedRecord, RecordScenery, RecordStatus,
-    RowStatus, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder, ValueScenery,
-    ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
+    Aggregate, CappedScenery, CustomAggregate, EnrichedRecord, OpCondition, RecordScenery,
+    RecordStatus, RowStatus, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder,
+    ValueScenery, ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
 };
 pub use servo::{Servo, ServoStatus};
 pub use vantage_vista::VistaCapabilities;

--- a/vantage-diorama/src/scenery/mod.rs
+++ b/vantage-diorama/src/scenery/mod.rs
@@ -5,7 +5,9 @@ pub mod value;
 
 pub use enriched_record::{EnrichedRecord, RowStatus};
 pub use record::{RecordScenery, RecordStatus};
-pub use table::{CappedScenery, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder};
+pub use table::{
+    CappedScenery, OpCondition, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder,
+};
 pub use value::{
     Aggregate, CustomAggregate, ValueScenery, ValueSceneryBuilder, ValueStatus,
     boxed_custom_aggregate,

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -8,6 +8,7 @@ use vantage_core::Result;
 
 use crate::dio::{Dio, DioInner, Generation};
 
+use super::helpers::op_conditions_key;
 use super::loader::{enqueue_viewport, viewport_loop};
 use super::reactor::reload_loop;
 use super::state::TableSceneryState;
@@ -17,6 +18,10 @@ use super::{SceneryGuard, SortDir, TableScenery, TableSceneryImpl, ViewportReque
 pub struct TableSceneryBuilder {
     pub(crate) dio: Arc<DioInner>,
     pub(crate) conditions: Vec<(String, CborValue)>,
+    /// Non-equality filters applied locally over the cache (the fallback for
+    /// operators the master vista can't push down). Kept separate from the
+    /// equality `conditions` so the plain eq path is untouched.
+    pub(crate) op_conditions: Vec<super::OpCondition>,
     pub(crate) sort: Option<(String, SortDir)>,
     pub(crate) search: Option<String>,
     pub(crate) page_size: usize,
@@ -31,6 +36,7 @@ impl TableSceneryBuilder {
         Self {
             dio,
             conditions: Vec::new(),
+            op_conditions: Vec::new(),
             sort: None,
             search: None,
             page_size: 100,
@@ -43,6 +49,20 @@ impl TableSceneryBuilder {
 
     pub fn where_eq(mut self, col: impl Into<String>, value: impl Into<CborValue>) -> Self {
         self.conditions.push((col.into(), value.into()));
+        self
+    }
+
+    /// Add a non-equality filter (`!=`, `<`, `in`, …) applied locally over the
+    /// cache. Use for operators the master vista can't push down; a plain
+    /// equality is cheaper through [`where_eq`](Self::where_eq).
+    pub fn where_op(
+        mut self,
+        col: impl Into<String>,
+        op: vantage_vista::FilterOp,
+        value: impl Into<CborValue>,
+    ) -> Self {
+        self.op_conditions
+            .push(super::OpCondition::new(col, op, value));
         self
     }
 
@@ -122,6 +142,7 @@ impl TableSceneryBuilder {
         let TableSceneryBuilder {
             dio,
             conditions,
+            op_conditions,
             sort,
             search,
             page_size,
@@ -171,11 +192,12 @@ impl TableSceneryBuilder {
                 }
             };
             let mut key = format!(
-                "table\u{1}{}\u{1}{}\u{1}{}\u{1}{}",
+                "table\u{1}{}\u{1}{}\u{1}{}\u{1}{}\u{1}{}",
                 dio.master
                     .read()
                     .unwrap()
                     .index_key(&conditions, vista_sort),
+                op_conditions_key(&op_conditions),
                 search.as_deref().unwrap_or(""),
                 titles_only as u8,
                 demand_key,
@@ -212,7 +234,10 @@ impl TableSceneryBuilder {
         // predicates anyway.
         let local_refine = two_pass
             && !titles_only
-            && (!conditions.is_empty() || sort.is_some() || search.is_some());
+            && (!conditions.is_empty()
+                || !op_conditions.is_empty()
+                || sort.is_some()
+                || search.is_some());
         let index = if two_pass {
             let vista_sort = sort.as_ref().map(|(col, dir)| {
                 let dir = match dir {
@@ -221,11 +246,16 @@ impl TableSceneryBuilder {
                 };
                 (col.as_str(), dir)
             });
-            let key = dio
+            let mut key = dio
                 .master
                 .read()
                 .unwrap()
                 .index_key(&conditions, vista_sort);
+            // Operator filters live outside the vista's eq-only index_key, so
+            // fold them into the shared-index key here — two op-filter variants
+            // must not collide onto one ordered index.
+            key.push('\u{1}');
+            key.push_str(&op_conditions_key(&op_conditions));
             Some(dio.query_index(&key))
         } else {
             None
@@ -244,6 +274,7 @@ impl TableSceneryBuilder {
             _tally: crate::stats::Tally::table_scenery(),
             dio_weak: Arc::downgrade(&dio),
             conditions: RwLock::new(conditions),
+            op_conditions: RwLock::new(op_conditions),
             sort: RwLock::new(sort),
             search: RwLock::new(search),
             rows: RwLock::new(Default::default()),

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -1,6 +1,8 @@
 use ciborium::Value as CborValue;
 use vantage_types::Record;
 
+use super::SortDir;
+
 /// Resolve a column key against a record, walking dotted paths (`obj.field`)
 /// into nested CBOR `Map`s. A REST `?mode=detailed` response stores belongs-to
 /// objects as nested maps (e.g. `launch_service_provider: { name: … }`) and
@@ -34,6 +36,53 @@ pub(crate) fn matches_conditions(rec: &Record<CborValue>, conds: &[(String, Cbor
         })
 }
 
+/// Local evaluation of the non-equality [`OpCondition`](super::OpCondition)
+/// filters — the fallback for operators the master vista can't push down. A
+/// missing column never matches (same convention as
+/// [`matches_conditions`]).
+pub(crate) fn matches_op_conditions(rec: &Record<CborValue>, conds: &[super::OpCondition]) -> bool {
+    use vantage_vista::FilterOp;
+    conds.iter().all(|cond| {
+        let Some(cell) = record_get_path(rec, &cond.column) else {
+            return false;
+        };
+        match cond.op {
+            FilterOp::Eq => cbor_eq(cell, &cond.value),
+            FilterOp::Ne => !cbor_eq(cell, &cond.value),
+            FilterOp::Gt | FilterOp::Gte | FilterOp::Lt | FilterOp::Lte => cond
+                .op
+                .matches_ordering(cbor_cmp(Some(cell), Some(&cond.value))),
+            FilterOp::InSet => set_members(&cond.value).any(|m| cbor_eq(cell, m)),
+            FilterOp::NotInSet => !set_members(&cond.value).any(|m| cbor_eq(cell, m)),
+        }
+    })
+}
+
+/// Iterate the members of a set operand — the `CborValue::Array` payload of an
+/// `InSet` / `NotInSet` condition. A non-array operand yields nothing (so an
+/// `InSet` matches nothing and a `NotInSet` matches everything), matching the
+/// "malformed filter fails closed for membership" intent.
+fn set_members(value: &CborValue) -> std::slice::Iter<'_, CborValue> {
+    const EMPTY: &[CborValue] = &[];
+    match value {
+        CborValue::Array(items) => items.iter(),
+        _ => EMPTY.iter(),
+    }
+}
+
+/// Order-insensitive cache-key fragment for a set of
+/// [`OpCondition`](super::OpCondition)s, so a scenery narrowed by operators
+/// gets a distinct ordered index. Empty set → empty string (no key cost for
+/// the common no-op-filter case).
+pub(crate) fn op_conditions_key(conds: &[super::OpCondition]) -> String {
+    if conds.is_empty() {
+        return String::new();
+    }
+    let mut frags: Vec<String> = conds.iter().map(|c| c.key_fragment()).collect();
+    frags.sort();
+    frags.join(";")
+}
+
 pub(crate) fn matches_search(rec: &Record<CborValue>, needle: Option<&str>) -> bool {
     let Some(needle) = needle else {
         return true;
@@ -53,6 +102,129 @@ pub(crate) fn cbor_eq(a: &CborValue, b: &CborValue) -> bool {
         // Float and the rest fall back to format-string compare. Good
         // enough for v1's hand-rolled filter.
         _ => format!("{a:?}") == format!("{b:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scenery::table::OpCondition;
+    use vantage_vista::FilterOp;
+
+    fn rec(status: &str, count: i64) -> Record<CborValue> {
+        let mut r = Record::new();
+        r.insert("status".to_string(), CborValue::Text(status.to_string()));
+        r.insert("count".to_string(), CborValue::Integer(count.into()));
+        r
+    }
+
+    fn text_array(items: &[&str]) -> CborValue {
+        CborValue::Array(
+            items
+                .iter()
+                .map(|s| CborValue::Text((*s).to_string()))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn ne_filters_out_only_the_equal_value() {
+        let conds = vec![OpCondition::new(
+            "status",
+            FilterOp::Ne,
+            CborValue::Text("unregistered".into()),
+        )];
+        assert!(matches_op_conditions(&rec("registered", 1), &conds));
+        assert!(!matches_op_conditions(&rec("unregistered", 1), &conds));
+    }
+
+    #[test]
+    fn ordered_operators_compare_numerically() {
+        let gt = vec![OpCondition::new(
+            "count",
+            FilterOp::Gt,
+            CborValue::Integer(5.into()),
+        )];
+        assert!(matches_op_conditions(&rec("x", 6), &gt));
+        assert!(!matches_op_conditions(&rec("x", 5), &gt));
+
+        let lte = vec![OpCondition::new(
+            "count",
+            FilterOp::Lte,
+            CborValue::Integer(5.into()),
+        )];
+        assert!(matches_op_conditions(&rec("x", 5), &lte));
+        assert!(!matches_op_conditions(&rec("x", 6), &lte));
+    }
+
+    #[test]
+    fn set_membership() {
+        let in_set = vec![OpCondition::new(
+            "status",
+            FilterOp::InSet,
+            text_array(&["registered", "pending"]),
+        )];
+        assert!(matches_op_conditions(&rec("registered", 1), &in_set));
+        assert!(!matches_op_conditions(&rec("unregistered", 1), &in_set));
+
+        let not_in = vec![OpCondition::new(
+            "status",
+            FilterOp::NotInSet,
+            text_array(&["unregistered"]),
+        )];
+        assert!(matches_op_conditions(&rec("registered", 1), &not_in));
+        assert!(!matches_op_conditions(&rec("unregistered", 1), &not_in));
+    }
+
+    #[test]
+    fn missing_column_never_matches() {
+        let conds = vec![OpCondition::new(
+            "nonexistent",
+            FilterOp::Ne,
+            CborValue::Text("x".into()),
+        )];
+        assert!(!matches_op_conditions(&rec("registered", 1), &conds));
+    }
+
+    #[test]
+    fn op_key_is_order_insensitive_and_operator_distinct() {
+        let a = OpCondition::new("status", FilterOp::Ne, CborValue::Text("u".into()));
+        let b = OpCondition::new("count", FilterOp::Gt, CborValue::Integer(5.into()));
+        // Same set, different declared order → same key.
+        assert_eq!(
+            op_conditions_key(&[a.clone(), b.clone()]),
+            op_conditions_key(&[b, a])
+        );
+        // Different operator → different key.
+        let ne = OpCondition::new("status", FilterOp::Ne, CborValue::Text("u".into()));
+        let eq = OpCondition::new("status", FilterOp::Eq, CborValue::Text("u".into()));
+        assert_ne!(op_conditions_key(&[ne]), op_conditions_key(&[eq]));
+    }
+}
+
+/// Row comparator for a sortable column that keeps **empty (`None`) values at
+/// the end regardless of direction**. Only the present-vs-present comparison
+/// follows `dir`; a missing value always sorts after a present one, so
+/// flipping asc↔desc never lifts blanks to the top. Use this instead of
+/// `cbor_cmp(...).reverse()`, which reverses null placement along with
+/// everything else.
+pub(crate) fn cmp_sort(
+    a: Option<&CborValue>,
+    b: Option<&CborValue>,
+    dir: SortDir,
+) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (None, None) => Ordering::Equal,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(_), None) => Ordering::Less,
+        (Some(_), Some(_)) => {
+            let ord = cbor_cmp(a, b);
+            match dir {
+                SortDir::Asc => ord,
+                SortDir::Desc => ord.reverse(),
+            }
+        }
     }
 }
 
@@ -80,5 +252,35 @@ pub(crate) fn cbor_cmp(a: Option<&CborValue>, b: Option<&CborValue>) -> std::cmp
             (CborValue::Bool(l), CborValue::Bool(r)) => l.cmp(r),
             _ => format!("{lhs:?}").cmp(&format!("{rhs:?}")),
         },
+    }
+}
+
+#[cfg(test)]
+mod sort_tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn empty_values_sort_last_in_both_directions() {
+        let one = CborValue::Integer(1i64.into());
+        let two = CborValue::Integer(2i64.into());
+
+        // Present values follow the direction.
+        assert_eq!(
+            cmp_sort(Some(&one), Some(&two), SortDir::Asc),
+            Ordering::Less
+        );
+        assert_eq!(
+            cmp_sort(Some(&one), Some(&two), SortDir::Desc),
+            Ordering::Greater
+        );
+
+        // A missing value sorts AFTER a present one regardless of direction —
+        // so flipping asc↔desc never lifts blanks to the top.
+        for dir in [SortDir::Asc, SortDir::Desc] {
+            assert_eq!(cmp_sort(None, Some(&one), dir), Ordering::Greater);
+            assert_eq!(cmp_sort(Some(&one), None, dir), Ordering::Less);
+            assert_eq!(cmp_sort(None, None, dir), Ordering::Equal);
+        }
     }
 }

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -47,6 +47,41 @@ pub enum SortDir {
     Desc,
 }
 
+/// A non-equality filter condition applied **locally** over the cached rows —
+/// the fallback path when the master vista can't push the operator into its
+/// query (advertised via
+/// [`can_filter_operators`](vantage_vista::VistaCapabilities::can_filter_operators)).
+/// `value` carries a scalar for the scalar operators and a
+/// [`CborValue::Array`](ciborium::Value::Array) for `InSet` / `NotInSet`.
+/// Plain equality keeps using the lighter `where_eq` / `conditions` path.
+#[derive(Debug, Clone)]
+pub struct OpCondition {
+    pub column: String,
+    pub op: vantage_vista::FilterOp,
+    pub value: ciborium::Value,
+}
+
+impl OpCondition {
+    pub fn new(
+        column: impl Into<String>,
+        op: vantage_vista::FilterOp,
+        value: impl Into<ciborium::Value>,
+    ) -> Self {
+        Self {
+            column: column.into(),
+            op,
+            value: value.into(),
+        }
+    }
+
+    /// Stable `field<sym>value` fragment for the query-variant cache key, so a
+    /// scenery narrowed by this operator gets its own ordered index (never
+    /// colliding with the unfiltered set or a different-operator filter).
+    pub(crate) fn key_fragment(&self) -> String {
+        format!("{}{}{:?}", self.column, self.op.key_symbol(), self.value)
+    }
+}
+
 /// Internal viewport request carried over the debounce channel.
 #[derive(Debug, Clone)]
 pub(crate) struct ViewportRequest {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -12,7 +12,9 @@ use crate::dio::{DioInner, Generation};
 use crate::lens::SceneryChunkTarget;
 use crate::scenery::enriched_record::{EnrichedRecord, RowStatus};
 
-use super::helpers::{cbor_cmp, matches_conditions, matches_search, record_get_path};
+use super::helpers::{
+    cmp_sort, matches_conditions, matches_op_conditions, matches_search, record_get_path,
+};
 use super::{SortDir, ViewportRequest};
 
 /// Internal state shared by the public scenery handle, the reactor
@@ -25,6 +27,10 @@ pub(crate) struct TableSceneryState {
     pub(crate) dio_weak: std::sync::Weak<DioInner>,
 
     pub(crate) conditions: RwLock<Vec<(String, CborValue)>>,
+    /// Non-equality filters applied locally over the cache (see
+    /// [`OpCondition`](super::OpCondition)). Separate from `conditions` so the
+    /// eq path is unchanged; both are ANDed in the reseed filter chain.
+    pub(crate) op_conditions: RwLock<Vec<super::OpCondition>>,
     pub(crate) sort: RwLock<Option<(String, SortDir)>>,
     pub(crate) search: RwLock<Option<String>>,
 
@@ -186,12 +192,14 @@ impl TableSceneryState {
         let all = dio_inner.cache.list_values().await?;
 
         let conditions = self.conditions.read().unwrap().clone();
+        let op_conditions = self.op_conditions.read().unwrap().clone();
         let search = self.search.read().unwrap().clone();
         let sort = self.sort.read().unwrap().clone();
 
         let mut filtered: Vec<(String, Record<CborValue>)> = all
             .into_iter()
             .filter(|(_, rec)| matches_conditions(rec, &conditions))
+            .filter(|(_, rec)| matches_op_conditions(rec, &op_conditions))
             .filter(|(_, rec)| matches_search(rec, search.as_deref()))
             .collect();
 
@@ -201,11 +209,7 @@ impl TableSceneryState {
                 .filter(|(_, r)| record_get_path(r, &col).is_none())
                 .count();
             filtered.sort_by(|(_, a), (_, b)| {
-                let ord = cbor_cmp(record_get_path(a, &col), record_get_path(b, &col));
-                match dir {
-                    SortDir::Asc => ord,
-                    SortDir::Desc => ord.reverse(),
-                }
+                cmp_sort(record_get_path(a, &col), record_get_path(b, &col), dir)
             });
             tracing::debug!(
                 target: "vantage_diorama::sort",

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -95,7 +95,9 @@ fn references_augmented_column(
 /// column is absent → no match), so matches surface as rows hydrate. The row's
 /// `Fresh`/`Incomplete` status is preserved.
 pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
-    use super::helpers::{cbor_cmp, matches_conditions, matches_search, record_get_path};
+    use super::helpers::{
+        cmp_sort, matches_conditions, matches_op_conditions, matches_search, record_get_path,
+    };
 
     let Some(dio_inner) = state.dio_weak.upgrade() else {
         return;
@@ -105,6 +107,7 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
     };
     let ids = index.ids();
     let conditions = state.conditions.read().unwrap().clone();
+    let op_conditions = state.op_conditions.read().unwrap().clone();
     let search = state.search.read().unwrap().clone();
     let sort = state.sort.read().unwrap().clone();
 
@@ -118,6 +121,7 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
             .ok()
             .flatten()
             && matches_conditions(&rec, &conditions)
+            && matches_op_conditions(&rec, &op_conditions)
             && matches_search(&rec, search.as_deref())
         {
             gathered.push((id.clone(), rec, status));
@@ -126,11 +130,7 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
 
     if let Some((col, dir)) = &sort {
         gathered.sort_by(|(_, a, _), (_, b, _)| {
-            let ord = cbor_cmp(record_get_path(a, col), record_get_path(b, col));
-            match dir {
-                SortDir::Asc => ord,
-                SortDir::Desc => ord.reverse(),
-            }
+            cmp_sort(record_get_path(a, col), record_get_path(b, col), *dir)
         });
     }
 
@@ -315,6 +315,7 @@ pub(crate) async fn resort(state: Arc<TableSceneryState>) {
     // 1. Re-point at the index for the new (conditions, sort) variant. Reusing
     //    a variant opened earlier finds its index already built.
     let conditions = state.conditions.read().unwrap().clone();
+    let op_conditions = state.op_conditions.read().unwrap().clone();
     let sort = state.sort.read().unwrap().clone();
     let vista_sort = sort.as_ref().map(|(col, dir)| {
         let dir = match dir {
@@ -323,11 +324,13 @@ pub(crate) async fn resort(state: Arc<TableSceneryState>) {
         };
         (col.as_str(), dir)
     });
-    let key = dio_inner
+    let mut key = dio_inner
         .master
         .read()
         .unwrap()
         .index_key(&conditions, vista_sort);
+    key.push('\u{1}');
+    key.push_str(&super::helpers::op_conditions_key(&op_conditions));
     let new_index = dio_inner.query_index(&key);
     state.set_index(Some(new_index.clone()));
 
@@ -429,6 +432,7 @@ pub(crate) async fn refresh_index(state: &Arc<TableSceneryState>) {
     };
 
     let conditions = state.conditions.read().unwrap().clone();
+    let op_conditions = state.op_conditions.read().unwrap().clone();
     let sort = state.sort.read().unwrap().clone();
     let vista_sort = sort.as_ref().map(|(col, dir)| {
         let dir = match dir {
@@ -437,11 +441,13 @@ pub(crate) async fn refresh_index(state: &Arc<TableSceneryState>) {
         };
         (col.as_str(), dir)
     });
-    let key = dio_inner
+    let mut key = dio_inner
         .master
         .read()
         .unwrap()
         .index_key(&conditions, vista_sort);
+    key.push('\u{1}');
+    key.push_str(&super::helpers::op_conditions_key(&op_conditions));
     if !dio_inner.has_dio_augment() && dio_inner.lens.callbacks.on_list_page.is_none() {
         return;
     }

--- a/vantage-diorama/tests/dio_op_conditions.rs
+++ b/vantage-diorama/tests/dio_op_conditions.rs
@@ -1,0 +1,65 @@
+//! Local operator filters. A scenery `where_op(col, op, value)` narrows the
+//! visible set over the cache using a comparison operator (`!=`, `in`, …) — the
+//! fallback the Dio applies when the master vista can't push the operator into
+//! its query. The `MockShell` master here advertises no operator push-down
+//! (`can_filter_operators = false` by default), so every operator resolves
+//! locally, exactly like a REST/CSV-backed table.
+//!
+//! `teams_master`: rows a=red, b=blue, c=red on a native `team` column.
+
+mod support;
+
+use ciborium::Value as CborValue;
+use support::{MockView, eager_dio, teams_master};
+use vantage_diorama::Dio;
+use vantage_vista::FilterOp;
+
+#[tokio::test]
+async fn ne_filters_out_the_equal_rows() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    let view = MockView::open_with(&dio, 10, |b| b.where_op("team", FilterOp::Ne, "red")).await;
+    view.settle_until("only non-red rows", |v| v.row_count() == 1)
+        .await;
+
+    assert_eq!(
+        view.row_count(),
+        1,
+        "only the one blue row survives `!= red`"
+    );
+    assert_eq!(view.col_at(0, "team").as_deref(), Some("blue"));
+}
+
+#[tokio::test]
+async fn in_set_keeps_only_listed_values() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    let set = CborValue::Array(vec![CborValue::Text("blue".into())]);
+    let view =
+        MockView::open_with(&dio, 10, move |b| b.where_op("team", FilterOp::InSet, set)).await;
+    view.settle_until("only blue", |v| v.row_count() == 1).await;
+
+    assert_eq!(view.row_count(), 1);
+    assert_eq!(view.col_at(0, "team").as_deref(), Some("blue"));
+}
+
+#[tokio::test]
+async fn not_in_set_excludes_listed_values() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    let set = CborValue::Array(vec![CborValue::Text("red".into())]);
+    let view = MockView::open_with(&dio, 10, move |b| {
+        b.where_op("team", FilterOp::NotInSet, set)
+    })
+    .await;
+    view.settle_until("everything but red", |v| v.row_count() == 1)
+        .await;
+
+    assert_eq!(view.row_count(), 1, "both reds excluded, blue remains");
+    assert_eq!(view.col_at(0, "team").as_deref(), Some("blue"));
+}
+
+#[tokio::test]
+async fn no_op_condition_keeps_all_rows() {
+    let dio: Dio = eager_dio(teams_master()).await;
+    let view = MockView::open(&dio, 10).await;
+    view.settle_until("all rows", |v| v.row_count() == 3).await;
+    assert_eq!(view.row_count(), 3);
+}

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -156,6 +156,20 @@ impl MockView {
         Self { scenery }
     }
 
+    /// Open a view, customizing the scenery builder first — e.g. to add a
+    /// `where_op` operator filter or a `sort`.
+    pub async fn open_with(
+        dio: &Dio,
+        page_size: usize,
+        customize: impl FnOnce(
+            vantage_diorama::TableSceneryBuilder,
+        ) -> vantage_diorama::TableSceneryBuilder,
+    ) -> Self {
+        let builder = dio.table_scenery().page_size(page_size);
+        let scenery = customize(builder).open().await.expect("scenery opens");
+        Self { scenery }
+    }
+
     pub fn scenery(&self) -> &Arc<dyn TableScenery> {
         &self.scenery
     }

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.15 — 2026-07-23
+
+- `add_op_condition` pushes non-equality filters into the SQL query for all three
+  flavours (SQLite/Postgres/MySQL): `!=`, `<`, `<=`, `>`, `>=`, and `in` /
+  `not in` (via `in_list` / `not_in_list` over a `Value::Array` operand). The
+  factories advertise `can_filter_operators`.
+
 ## 0.6.14 — 2026-07-23
 
 - SQLite binds lower `Tag(8)` record references (`["table", id]` or

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -63,6 +63,7 @@ impl MysqlVistaFactory {
             table,
             VistaCapabilities {
                 can_count: true,
+                can_filter_operators: true,
                 can_insert: !read_only,
                 can_update: !read_only,
                 can_delete: !read_only,

--- a/vantage-sql/src/mysql/vista/source.rs
+++ b/vantage-sql/src/mysql/vista/source.rs
@@ -182,6 +182,54 @@ where
         Ok(())
     }
 
+    fn add_op_condition(
+        &mut self,
+        field: &str,
+        op: vantage_vista::FilterOp,
+        value: &CborValue,
+    ) -> Result<()> {
+        use vantage_vista::FilterOp;
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for condition", field = field))?
+            .clone();
+        match op {
+            FilterOp::InSet | FilterOp::NotInSet => {
+                let CborValue::Array(items) = value else {
+                    return Err(error!(
+                        "in_set/not_in_set requires an array value",
+                        field = field
+                    ));
+                };
+                let values: Vec<AnyMysqlType> = items
+                    .iter()
+                    .map(|v| AnyMysqlType::untyped(v.clone()))
+                    .collect();
+                let condition = match op {
+                    FilterOp::InSet => column.in_list(&values),
+                    _ => column.not_in_list(&values),
+                };
+                self.table.add_condition(condition);
+            }
+            _ => {
+                let sql_value = AnyMysqlType::untyped(value.clone());
+                let condition = match op {
+                    FilterOp::Eq => column.eq(sql_value),
+                    FilterOp::Ne => column.ne(sql_value),
+                    FilterOp::Gt => column.gt(sql_value),
+                    FilterOp::Gte => column.gte(sql_value),
+                    FilterOp::Lt => column.lt(sql_value),
+                    FilterOp::Lte => column.lte(sql_value),
+                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                };
+                self.table.add_condition(condition);
+            }
+        }
+        Ok(())
+    }
+
     fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
         let native_row = to_native_record(row);
         let target = self

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -64,6 +64,7 @@ impl PostgresVistaFactory {
             VistaCapabilities {
                 can_count: true,
                 can_order: true,
+                can_filter_operators: true,
                 can_insert: !read_only,
                 can_update: !read_only,
                 can_delete: !read_only,

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -203,6 +203,54 @@ where
         Ok(())
     }
 
+    fn add_op_condition(
+        &mut self,
+        field: &str,
+        op: vantage_vista::FilterOp,
+        value: &CborValue,
+    ) -> Result<()> {
+        use vantage_vista::FilterOp;
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for condition", field = field))?
+            .clone();
+        match op {
+            FilterOp::InSet | FilterOp::NotInSet => {
+                let CborValue::Array(items) = value else {
+                    return Err(error!(
+                        "in_set/not_in_set requires an array value",
+                        field = field
+                    ));
+                };
+                let values: Vec<AnyPostgresType> = items
+                    .iter()
+                    .map(|v| AnyPostgresType::untyped(v.clone()))
+                    .collect();
+                let condition = match op {
+                    FilterOp::InSet => column.in_list(&values),
+                    _ => column.not_in_list(&values),
+                };
+                self.table.add_condition(condition);
+            }
+            _ => {
+                let sql_value = AnyPostgresType::untyped(value.clone());
+                let condition = match op {
+                    FilterOp::Eq => column.eq(sql_value),
+                    FilterOp::Ne => column.ne(sql_value),
+                    FilterOp::Gt => column.gt(sql_value),
+                    FilterOp::Gte => column.gte(sql_value),
+                    FilterOp::Lt => column.lt(sql_value),
+                    FilterOp::Lte => column.lte(sql_value),
+                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                };
+                self.table.add_condition(condition);
+            }
+        }
+        Ok(())
+    }
+
     fn add_order(&mut self, field: &str, dir: SortDirection) -> Result<()> {
         if !self.table.columns().contains_key(field) {
             return Err(error!("Unknown column for add_order", field = field));

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -72,6 +72,7 @@ impl SqliteVistaFactory {
                 can_delete: !read_only,
                 can_order: true,
                 can_search: true,
+                can_filter_operators: true,
                 can_set_page_size: true,
                 can_fetch_page: true,
                 can_fetch_window: true,

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -202,6 +202,54 @@ where
         Ok(())
     }
 
+    fn add_op_condition(
+        &mut self,
+        field: &str,
+        op: vantage_vista::FilterOp,
+        value: &CborValue,
+    ) -> Result<()> {
+        use vantage_vista::FilterOp;
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for condition", field = field))?
+            .clone();
+        match op {
+            FilterOp::InSet | FilterOp::NotInSet => {
+                let CborValue::Array(items) = value else {
+                    return Err(error!(
+                        "in_set/not_in_set requires an array value",
+                        field = field
+                    ));
+                };
+                let values: Vec<AnySqliteType> = items
+                    .iter()
+                    .map(|v| AnySqliteType::untyped(v.clone()))
+                    .collect();
+                let condition = match op {
+                    FilterOp::InSet => column.in_list(&values),
+                    _ => column.not_in_list(&values),
+                };
+                self.table.add_condition(condition);
+            }
+            _ => {
+                let sql_value = AnySqliteType::untyped(value.clone());
+                let condition = match op {
+                    FilterOp::Eq => column.eq(sql_value),
+                    FilterOp::Ne => column.ne(sql_value),
+                    FilterOp::Gt => column.gt(sql_value),
+                    FilterOp::Gte => column.gte(sql_value),
+                    FilterOp::Lt => column.lt(sql_value),
+                    FilterOp::Lte => column.lte(sql_value),
+                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                };
+                self.table.add_condition(condition);
+            }
+        }
+        Ok(())
+    }
+
     fn add_order(&mut self, field: &str, dir: SortDirection) -> Result<()> {
         if !self.table.columns().contains_key(field) {
             return Err(error!("Unknown column for add_order", field = field));

--- a/vantage-sql/tests/sqlite/6_vista.rs
+++ b/vantage-sql/tests/sqlite/6_vista.rs
@@ -107,6 +107,58 @@ async fn vista_count_with_eq_condition() -> TestResult {
 }
 
 #[tokio::test]
+async fn vista_pushes_operator_conditions_server_side() -> TestResult {
+    use vantage_vista::FilterOp;
+
+    // products: a=Alpha/10/0, b=Beta/20/1, c=Gamma/30/0.
+    let db = setup().await;
+
+    // capability advertised
+    assert!(
+        db.vista_factory()
+            .from_table(product_table(db.clone()))?
+            .capabilities()
+            .can_filter_operators,
+        "sqlite advertises operator push-down"
+    );
+
+    // `!=` — price != 20 excludes Beta → a, c.
+    let mut vista = db.vista_factory().from_table(product_table(db.clone()))?;
+    vista.add_condition("price", FilterOp::Ne, CborValue::Integer(20i64.into()))?;
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("a") && rows.contains_key("c") && !rows.contains_key("b"));
+
+    // `>` — price > 15 → Beta, Gamma.
+    let mut vista = db.vista_factory().from_table(product_table(db.clone()))?;
+    vista.add_condition("price", FilterOp::Gt, CborValue::Integer(15i64.into()))?;
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("b") && rows.contains_key("c") && !rows.contains_key("a"));
+
+    // `in` — id in {a, c}.
+    let mut vista = db.vista_factory().from_table(product_table(db.clone()))?;
+    let set = CborValue::Array(vec![
+        CborValue::Text("a".into()),
+        CborValue::Text("c".into()),
+    ]);
+    vista.add_condition("id", FilterOp::InSet, set)?;
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("a") && rows.contains_key("c") && !rows.contains_key("b"));
+
+    // `not in` — id not in {b}.
+    let mut vista = db.vista_factory().from_table(product_table(db.clone()))?;
+    let set = CborValue::Array(vec![CborValue::Text("b".into())]);
+    vista.add_condition("id", FilterOp::NotInSet, set)?;
+    let rows = vista.list_values().await?;
+    assert_eq!(rows.len(), 2);
+    assert!(rows.contains_key("a") && rows.contains_key("c") && !rows.contains_key("b"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn vista_yaml_loads_table_and_columns() -> TestResult {
     let db = setup().await;
 

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.11 — 2026-07-23
+
+- `add_op_condition` pushes non-equality filters into the SurrealDB query: `!=`,
+  `<`, `<=`, `>`, `>=`, and `in` (`column.in_` over a `Value::Array` operand).
+  The factory advertises `can_filter_operators`. `not_in_set` has no builder form
+  yet and reports `Unimplemented`, so the caller filters it locally.
+
 ## 0.6.10 — 2026-07-23
 
 - `SurrealTableShell` implements `get_ref_target` — the bare, unconditioned

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.10"
+version = "0.6.11"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -83,6 +83,7 @@ impl SurrealVistaFactory {
                 can_subscribe: !read_only,
                 can_order: true,
                 can_search: true,
+                can_filter_operators: true,
                 can_set_page_size: true,
                 can_fetch_page: true,
                 can_fetch_next: true,

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -239,6 +239,54 @@ where
         Ok(())
     }
 
+    fn add_op_condition(
+        &mut self,
+        field: &str,
+        op: vantage_vista::FilterOp,
+        value: &CborValue,
+    ) -> Result<()> {
+        use vantage_vista::FilterOp;
+        let column = self
+            .table
+            .columns()
+            .get(field)
+            .ok_or_else(|| error!("Unknown column for condition", field = field))?
+            .clone();
+        // Same id-column coercion as `add_eq_condition`: a `table:key` /
+        // bare-key string compared against the id column becomes a Thing.
+        let id_field = self.metadata.id_column.as_deref().unwrap_or("id");
+        let surreal_value = match value {
+            CborValue::Text(s) if field == id_field => {
+                AnySurrealType::from(self.parse_id(s).to_cbor())
+            }
+            _ => AnySurrealType::from(value.clone()),
+        };
+        let condition = match op {
+            FilterOp::Eq => column.eq(surreal_value),
+            FilterOp::Ne => column.ne(surreal_value),
+            FilterOp::Gt => column.gt(surreal_value),
+            FilterOp::Gte => column.gte(surreal_value),
+            FilterOp::Lt => column.lt(surreal_value),
+            FilterOp::Lte => column.lte(surreal_value),
+            // `value` is a CBOR array → a SurrealDB array literal; `field IN [ … ]`.
+            FilterOp::InSet => column.in_(surreal_value),
+            // The SurrealDB expression builder has no `NOT IN` combinator yet.
+            // Report Unimplemented so the consumer filters locally (correct,
+            // just not pushed) rather than silently dropping the filter.
+            FilterOp::NotInSet => {
+                return Err(error!(
+                    "SurrealDB add_op_condition: NotInSet has no push-down; filter locally",
+                    method = "add_op_condition",
+                    source_type = std::any::type_name::<Self>()
+                )
+                .mark_unimplemented()
+                .traced());
+            }
+        };
+        self.table.add_condition(condition);
+        Ok(())
+    }
+
     /// Route a boxed driver-native condition onto the wrapped table. The boxed
     /// value must be a SurrealDB [`crate::Expr`] (`Expression<AnySurrealType>`,
     /// the table's `Condition` type) — the type a Rhai `with_condition(...)`

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.15 — 2026-07-23
+
+- `FilterOp` (`eq`/`ne`/`gt`/`gte`/`lt`/`lte`/`in_set`/`not_in_set`) plus
+  `Vista::add_condition(field, op, value)` and the `TableShell::add_op_condition`
+  hook — non-equality filters. The default impl routes `Eq` to `add_eq_condition`
+  and returns `Unimplemented` for the richer operators, so drivers opt in per
+  operator and callers fall back to local filtering otherwise. `in_set` /
+  `not_in_set` carry a `ciborium::Value::Array` operand.
+- `VistaCapabilities::can_filter_operators` — advertises whether a backend
+  pushes operator filters into its query (vs. equality-only, handled locally).
+
 ## 0.6.14 — 2026-07-21
 
 - `can_traverse_in_columns` — and the previously missing `can_fetch_window` —

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -27,6 +27,15 @@ pub struct VistaCapabilities {
     /// Server-side quicksearch via `add_search(text)`, OR'd across
     /// columns flagged `SEARCHABLE`.
     pub can_search: bool,
+    /// Server-side filtering by a comparison *operator* other than equality
+    /// via `add_op_condition(field, op, value)` (`!=`, `<`, `>=`, …).
+    /// Equality push-down (`add_eq_condition`) is assumed universal and is
+    /// NOT gated by this flag; only the richer operators are. Backends whose
+    /// query language expresses these operators (SQL, SurrealDB) advertise
+    /// `true`; those that can only match equality server-side (CSV, REST
+    /// `?key=value`, cmd) leave it `false`, and the consumer applies the
+    /// operator locally over the loaded rows.
+    pub can_filter_operators: bool,
     /// Consumer may pick the page size via `set_page_size(n)`. Some
     /// REST APIs return fixed-size pages and set this to `false`.
     pub can_set_page_size: bool,

--- a/vantage-vista/src/filter.rs
+++ b/vantage-vista/src/filter.rs
@@ -1,0 +1,84 @@
+//! Comparison operator for a filter condition at the `Vista` boundary.
+//!
+//! Equality has always had a dedicated channel
+//! ([`add_eq_condition`](crate::source::TableShell::add_eq_condition)); this
+//! enum carries the rest so a caller can request `field != value`,
+//! `field > value`, etc. through the general
+//! [`add_op_condition`](crate::source::TableShell::add_op_condition) method.
+//! Backends that can push the operator into their query advertise
+//! [`can_filter_operators`](crate::VistaCapabilities::can_filter_operators);
+//! others leave it `false` and the consumer filters locally.
+
+use serde::{Deserialize, Serialize};
+
+/// A comparison operator. The scalar operators mirror the query-builder
+/// vocabulary the SQL and SurrealDB expression layers already expose
+/// (`eq`/`ne`/`gt`/…); [`InSet`](FilterOp::InSet) / [`NotInSet`](FilterOp::NotInSet)
+/// test membership against a list and carry a [`ciborium::Value::Array`] operand
+/// rather than a scalar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterOp {
+    /// `field == value`
+    Eq,
+    /// `field != value`
+    Ne,
+    /// `field > value`
+    Gt,
+    /// `field >= value`
+    Gte,
+    /// `field < value`
+    Lt,
+    /// `field <= value`
+    Lte,
+    /// `field ∈ value` — `value` is an array; matches when the cell equals any
+    /// element.
+    InSet,
+    /// `field ∉ value` — `value` is an array; matches when the cell equals no
+    /// element.
+    NotInSet,
+}
+
+impl FilterOp {
+    /// Whether this operator's operand is a list (`InSet` / `NotInSet`) rather
+    /// than a scalar. Callers building the CBOR operand use this to know
+    /// whether to wrap the value in a [`ciborium::Value::Array`].
+    pub fn takes_set(&self) -> bool {
+        matches!(self, FilterOp::InSet | FilterOp::NotInSet)
+    }
+
+    /// Compact, stable symbol used when rendering the operator into a cache
+    /// key (see [`Vista::index_key`](crate::Vista::index_key)). Distinct
+    /// operators must produce distinct symbols so two filters that differ only
+    /// by operator can't collide onto the same cached index.
+    pub fn key_symbol(&self) -> &'static str {
+        match self {
+            FilterOp::Eq => "=",
+            FilterOp::Ne => "!=",
+            FilterOp::Gt => ">",
+            FilterOp::Gte => ">=",
+            FilterOp::Lt => "<",
+            FilterOp::Lte => "<=",
+            FilterOp::InSet => "in",
+            FilterOp::NotInSet => "!in",
+        }
+    }
+
+    /// Whether an `Ordering` of `value` relative to the operand satisfies this
+    /// operator. `Eq`/`Ne` are handled by the caller (they don't need a total
+    /// order); this covers the four ordered comparisons. `ordering` is
+    /// `cmp(cell, operand)`.
+    pub fn matches_ordering(&self, ordering: std::cmp::Ordering) -> bool {
+        use std::cmp::Ordering::{Equal, Greater, Less};
+        match self {
+            FilterOp::Gt => ordering == Greater,
+            FilterOp::Gte => ordering == Greater || ordering == Equal,
+            FilterOp::Lt => ordering == Less,
+            FilterOp::Lte => ordering == Less || ordering == Equal,
+            // Eq/Ne and the set operators don't use a total order; treat as
+            // non-matching here so a misuse fails closed rather than silently
+            // passing everything. Callers handle these operators directly.
+            FilterOp::Eq | FilterOp::Ne | FilterOp::InSet | FilterOp::NotInSet => false,
+        }
+    }
+}

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -5,6 +5,7 @@ pub mod capabilities;
 pub mod column;
 pub mod contained;
 pub mod factory;
+pub mod filter;
 pub mod flags;
 pub mod impls;
 pub mod insert;
@@ -25,6 +26,7 @@ pub use contained::{
     ContainedRefResolver, ContainedShell, ContainedWriteback, build_contained_vista,
 };
 pub use factory::VistaFactory;
+pub use filter::FilterOp;
 pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 #[cfg(feature = "rhai")]

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -227,6 +227,36 @@ pub trait TableShell: Send + Sync + 'static {
         .traced())
     }
 
+    /// Translate `field <op> value` into the driver's native condition and
+    /// apply it. The default routes `Eq` to [`add_eq_condition`](Self::add_eq_condition)
+    /// (so every driver gets equality for free) and returns `Unimplemented`
+    /// for every richer operator. Drivers whose query language expresses the
+    /// operators (SQL, SurrealDB) override this and advertise
+    /// [`can_filter_operators`](crate::VistaCapabilities::can_filter_operators);
+    /// consumers that see `false` skip the call and filter locally instead.
+    fn add_op_condition(
+        &mut self,
+        field: &str,
+        op: crate::FilterOp,
+        value: &CborValue,
+    ) -> Result<()> {
+        match op {
+            crate::FilterOp::Eq => self.add_eq_condition(field, value),
+            _ => Err(error!(
+                format!(
+                    "add_op_condition operator {:?} not implemented for '{}'",
+                    op,
+                    std::any::type_name::<Self>()
+                ),
+                method = "add_op_condition",
+                operator = format!("{:?}", op),
+                source_type = std::any::type_name::<Self>()
+            )
+            .mark_unimplemented()
+            .traced()),
+        }
+    }
+
     /// Push a driver-native condition into the wrapped table. The
     /// caller boxes the condition as `dyn Any` and the driver
     /// downcasts to its own `T::Condition`. Used by YAML-driven

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -117,6 +117,21 @@ impl Vista {
         self.source.add_eq_condition(&field.into(), &value)
     }
 
+    /// Narrow the vista to records matching `field <op> value`. Equality is
+    /// always supported; richer operators (`!=`, `<`, `>=`, …) require the
+    /// driver to advertise
+    /// [`can_filter_operators`](crate::VistaCapabilities::can_filter_operators)
+    /// — otherwise this returns an `Unimplemented` error and the caller should
+    /// filter locally.
+    pub fn add_condition(
+        &mut self,
+        field: impl Into<String>,
+        op: crate::FilterOp,
+        value: CborValue,
+    ) -> Result<()> {
+        self.source.add_op_condition(&field.into(), op, &value)
+    }
+
     /// Narrow to a single row by id.
     ///
     /// Convenience for the "I only know an id" workflow: pair with


### PR DESCRIPTION
## What

Two related scenery/query changes:

### 1. Filter conditions by comparison operator
Filtering was equality-only (`add_eq_condition`, the `Vec<(String, CborValue)>` tuple, `index_key`'s hardcoded `=`). This adds the full operator set and wires it end to end.

- **`vantage_vista::FilterOp`** — `Eq / Ne / Gt / Gte / Lt / Lte / InSet / NotInSet` (set ops carry a `ciborium::Value::Array` operand).
- **Server-side push-down** — `Vista::add_condition(field, op, value)` → new `TableShell::add_op_condition`. The default routes `Eq` to the existing eq path and returns `Unimplemented` for richer operators, so backends that can't push degrade gracefully.
  - **SurrealDB**: all scalar ops + `InSet` (`column.in_`). `NotInSet` has no builder combinator → `Unimplemented` (local fallback).
  - **SQL (sqlite/postgres/mysql)**: full set incl. `in_list` / `not_in_list`.
- **Capability gate** — `VistaCapabilities::can_filter_operators` (true for SQL + SurrealDB; default false, so REST/cmd/CSV keep filtering locally). The Dio facade passes the master's flag through.
- **Local fallback (diorama)** — a parallel `op_conditions` channel (`TableSceneryBuilder::where_op`), evaluated over the cache in `matches_op_conditions` (all operators incl. set membership), folded into the query-variant cache key so a filtered scenery gets its own ordered index. The equality path is untouched.

### 2. Sort empties last, regardless of direction
`cbor_cmp` treated `None` as "less than everything" and the whole comparison was `.reverse()`d for descending — so blanks sorted to the **top** in ascending. New shared `cmp_sort(a, b, dir)` pulls null-handling out of the direction reversal: empty values always sort last, and only the present-vs-present comparison follows asc/desc.

## Tests
- `vantage-sql` `vista_pushes_operator_conditions_server_side` — real in-memory sqlite: `ne`/`gt`/`in`/`not-in` reach the DB as WHERE clauses.
- `vantage-diorama` `dio_op_conditions` (4) — operators resolve locally when the backend can't push (MockShell = no push-down).
- `vantage-diorama` helpers unit tests — matcher semantics, cache-key isolation, and nulls-last sort.
- Full diorama suite green (no regressions in existing sort/condition tests).

## Notes
- SurrealDB `NotInSet` is local-only for now (no `NOT IN` builder form yet).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advanced filters, including inequality, range, and set-membership operators.
  * Filters are applied directly by supported database engines for improved query handling.
  * When unavailable server-side, advanced filters are applied locally without incorrect cache sharing.
  * Added capability reporting so applications can determine advanced-filter support.

* **Bug Fixes**
  * Improved filtered results and sorting for missing or empty values.
  * Added validation for unsupported operators and malformed set values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->