### PR TITLE
Draft-servo semantics, FlashRejection, servo-owned identity (diorama 0.8.0); Tag(12) datetime bridge (types 0.6.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5657,6 +5657,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "vantage-cmd",
  "vantage-core",
  "vantage-csv",
@@ -5858,8 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
+ "chrono",
  "ciborium",
  "csv",
  "indexmap",

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-diorama = { version = "0.7", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.8", path = "../vantage-diorama" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.8.0 — 2026-07-24
+
+Breaking: the servo becomes a **change draft**, structured save
+rejections, and servo-owned identity.
+
+- **Draft semantics** — `Servo::flash()` no longer settles the baseline
+  optimistically at fire time. Setpoints stay locked through the write
+  (status `Pending`); the bus task holds absorbs off while the servo's
+  own flash is in flight, so the optimistically staged cache value can't
+  masquerade as an upstream measurement and release the locks early. On
+  resolution the servo takes one deliberate measurement: a confirmed
+  write converges the draft clean (fields re-edited mid-save stay
+  locked); a rejected write restores the baseline while **keeping the
+  user's setpoints** — the draft survives a failed save, still dirty.
+- **`FlashRejection`** — a structured refusal (`message` + per-field
+  errors) that rides the `VantageError` source chain: an `on_flash`
+  route returns `FlashRejection::new(..).with_field(..).into_error()`,
+  and `ServoStatus::Failed` now carries the recovered rejection instead
+  of a bare `String` (breaking for matchers; unstructured failures
+  arrive message-only, so consumers handle exactly one shape).
+- **`IdStrategy` + `Dio::servo_new(strategy)`** (breaking signature) —
+  identity is the servo's, not the form's. `Uuid` (default) mints a
+  time-ordered UUID at creation and commands it into the id column, so
+  a retried create reuses the same id (a lost confirmation resolves as
+  a noop patch, never a duplicate). `Auto` runs the master's returning
+  insert inside `flash()` and binds the servo to the created row.
+  `FromRecord` keeps the previous behavior (id from the record's id
+  column at flash time).
+
 ## 0.7.4 — 2026-07-23
 
 - `TableSceneryBuilder::where_op(col, op, value)` and the `OpCondition` type —

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -26,6 +26,7 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 tracing = "0.1"
+uuid = { version = "1", features = ["v7"] }
 
 [features]
 # Rhai-scripted augmentation sources/fetches. Flips on `vantage-vista`'s rhai

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -24,7 +24,7 @@ use crate::scenery::record::spawn_record_scenery;
 use crate::scenery::{
     RecordScenery, RecordStatus, TableScenery, TableSceneryBuilder, ValueSceneryBuilder,
 };
-use crate::servo::{Servo, spawn_servo};
+use crate::servo::{IdStrategy, Servo, spawn_servo};
 
 use ciborium::Value as CborValue;
 use vantage_types::Record;
@@ -532,19 +532,19 @@ impl Dio {
     /// this Dio, keeping the write pipeline alive while a form is open.
     pub async fn servo(&self, id: impl Into<String>) -> Result<Servo> {
         let id = id.into();
-        let servo = spawn_servo(self, Some(id.clone()));
+        let servo = spawn_servo(self, Some(id.clone()), IdStrategy::FromRecord);
         if let Some(initial) = self.inner.cache.get_value(&id).await? {
             servo.absorb(Some(initial));
         }
         Ok(servo)
     }
 
-    /// Open a [`Servo`] for a record that does not exist yet. Command
-    /// its fields with [`set`](crate::servo::Servo::set) (including the
-    /// id column) and the first [`flash`](crate::servo::Servo::flash)
-    /// emits an insert.
-    pub fn servo_new(&self) -> Servo {
-        spawn_servo(self, None)
+    /// Open a [`Servo`] for a record that does not exist yet; the first
+    /// [`flash`](crate::servo::Servo::flash) emits an insert. Identity
+    /// follows `strategy`: minted UUID (v7) at creation, backend-assigned
+    /// on first save, or commanded through the record's id column.
+    pub fn servo_new(&self, strategy: IdStrategy) -> Servo {
+        spawn_servo(self, None, strategy)
     }
 
     /// Open a reactive view onto a single record with the row already

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -26,13 +26,13 @@ pub use lens::{
     DioTotalProviderCallback, Lens, LensBuilder, LensCallbacks, LensDefaults, MemoryCache,
     MemoryCacheTable, RedbCache, RedbCacheTable,
 };
-pub use ops::{ChangeEvent, ChangeFlash, FlashKind, QueryDescriptor};
+pub use ops::{ChangeEvent, ChangeFlash, FlashKind, FlashRejection, QueryDescriptor};
 pub use scenery::{
     Aggregate, CappedScenery, CustomAggregate, EnrichedRecord, OpCondition, RecordScenery,
     RecordStatus, RowStatus, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder,
     ValueScenery, ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
 };
-pub use servo::{Servo, ServoStatus};
+pub use servo::{IdStrategy, Servo, ServoStatus};
 pub use vantage_vista::VistaCapabilities;
 
 /// Common imports for working with vantage-diorama.
@@ -48,6 +48,6 @@ pub mod prelude {
     pub use crate::scenery::{
         EnrichedRecord, RecordScenery, RecordStatus, RowStatus, SortDir, TableScenery, ValueScenery,
     };
-    pub use crate::servo::{Servo, ServoStatus};
+    pub use crate::servo::{IdStrategy, Servo, ServoStatus};
     pub use vantage_vista_factory::VistaCatalog;
 }

--- a/vantage-diorama/src/ops/flash_rejection.rs
+++ b/vantage-diorama/src/ops/flash_rejection.rs
@@ -1,0 +1,138 @@
+//! `FlashRejection` — a structured refusal of a [`ChangeFlash`](crate::ChangeFlash).
+//!
+//! A write path that turns a flash down (an `on_flash` route running
+//! validation, a master mapping a constraint violation) can say *which
+//! fields* failed, not just that the write did. The rejection rides the
+//! [`VantageError`] source chain back through the pipeline; the servo
+//! extracts it with [`from_error`](FlashRejection::from_error) and
+//! carries it in [`ServoStatus::Failed`](crate::ServoStatus::Failed),
+//! where a form maps the entries onto its fields.
+//!
+//! A failure with no structure still becomes a rejection — message only,
+//! empty field list — so consumers handle exactly one shape.
+
+use std::fmt;
+
+use vantage_core::{Context as _, VantageError};
+
+/// A refused flash: an overall message plus zero or more
+/// `(field, message)` entries naming what failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlashRejection {
+    message: String,
+    field_errors: Vec<(String, String)>,
+}
+
+impl FlashRejection {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            field_errors: Vec::new(),
+        }
+    }
+
+    /// Name a failed field (builder, chainable).
+    pub fn with_field(mut self, field: impl Into<String>, message: impl Into<String>) -> Self {
+        self.field_errors.push((field.into(), message.into()));
+        self
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn field_errors(&self) -> &[(String, String)] {
+        &self.field_errors
+    }
+
+    /// The message for one field, when the rejection names it.
+    pub fn error_for(&self, field: &str) -> Option<&str> {
+        self.field_errors
+            .iter()
+            .find(|(f, _)| f == field)
+            .map(|(_, m)| m.as_str())
+    }
+
+    /// Wrap into a [`VantageError`] whose source chain carries `self` —
+    /// what an `on_flash` route returns to reject a flash with structure.
+    pub fn into_error(self) -> VantageError {
+        let message = self.message.clone();
+        Err::<(), _>(self)
+            .context(VantageError::other(message))
+            .unwrap_err()
+    }
+
+    /// Recover a rejection from an error's source chain. `None` when the
+    /// failure carried no structure.
+    pub fn from_error(err: &VantageError) -> Option<Self> {
+        let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+        while let Some(e) = cur {
+            if let Some(rejection) = e.downcast_ref::<FlashRejection>() {
+                return Some(rejection.clone());
+            }
+            cur = e.source();
+        }
+        None
+    }
+
+    /// Recover a rejection, falling back to a message-only one — the
+    /// single shape [`ServoStatus::Failed`](crate::ServoStatus::Failed)
+    /// carries.
+    pub fn from_error_or_message(err: &VantageError) -> Self {
+        Self::from_error(err).unwrap_or_else(|| Self::new(err.to_string()))
+    }
+}
+
+impl fmt::Display for FlashRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)?;
+        if !self.field_errors.is_empty() {
+            write!(f, " [")?;
+            for (i, (field, msg)) in self.field_errors.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{field}: {msg}")?;
+            }
+            write!(f, "]")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for FlashRejection {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_through_the_error_chain() {
+        let rejection = FlashRejection::new("validation failed")
+            .with_field("price", "must be positive")
+            .with_field("name", "required");
+        let err = rejection.clone().into_error();
+        assert_eq!(FlashRejection::from_error(&err), Some(rejection));
+    }
+
+    #[test]
+    fn survives_extra_wrapping() {
+        let inner = FlashRejection::new("nope")
+            .with_field("a", "bad")
+            .into_error();
+        let outer = Err::<(), _>(inner)
+            .context(vantage_core::error!("route rejected the flash"))
+            .unwrap_err();
+        let got = FlashRejection::from_error(&outer).expect("found through wrapping");
+        assert_eq!(got.error_for("a"), Some("bad"));
+    }
+
+    #[test]
+    fn unstructured_failure_becomes_message_only() {
+        let err = vantage_core::error!("disk on fire");
+        assert_eq!(FlashRejection::from_error(&err), None);
+        let fallback = FlashRejection::from_error_or_message(&err);
+        assert_eq!(fallback.message(), "disk on fire");
+        assert!(fallback.field_errors().is_empty());
+    }
+}

--- a/vantage-diorama/src/ops/mod.rs
+++ b/vantage-diorama/src/ops/mod.rs
@@ -1,7 +1,9 @@
 pub mod change_event;
 pub mod change_flash;
+pub mod flash_rejection;
 pub mod query_descriptor;
 
 pub use change_event::ChangeEvent;
 pub use change_flash::{ChangeFlash, FlashKind};
+pub use flash_rejection::FlashRejection;
 pub use query_descriptor::QueryDescriptor;

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -9,11 +9,22 @@
 //! clean. Touched fields lock and hold; upstream converging to the
 //! setpoint zeroes the error and releases the lock on its own.
 //!
-//! [`flash`](Servo::flash) is the actuation: it freezes the error signal
-//! at fire time into an immutable [`ChangeFlash`] carrying only the
-//! changed fields, emits it through the Dio's optimistic write path, and
-//! settles the servo clean. Later upstream changes or slow persistence
-//! never mutate an emitted flash.
+//! The servo is a **change draft**: the baseline moves only on measured
+//! upstream state, never on hope. [`flash`](Servo::flash) freezes the
+//! error signal at fire time into an immutable [`ChangeFlash`] carrying
+//! only the changed fields and emits it through the Dio's optimistic
+//! write path — but the setpoints stay locked until the write resolves.
+//! Confirmation absorbs the confirmed record and convergence releases
+//! every lock; rejection absorbs the restored pre-image and the
+//! setpoints still stand — the user's draft survives a failed save,
+//! reported through [`ServoStatus::Failed`] as a [`FlashRejection`]
+//! (with per-field errors when the write path named them).
+//!
+//! Identity is the servo's, not the form's: [`Dio::servo_new`] mints a
+//! time-ordered UUID up front (or defers to the backend with
+//! [`IdStrategy::Auto`]), so a retried create reuses the same id — if
+//! the first insert actually landed, the retry patches over it as a
+//! noop instead of duplicating the record.
 //!
 //! A servo holds a **strong** Dio handle — deliberately, unlike
 //! sceneries: while a form is open, the write pipeline it will flash
@@ -30,7 +41,7 @@ use vantage_core::Result;
 use vantage_types::Record;
 
 use crate::dio::{Dio, DioEvent, DioInner, Generation, cbor_scalar_string};
-use crate::ops::{ChangeFlash, FlashKind};
+use crate::ops::{ChangeFlash, FlashKind, FlashRejection};
 
 /// Where the servo loop currently stands.
 #[derive(Debug, Clone)]
@@ -39,17 +50,41 @@ pub enum ServoStatus {
     Tracking,
     /// A flash was emitted and its write-through hasn't confirmed yet.
     Pending,
-    /// The last flash was rejected and rolled back.
-    Failed(String),
+    /// The last flash was rejected and rolled back. The setpoints are
+    /// still held — the draft survives; the rejection carries per-field
+    /// errors when the write path named them.
+    Failed(FlashRejection),
+}
+
+/// How an unsaved servo ([`Dio::servo_new`]) gets its identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IdStrategy {
+    /// Mint a time-ordered UUID (v7) the moment the servo opens and
+    /// command it into the id column — every save reuses it, so a
+    /// retried create can't duplicate the record.
+    #[default]
+    Uuid,
+    /// The backend assigns the id on the first save (returning insert);
+    /// the servo binds to the created row.
+    Auto,
+    /// The id comes from the record's id column at flash time — the
+    /// caller commands it like any other field.
+    FromRecord,
 }
 
 pub(crate) struct ServoState {
     /// Live-instance census (see [`crate::stats`]).
     _tally: crate::stats::Tally,
     id: RwLock<Option<String>>,
+    strategy: IdStrategy,
     baseline: RwLock<Option<Record<CborValue>>>,
     data: RwLock<Record<CborValue>>,
     status: RwLock<ServoStatus>,
+    /// Non-zero while this servo's own flash is in flight. The bus task
+    /// holds absorbs off for the window so the optimistic stage of our
+    /// own write can't masquerade as an upstream measurement and release
+    /// the locks before the write actually resolves.
+    in_flight: AtomicU64,
     generation: AtomicU64,
     generation_tx: watch::Sender<Generation>,
 }
