### PR TITLE
diorama: viewport skip without on_load_chunk logs at debug, not warn (0.8.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.8.2 — 2026-07-25
+
+- **Viewport skip logging** — `fire_chunk_load`'s "no `on_load_chunk`
+  callback" skip drops from WARN to DEBUG, matching the "visible fully
+  cached" skip beside it. An eager lens holds every row and registers no
+  chunk callback, so a viewport it can't page for is a steady state, not
+  a fault; any consumer that re-drives the viewport on a timer (a
+  relation list's periodic re-pull, `refresh_loaded_viewport`) emitted
+  one warning per tick indefinitely. No behaviour change — the skip
+  itself is untouched.
+
 ## 0.8.0 — 2026-07-24
 
 Breaking: the servo becomes a **change draft**, structured save

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.8.0"
+version = "0.8.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -207,10 +207,16 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         }
     };
 
+    // An eager lens holds every row already, so it registers no
+    // `on_load_chunk` — a viewport it can't page for is its steady state,
+    // not a fault. Logged at DEBUG like the fully-cached skip above:
+    // anything that re-drives the viewport on a timer (a relation list's
+    // periodic re-pull, `refresh_loaded_viewport`) would otherwise emit a
+    // warning per tick, forever.
     let cb = match dio_inner.lens.callbacks.on_load_chunk.as_ref() {
         Some(cb) => cb,
         None => {
-            tracing::warn!(
+            tracing::debug!(
                 target: "vantage_diorama::viewport",
                 visible = ?visible,
                 "fire_chunk_load: SKIP (no on_load_chunk callback)",


### PR DESCRIPTION
An eager lens holds every row up front, so it registers no `on_load_chunk` callback. When a consumer sets a viewport on such a scenery, `fire_chunk_load` has nothing to dispatch and returns early — correct, and the rows are already there.

That early return logged at WARN. The skip right above it, "visible fully cached", logs at DEBUG for the same class of non-event.

Anything that re-drives the viewport on a timer therefore emitted a warning per tick, forever. A relation list with a periodic re-pull produced a steady `fire_chunk_load: SKIP (no on_load_chunk callback)` heartbeat at WARN — noise that buries real warnings in `list_logs`. `refresh_loaded_viewport` re-enqueues the last viewport too, so a plain `request_refresh()` hits the same branch.

Demotes that one `warn!` to `debug!` and adds a comment explaining why the branch is a steady state rather than a fault. No behaviour change: the skip, the early return, and every other log line are untouched.

Version 0.8.2 (0.8.1 is claimed by the open #361). Dependents pin `vantage-diorama = "0.8"`, so no dependent bumps.

Tested: `cargo test -p vantage-diorama` — 29 test binaries, 0 failures; `cargo +1.97.0 clippy -p vantage-diorama --all-targets` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repetitive warning messages during normal table loading when no load callback is configured.
  * Preserved existing skip behavior for fully cached or eagerly loaded table data.

* **Documentation**
  * Added release notes for version 0.8.2.
  * Updated the package version to 0.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->