@@ -96,8 +131,9 @@ impl Drop for ServoGuard {
 }
 
 impl Servo {
-    /// The record id this servo is bound to. `None` until an unsaved
-    /// [`Dio::servo_new`](crate::Dio::servo_new) fires its first flash.
+    /// The record id this servo is bound to. Bound at creation for
+    /// [`Dio::servo`](crate::Dio::servo) and [`IdStrategy::Uuid`];
+    /// `None` until the first confirmed save for [`IdStrategy::Auto`].
     pub fn id(&self) -> Option<String> {
         self.state.id.read().unwrap().clone()
     }
@@ -196,20 +232,23 @@ impl Servo {
     /// the error is zero — nothing dirty, nothing fired.
     ///
     /// The diff is taken synchronously at the moment of the call; the
-    /// emitted flash never changes afterwards, no matter how long
-    /// persistence takes or what arrives upstream meanwhile. The servo
-    /// itself settles clean immediately (the staged value becomes the
-    /// new baseline) and reports [`Pending`](ServoStatus::Pending) until
-    /// the write-through confirms.
+    /// emitted flash never changes afterwards. The servo stays a
+    /// **draft** for the whole write: setpoints hold locked and the
+    /// status reports [`Pending`](ServoStatus::Pending). Confirmation
+    /// absorbs the confirmed record — convergence zeroes the error and
+    /// releases every lock. Rejection absorbs the restored pre-image
+    /// and the setpoints still stand: the user's values survive, dirty,
+    /// with the failure in [`Failed`](ServoStatus::Failed).
     ///
-    /// On a servo without a baseline (opened via
-    /// [`Dio::servo_new`](crate::Dio::servo_new), or on a row that
-    /// vanished) the flash is an insert of the full record; the id comes
-    /// from the servo's binding or the record's id column.
+    /// On a servo without a baseline the flash is an insert of the full
+    /// record; the id comes from the servo's binding (minted at
+    /// creation for [`IdStrategy::Uuid`]), from the record's id column
+    /// ([`IdStrategy::FromRecord`]), or from the backend via a
+    /// returning insert ([`IdStrategy::Auto`]).
     pub async fn flash(&self) -> Result<Option<ChangeFlash>> {
         // Freeze synchronously: everything the flash carries is decided
         // before the first await point.
-        let flash = {
+        let frozen = {
             let baseline = self.state.baseline.read().unwrap();
             let data = self.state.data.read().unwrap();
             match baseline.as_ref() {
@@ -225,41 +264,100 @@ impl Servo {
                         .unwrap()
                         .clone()
                         .expect("a servo with a baseline is bound to an id");
-                    ChangeFlash::new(FlashKind::Patch, Some(id), error).with_before(base.clone())
+                    Some(
+                        ChangeFlash::new(FlashKind::Patch, Some(id), error)
+                            .with_before(base.clone()),
+                    )
                 }
                 None => {
                     if data.is_empty() {
                         return Ok(None);
                     }
-                    let id = match self.state.id.read().unwrap().clone() {
-                        Some(id) => id,
-                        None => self.id_from_record(&data)?,
-                    };
-                    ChangeFlash::insert(id, data.clone())
+                    match self.state.id.read().unwrap().clone() {
+                        Some(id) => Some(ChangeFlash::insert(id, data.clone())),
+                        None => match self.state.strategy {
+                            // No id exists until the backend assigns one.
+                            IdStrategy::Auto => None,
+                            _ => Some(ChangeFlash::insert(
+                                self.id_from_record(&data)?,
+                                data.clone(),
+                            )),
+                        },
+                    }
                 }
             }
         };
 
-        // Settle clean-and-pending locally: the emitted state is the new
-        // baseline. The optimistic stage makes the cache agree in a moment.
-        let after = flash.after().expect("insert/patch always has an after");
+        let Some(flash) = frozen else {
+            return self.flash_auto_insert().await.map(Some);
+        };
+
+        // Draft semantics: bind identity and report Pending, but neither
+        // the baseline nor the setpoints move until the write resolves.
         {
             *self.state.id.write().unwrap() = flash.id().map(str::to_string);
-            *self.state.baseline.write().unwrap() = Some(after.clone());
-            *self.state.data.write().unwrap() = after;
             *self.state.status.write().unwrap() = ServoStatus::Pending;
         }
+        self.state.in_flight.fetch_add(1, Ordering::SeqCst);
         self.state.bump_generation();
 
-        match self.dio.flash(flash.clone()).await {
+        let outcome = self.dio.flash(flash.clone()).await;
+        self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+        // One deliberate measurement now that the write resolved: the
+        // confirmed value on success (convergence releases every lock),
+        // the restored pre-image on failure (setpoints still held — the
+        // draft survives).
+        self.absorb_now().await;
+        match outcome {
             Ok(()) => {
                 self.state.set_status(ServoStatus::Tracking);
                 Ok(Some(flash))
             }
             Err(e) => {
-                // The rollback restored the cache pre-image; the bus task
-                // absorbs it. Report the failure — never silently.
-                self.state.set_status(ServoStatus::Failed(e.to_string()));
+                self.state
+                    .set_status(ServoStatus::Failed(FlashRejection::from_error_or_message(
+                        &e,
+                    )));
+                Err(e)
+            }
+        }
+    }
+
+    /// The [`IdStrategy::Auto`] insert: no id exists until the master
+    /// returns one, so this runs the master's returning insert directly
+    /// (there is no row id to stage optimistically under), seeds the
+    /// cache with the created row, and binds the servo to it.
+    async fn flash_auto_insert(&self) -> Result<ChangeFlash> {
+        use vantage_dataset::traits::InsertableValueSet as _;
+
+        let record = self.state.data.read().unwrap().clone();
+        *self.state.status.write().unwrap() = ServoStatus::Pending;
+        self.state.in_flight.fetch_add(1, Ordering::SeqCst);
+        self.state.bump_generation();
+
+        let master = self.dio.master();
+        let outcome = async {
+            let id = master.insert_return_id_value(&record).await?;
+            let id_column = master.get_id_column().unwrap_or("id").to_string();
+            let mut with_id = record.clone();
+            with_id.insert(id_column, CborValue::Text(id.clone()));
+            self.dio.patched(id.clone(), with_id.clone()).await?;
+            Ok::<_, vantage_core::VantageError>((id, with_id))
+        }
+        .await;
+        self.state.in_flight.fetch_sub(1, Ordering::SeqCst);
+        match outcome {
+            Ok((id, with_id)) => {
+                *self.state.id.write().unwrap() = Some(id.clone());
+                self.absorb_now().await;
+                self.state.set_status(ServoStatus::Tracking);
+                Ok(ChangeFlash::insert(id, with_id))
+            }
+            Err(e) => {
+                self.state
+                    .set_status(ServoStatus::Failed(FlashRejection::from_error_or_message(
+                        &e,
+                    )));
                 Err(e)
             }
         }
@@ -295,6 +393,19 @@ impl Servo {
         self.state.absorb(incoming);
     }
 
+    /// Take a measurement from the cache right now — the deliberate
+    /// post-resolution read `flash` performs (the bus task holds
+    /// absorbs off while our own write is in flight).
+    async fn absorb_now(&self) {
+        let Some(id) = self.state.id.read().unwrap().clone() else {
+            return;
+        };
+        match self.dio.inner.cache.get_value(&id).await {
+            Ok(value) => self.state.absorb(value),
+            Err(e) => tracing::error!(error = %e, "servo measurement read failed"),
+        }
+    }
+
     /// Resolve an insert id from the record's id column.
     fn id_from_record(&self, data: &Record<CborValue>) -> Result<String> {
         let id_column = self
@@ -317,7 +428,10 @@ impl Servo {
 }
 
 /// The bus-tracking loop: every event about the bound record feeds the
-/// measurement side of the loop from the cache.
+/// measurement side of the loop from the cache. While this servo's own
+/// flash is in flight, everything is held off — `flash` takes its own
+/// measurement on resolution, so the optimistic stage of our own write
+/// never reads as upstream truth.
 async fn track_loop(
     state: Arc<ServoState>,
     dio_weak: Weak<DioInner>,
@@ -327,19 +441,33 @@ async fn track_loop(
         if dio_weak.upgrade().is_none() {
             return;
         }
+        let event = match bus.recv().await {
+            Ok(event) => event,
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                // Missed events: re-measure from the cache.
+                if state.in_flight.load(Ordering::SeqCst) == 0 {
+                    absorb_from_cache(&state, &dio_weak).await;
+                }
+                continue;
+            }
+            Err(broadcast::error::RecvError::Closed) => return,
+        };
+        if state.in_flight.load(Ordering::SeqCst) > 0 {
+            continue;
+        }
         let bound = |id: &str| state.id.read().unwrap().as_deref() == Some(id);
-        match bus.recv().await {
-            Ok(DioEvent::RecordChanged { id })
-            | Ok(DioEvent::RecordInserted { id })
-            | Ok(DioEvent::RecordRemoved { id })
+        match event {
+            DioEvent::RecordChanged { id }
+            | DioEvent::RecordInserted { id }
+            | DioEvent::RecordRemoved { id }
                 if bound(&id) =>
             {
                 absorb_from_cache(&state, &dio_weak).await;
             }
-            Ok(DioEvent::DatasetChanged) => {
+            DioEvent::DatasetChanged => {
                 absorb_from_cache(&state, &dio_weak).await;
             }
-            Ok(DioEvent::WritePending { id, kind }) if bound(&id) => {
+            DioEvent::WritePending { id, kind } if bound(&id) => {
                 // Same filter as the revert arm: someone else's staged
                 // delete is not this servo's write in flight.
                 if matches!(
@@ -349,7 +477,7 @@ async fn track_loop(
                     state.set_status(ServoStatus::Pending);
                 }
             }
-            Ok(DioEvent::WriteReverted { id, error, kind }) if bound(&id) => {
+            DioEvent::WriteReverted { id, error, kind } if bound(&id) => {
                 // Only editing kinds are this servo's failure — a reverted
                 // Delete/Clear belongs to its issuer (the confirm dialog),
                 // and a form displaying the record must not adopt it as a
@@ -358,16 +486,11 @@ async fn track_loop(
                     kind,
                     crate::FlashKind::Patch | crate::FlashKind::Replace | crate::FlashKind::Insert
                 ) {
-                    state.set_status(ServoStatus::Failed(error));
+                    state.set_status(ServoStatus::Failed(FlashRejection::new(error)));
                 }
                 absorb_from_cache(&state, &dio_weak).await;
             }
-            Ok(_) => {}
-            Err(broadcast::error::RecvError::Lagged(_)) => {
-                // Missed events: re-measure from the cache.
-                absorb_from_cache(&state, &dio_weak).await;
-            }
-            Err(broadcast::error::RecvError::Closed) => return,
+            _ => {}
         }
     }
 }
@@ -387,15 +510,28 @@ async fn absorb_from_cache(state: &Arc<ServoState>, dio_weak: &Weak<DioInner>) {
 
 /// Internal constructor — wires the bus task and returns the servo.
 /// Used by [`Dio::servo`](crate::Dio::servo) and
-/// [`Dio::servo_new`](crate::Dio::servo_new).
-pub(crate) fn spawn_servo(dio: &Dio, id: Option<String>) -> Servo {
+/// [`Dio::servo_new`](crate::Dio::servo_new). With [`IdStrategy::Uuid`]
+/// and no id, identity is minted here — before the first save — and
+/// commanded into the id column so the insert record carries it.
+pub(crate) fn spawn_servo(dio: &Dio, id: Option<String>, strategy: IdStrategy) -> Servo {
+    let mut id = id;
+    let mut data = Record::new();
+    if id.is_none() && strategy == IdStrategy::Uuid {
+        let minted = uuid::Uuid::now_v7().to_string();
+        let id_column = dio.master().get_id_column().unwrap_or("id").to_string();
+        data.insert(id_column, CborValue::Text(minted.clone()));
+        id = Some(minted);
+    }
+
     let (generation_tx, _rx) = watch::channel(Generation::default());
     let state = Arc::new(ServoState {
         _tally: crate::stats::Tally::servo(),
         id: RwLock::new(id),
+        strategy,
         baseline: RwLock::new(None),
-        data: RwLock::new(Record::new()),
+        data: RwLock::new(data),
         status: RwLock::new(ServoStatus::Tracking),
+        in_flight: AtomicU64::new(0),
         generation: AtomicU64::new(0),
         generation_tx,
     });

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use ciborium::Value as CborValue;
 use vantage_core::Result;
 use vantage_dataset::traits::ReadableValueSet;
-use vantage_diorama::{Dio, FlashKind, Generation, Lens, ServoStatus};
+use vantage_diorama::{Dio, FlashKind, FlashRejection, Generation, IdStrategy, Lens, ServoStatus};
 use vantage_types::Record;
 use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
 
@@ -299,7 +299,7 @@ async fn a_fired_flash_is_frozen_against_later_edits() -> Result<()> {
 async fn servo_new_flashes_an_insert() -> Result<()> {
     let shell = product_shell();
     let dio = dio_over(&shell).await?;
-    let servo = dio.servo_new();
+    let servo = dio.servo_new(IdStrategy::FromRecord);
 
     servo.set("id", text("p2"));
     servo.set("name", text("Croissant"));
@@ -354,21 +354,263 @@ async fn rejected_flash_reverts_and_reports_failed() -> Result<()> {
         dio.cache().insert_value(&id, &r).await?;
     }
     let servo = dio.servo("p1").await?;
-    let mut gen_rx = servo.subscribe();
 
     servo.set("name", text("Tea"));
-    let g = u64::from(*gen_rx.borrow_and_update());
     let result = servo.flash().await;
     assert!(result.is_err(), "the rejection surfaces to the caller");
 
-    // The optimistic stage was rolled back; the servo re-absorbs the
-    // restored pre-image and reports the failure.
-    wait_for_gen(&mut gen_rx, g).await;
+    // The optimistic stage was rolled back and the pre-image absorbed —
+    // but the servo is a draft: the setpoint survives the failure.
     assert!(matches!(servo.status(), ServoStatus::Failed(_)));
     assert_eq!(
         dio.cache().get_value("p1").await?.unwrap().get("name"),
         Some(&text("Coffee")),
         "cache pre-image restored"
+    );
+    assert_eq!(
+        servo.get("name"),
+        Some(text("Tea")),
+        "the user's value survives the rejection"
+    );
+    assert!(servo.dirty("name"), "and still reads dirty");
+    assert_eq!(
+        servo.baseline().unwrap().get("name"),
+        Some(&text("Coffee")),
+        "baseline is the restored measurement"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn draft_holds_through_pending() -> Result<()> {
+    // While the write-through is in flight the servo must stay a draft:
+    // setpoints locked, baseline unmoved, status Pending — the staged
+    // optimistic cache value must not read as an upstream measurement.
+    let shell = product_shell();
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let release = gate.clone();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(move |_dio, _flash| {
+                let gate = gate.clone();
+                async move {
+                    gate.notified().await;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(product_vista(&shell)).await?;
+    for (id, r) in dio.master().list_values().await? {
+        dio.cache().insert_value(&id, &r).await?;
+    }
+    let servo = Arc::new(dio.servo("p1").await?);
+
+    servo.set("name", text("Tea"));
+    let in_flight = {
+        let servo = servo.clone();
+        tokio::spawn(async move { servo.flash().await })
+    };
+    // Give the flash time to stage and block on the gate.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert!(matches!(servo.status(), ServoStatus::Pending));
+    assert_eq!(servo.get("name"), Some(text("Tea")), "setpoint locked");
+    assert!(servo.dirty("name"), "still dirty while pending");
+    assert_eq!(
+        servo.baseline().unwrap().get("name"),
+        Some(&text("Coffee")),
+        "baseline hasn't moved on hope"
+    );
+
+    release.notify_one();
+    in_flight.await.expect("join")?;
+
+    assert!(!servo.is_dirty(), "confirmation converged the draft clean");
+    assert!(matches!(servo.status(), ServoStatus::Tracking));
+    Ok(())
+}
+
+#[tokio::test]
+async fn failed_save_retries_successfully() -> Result<()> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let shell = product_shell();
+    let reject = Arc::new(AtomicBool::new(true));
+    let reject_flag = reject.clone();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(move |dio, flash| {
+                let reject = reject_flag.clone();
+                let master = dio.master();
+                async move {
+                    if reject.load(Ordering::SeqCst) {
+                        return Err(vantage_core::error!("route rejected the flash"));
+                    }
+                    flash
+                        .active_record(master.as_ref())?
+                        .save()
+                        .await
+                        .map(|_| ())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(product_vista(&shell)).await?;
+    for (id, r) in dio.master().list_values().await? {
+        dio.cache().insert_value(&id, &r).await?;
+    }
+    let servo = dio.servo("p1").await?;
+
+    servo.set("name", text("Tea"));
+    assert!(servo.flash().await.is_err());
+    assert!(servo.dirty("name"), "draft survives the first failure");
+
+    reject.store(false, Ordering::SeqCst);
+    let flash = servo.flash().await?.expect("retry fires the held draft");
+    assert_eq!(flash.patch().get("name"), Some(&text("Tea")));
+    assert!(!servo.is_dirty(), "retry landed and converged clean");
+    assert!(matches!(servo.status(), ServoStatus::Tracking));
+    Ok(())
+}
+
+#[tokio::test]
+async fn uuid_strategy_mints_identity_up_front() -> Result<()> {
+    let shell = product_shell();
+    let dio = dio_over(&shell).await?;
+    let servo = dio.servo_new(IdStrategy::Uuid);
+
+    let id = servo.id().expect("identity exists before the first save");
+    assert_eq!(
+        servo.get("id"),
+        Some(text(&id)),
+        "the minted id is commanded into the id column"
+    );
+
+    servo.set("name", text("Croissant"));
+    let first = servo.flash().await?.expect("insert fires");
+    assert_eq!(first.kind(), &FlashKind::Insert);
+    assert_eq!(first.id(), Some(id.as_str()));
+
+    // Continue editing the created record: same id, now a patch.
+    servo.set("price", int(4));
+    let second = servo.flash().await?.expect("follow-up fires");
+    assert_eq!(second.kind(), &FlashKind::Patch, "no duplicate insert");
+    assert_eq!(second.id(), Some(id.as_str()));
+    assert_eq!(
+        dio.master().get_value(&id).await?.unwrap().get("price"),
+        Some(&int(4)),
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn uuid_create_retry_reuses_the_id() -> Result<()> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let shell = product_shell();
+    let reject = Arc::new(AtomicBool::new(true));
+    let reject_flag = reject.clone();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(move |dio, flash| {
+                let reject = reject_flag.clone();
+                let master = dio.master();
+                async move {
+                    if reject.load(Ordering::SeqCst) {
+                        return Err(vantage_core::error!("route rejected the flash"));
+                    }
+                    flash
+                        .active_record(master.as_ref())?
+                        .save()
+                        .await
+                        .map(|_| ())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(product_vista(&shell)).await?;
+    let servo = dio.servo_new(IdStrategy::Uuid);
+    let id = servo.id().expect("minted at creation");
+
+    servo.set("name", text("Croissant"));
+    assert!(servo.flash().await.is_err(), "first create rejected");
+    assert_eq!(servo.id().as_deref(), Some(id.as_str()), "id unchanged");
+    assert!(servo.baseline().is_none(), "still a draft of a new record");
+
+    reject.store(false, Ordering::SeqCst);
+    let flash = servo.flash().await?.expect("retry fires");
+    assert_eq!(flash.kind(), &FlashKind::Insert);
+    assert_eq!(flash.id(), Some(id.as_str()), "same identity — idempotent");
+    Ok(())
+}
+
+#[tokio::test]
+async fn auto_strategy_binds_the_backend_id() -> Result<()> {
+    let shell = product_shell();
+    let dio = dio_over(&shell).await?;
+    let servo = dio.servo_new(IdStrategy::Auto);
+
+    assert!(
+        servo.id().is_none(),
+        "no identity until the backend assigns"
+    );
+    servo.set("name", text("Croissant"));
+    let flash = servo.flash().await?.expect("returning insert fires");
+
+    let id = servo.id().expect("bound to the created row");
+    assert_eq!(flash.id(), Some(id.as_str()));
+    assert!(
+        dio.cache().get_value(&id).await?.is_some(),
+        "cache seeded with the created row"
+    );
+    assert!(!servo.is_dirty(), "converged clean on the created row");
+
+    // Further edits patch the same id.
+    servo.set("price", int(2));
+    let second = servo.flash().await?.expect("follow-up fires");
+    assert_eq!(second.kind(), &FlashKind::Patch);
+    assert_eq!(second.id(), Some(id.as_str()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejection_field_errors_reach_the_status() -> Result<()> {
+    let shell = product_shell();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(|_dio, _flash| async move {
+                Err(FlashRejection::new("validation failed")
+                    .with_field("price", "must be positive")
+                    .into_error())
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(product_vista(&shell)).await?;
+    for (id, r) in dio.master().list_values().await? {
+        dio.cache().insert_value(&id, &r).await?;
+    }
+    let servo = dio.servo("p1").await?;
+
+    servo.set("price", int(-5));
+    assert!(servo.flash().await.is_err());
+
+    let ServoStatus::Failed(rejection) = servo.status() else {
+        panic!("expected Failed, got {:?}", servo.status());
+    };
+    assert_eq!(rejection.message(), "validation failed");
+    assert_eq!(rejection.error_for("price"), Some("must be positive"));
+    assert!(
+        servo.dirty("price"),
+        "the named field still holds its draft"
     );
     Ok(())
 }

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.8 — 2026-07-24
+
+- Track vantage-diorama 0.8 (draft-servo release). No behavior changes.
+
 ## 0.6.7 — 2026-07-23
 
 - `FolderListingShell` implements `get_ref_target` for the `subdir` relation —

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2029,6 +2029,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "vantage-core",
  "vantage-dataset",
  "vantage-table",
@@ -2052,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2097,8 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
+ "chrono",
  "ciborium",
  "indexmap",
  "paste",
@@ -2119,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.14"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.7", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.8", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"

--- a/vantage-faker/src/live_folder/listing_shell.rs
+++ b/vantage-faker/src/live_folder/listing_shell.rs
@@ -224,7 +224,10 @@ impl TableShell for FolderListingShell {
         // at this shell's own path — every subdirectory that could be picked.
         Ok(Vista::new(
             "live-folder-listing",
-            Box::new(FolderListingShell::new(self.inner.clone(), self.path.clone())),
+            Box::new(FolderListingShell::new(
+                self.inner.clone(),
+                self.path.clone(),
+            )),
         ))
     }
 

--- a/vantage-types/CHANGELOG.md
+++ b/vantage-types/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.5 — 2026-07-24
+
+- SurrealDB epoch-pair datetimes (`Tag(12, [seconds, nanos])`) join the
+  CBOR↔JSON bridge: `PresentationDialect` renders them as a lossless
+  nanosecond RFC-3339 string, and `json_to_cbor_with_hint` re-encodes an
+  (edited) string back to the same tag — an untouched field reproduces
+  identical bytes, killing the phantom "unsaved change" for datetime
+  columns. The conversions are exported (`tag12_to_rfc3339` /
+  `rfc3339_to_tag12`) so UI crates stop carrying their own copies.
+  Adds a no-default-features `chrono` dependency behind the `serde`
+  feature.
+
 ## 0.6.4 — 2026-07-23
 
 - `json_to_cbor_with_hint(value, hint)` — a hint-aware inverse of the

--- a/vantage-types/Cargo.toml
+++ b/vantage-types/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vantage-types"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Type system and Record types for the Vantage data framework"
 repository = "https://github.com/romaninsh/vantage"
 
 [features]
-serde = ["dep:serde", "dep:serde_json", "vantage-types-entity/serde"]
+serde = ["dep:serde", "dep:serde_json", "dep:chrono", "vantage-types-entity/serde"]
 
 
 
@@ -17,6 +17,7 @@ vantage-types-entity = { version = "0.6", path = "./entity" }
 indexmap = "2.14"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0.149", optional = true }
+chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 ciborium = { version = "0.2", features = ["std"] }
 vantage-core = { version = "0.6", path = "../vantage-core" }
 

--- a/vantage-types/src/cbor_json.rs
+++ b/vantage-types/src/cbor_json.rs
@@ -103,6 +103,13 @@ impl CborDialect for PresentationDialect {
             // RFC 3339 datetime (0), UUID (9), Decimal (10), Duration (13)
             // — all carry their displayable form as the inner text.
             (0 | 9 | 10 | 13, CborValue::Text(s)) => JsonValue::String(s),
+            // SurrealDB datetime — `Tag(12, [seconds, nanos])`. Render as a
+            // lossless nanosecond RFC-3339 string; `json_to_cbor_with_hint`
+            // re-encodes it back to the same tag. Off-shape inners fall back
+            // to the plain rendering.
+            (12, inner) => tag12_to_rfc3339(&inner)
+                .map(JsonValue::String)
+                .unwrap_or_else(|| cbor_to_json(self, inner)),
             // UUID carried as raw bytes.
             (37, CborValue::Bytes(b)) => JsonValue::String(hex_encode(&b)),
             // Anything else: drop the tag, render the payload.
@@ -232,6 +239,12 @@ pub fn json_to_cbor_with_hint(value: &JsonValue, hint: Option<&CborValue>) -> Cb
     match (value, hint) {
         // Record id: restore Tag(8) from its "table:id" presentation form.
         (JsonValue::String(s), Some(CborValue::Tag(8, inner))) => retag_record_id(s, inner),
+        // Epoch-pair datetime: re-encode the (edited) RFC-3339 string back
+        // into `Tag(12, [seconds, nanos])`. An unparseable edit stays text —
+        // the write path surfaces the type error rather than guessing.
+        (JsonValue::String(s), Some(CborValue::Tag(12, _))) => {
+            rfc3339_to_tag12(s).unwrap_or_else(|| CborValue::Text(s.clone()))
+        }
         // Datetime / uuid / decimal / duration — the form edits the inner
         // text; re-wrap it in the same tag so it round-trips.
         (JsonValue::String(s), Some(CborValue::Tag(tag, inner)))
@@ -298,6 +311,47 @@ fn retag_record_id(s: &str, inner: &CborValue) -> CborValue {
         }
         // Tag(8, Text("table:id")) — a single-text id form.
         _ => tag8(CborValue::Text(s.to_string())),
+    }
+}
+
+/// Render SurrealDB's epoch-pair datetime — `Tag(12, [seconds, nanos])`
+/// carries its payload as integers, not text — as a lossless RFC-3339
+/// string (nanosecond fraction preserved, UTC). `None` when the inner
+/// shape isn't the epoch pair.
+pub fn tag12_to_rfc3339(inner: &CborValue) -> Option<String> {
+    use chrono::{SecondsFormat, TimeZone as _};
+    let CborValue::Array(arr) = inner else {
+        return None;
+    };
+    let secs = cbor_i64(arr.first()?)?;
+    let nanos = arr.get(1).and_then(cbor_i64).unwrap_or(0);
+    let dt = chrono::Utc
+        .timestamp_opt(secs, nanos.try_into().ok()?)
+        .single()?;
+    Some(dt.to_rfc3339_opts(SecondsFormat::Nanos, true))
+}
+
+/// Inverse of [`tag12_to_rfc3339`]: parse an (edited) RFC-3339 string back
+/// into `Tag(12, [seconds, nanos])`, preserving the nanosecond fraction.
+/// `None` when the string isn't RFC-3339 (the caller keeps it as `Text`).
+pub fn rfc3339_to_tag12(s: &str) -> Option<CborValue> {
+    let dt = chrono::DateTime::parse_from_rfc3339(s)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    Some(CborValue::Tag(
+        12,
+        Box::new(CborValue::Array(vec![
+            CborValue::Integer(dt.timestamp().into()),
+            CborValue::Integer(i64::from(dt.timestamp_subsec_nanos()).into()),
+        ])),
+    ))
+}
+
+fn cbor_i64(v: &CborValue) -> Option<i64> {
+    match v {
+        CborValue::Integer(i) => i64::try_from(i128::from(*i)).ok(),
+        CborValue::Float(f) => Some(*f as i64),
+        _ => None,
     }
 }
 
@@ -384,6 +438,42 @@ mod tests {
     fn tag_unwraps_by_default() {
         let v = CborValue::Tag(999, Box::new(CborValue::Text("hi".into())));
         assert_eq!(cbor_to_json(&PlainDialect, v), json!("hi"));
+    }
+
+    #[test]
+    fn tag12_renders_lossless_rfc3339_and_round_trips() {
+        // 2027-07-22T09:30:00.123456789Z
+        let tagged = CborValue::Tag(
+            12,
+            Box::new(CborValue::Array(vec![
+                CborValue::Integer(1816421400.into()),
+                CborValue::Integer(123_456_789.into()),
+            ])),
+        );
+        let json = cbor_to_json(&PresentationDialect, tagged.clone());
+        let JsonValue::String(s) = &json else {
+            panic!("expected string, got {json:?}");
+        };
+        assert!(s.ends_with('Z'), "UTC preserved: {s}");
+        assert!(s.contains(".123456789"), "nanos preserved: {s}");
+        // The untouched round trip reproduces identical bytes — no
+        // phantom dirty.
+        assert_eq!(json_to_cbor_with_hint(&json, Some(&tagged)), tagged);
+    }
+
+    #[test]
+    fn unparseable_edit_under_tag12_hint_stays_text() {
+        let tagged = CborValue::Tag(
+            12,
+            Box::new(CborValue::Array(vec![
+                CborValue::Integer(0.into()),
+                CborValue::Integer(0.into()),
+            ])),
+        );
+        assert_eq!(
+            json_to_cbor_with_hint(&json!("not a date"), Some(&tagged)),
+            CborValue::Text("not a date".into())
+        );
     }
 
     #[test]

--- a/vantage-types/src/lib.rs
+++ b/vantage-types/src/lib.rs
@@ -13,7 +13,7 @@ pub mod type_system;
 #[cfg(feature = "serde")]
 pub use cbor_json::{
     CborDialect, PlainDialect, PresentationDialect, cbor_to_json, cbor_to_string, json_to_cbor,
-    json_to_cbor_with_hint,
+    json_to_cbor_with_hint, rfc3339_to_tag12, tag12_to_rfc3339,
 };
 pub use null::InvariantValue;
 pub use record::{IntoRecord, Record, TryFromRecord, TryIntoRecord};


### PR DESCRIPTION
## What

The servo becomes a **change draft** — the foundation for the vantage-ui 0.29 form rework.

**vantage-diorama 0.8.0** (breaking):
- `Servo::flash()` no longer settles the baseline optimistically at fire time. Setpoints stay locked through the write (`Pending`); an `in_flight` guard holds bus absorbs off so the servo's own optimistically staged cache value can't masquerade as an upstream measurement and release the locks early. On resolution the servo takes one deliberate measurement: a confirmed write converges the draft clean (a field re-edited mid-save stays locked); a rejected write restores the baseline while **keeping the user's setpoints** — a failed save never loses the draft.
- `FlashRejection` — structured refusal (`message` + per-field errors) riding the `VantageError` source chain. An `on_flash` route returns `FlashRejection::new(..).with_field(..).into_error()`; `ServoStatus::Failed` now carries the recovered rejection instead of a `String` (unstructured failures arrive message-only, so consumers handle one shape).
- `IdStrategy` + `Dio::servo_new(strategy)` — identity moves from the UI into the servo. `Uuid` (default) mints a v7 at creation and commands the id column, so a retried create reuses the id (a lost confirmation resolves as a noop patch, never a duplicate). `Auto` runs the master's returning insert inside `flash()` and binds to the created row. `FromRecord` keeps the old behavior.

**vantage-types 0.6.5**: SurrealDB `Tag(12, [secs, nanos])` datetimes join the CBOR↔JSON bridge — `PresentationDialect` renders a lossless nanosecond RFC-3339 string, `json_to_cbor_with_hint` re-encodes edits back to the tag, and `tag12_to_rfc3339`/`rfc3339_to_tag12` are exported so UI crates drop their local copies. Kills the phantom "unsaved change" on datetime columns at the conversion layer shared by grids/scripts/MCP.

**vantage-faker 0.6.8**: tracks diorama 0.8; no behavior changes. (`vantage-api-adapters` dep req updated in-tree; unpublished.)

## Why

Forms need the servo to be a draft: a rejected save must keep the user's values dirty (with the failing fields named), retries of a create must be idempotent, and the UI must never lose an edit to its own optimistic staging. See the per-crate CHANGELOGs for the full contracts.

## Tests

- 6 new servo tests: draft-hold under a gated write route, reject-then-retry (values retained), UUID/Auto identity strategies, create-retry id reuse, field-error round-trip through wrapped error chains.
- New `flash_rejection` unit tests (chain recovery, extra wrapping, message-only fallback).
- `tag12` render/round-trip tests in vantage-types.
- Full diorama + types + faker suites green; clippy clean; no rustdoc warnings.

Verified end-to-end against the vantage-ui form rework branch (patched locally) incl. a dedicated form-tester app: two forms over one record, chaos rejection routes, live faker pulse tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft-based servo saves that preserve edits during pending or rejected writes and support reliable retries.
  * Added structured flash rejection details, including field-level validation errors.
  * Added configurable identity strategies for new servo records.
  * Added lossless RFC 3339 nanosecond datetime conversion for supported CBOR values.

* **Bug Fixes**
  * Prevented phantom unsaved changes when editing supported datetime values.
  * Improved restoration and status reporting after rejected servo saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->