### PR TITLE
vista/sql: pin the change-subscription contract; postgres NOTIFY becomes an explicit opt-in (VAN-110)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/docs4/src/intro/step8-sql-notify.md
+++ b/docs4/src/intro/step8-sql-notify.md
@@ -36,6 +36,24 @@ sqlx::query(
 changed" ping is all the Dio needs to reconcile. The payload is empty on purpose (more on that
 below).
 
+## Tell the Vista the trigger exists
+
+Postgres offers no way to ask "is anything going to notify me on this channel?" — `LISTEN` on a
+channel nobody feeds succeeds and then waits forever. A Vista that assumed it could push just
+because the table is writable would advertise a feed that may never arrive, and no consumer could
+tell the difference between that and a quiet table. So the application, which is the only party
+that knows, says so:
+
+```rust
+let mut master = db
+    .vista_factory()
+    .with_notify(true)   // we installed product_notify_trg above
+    .from_table(Product::table(db.clone()))?;
+```
+
+That one call is what makes `can_watch()` answer `true` in the next section. Leave it off and
+everything still works — the Dio simply falls back to whatever refresh you configure.
+
 ## One line replaces the poll
 
 The server builds the Dio exactly as before — an eager in-memory cache, an `on_start` that loads it
@@ -51,10 +69,11 @@ dio.watch().await?;
 ```
 
 That is the whole change. [`Dio::watch()`](https://docs.rs/vantage-diorama) asks the master Vista
-whether it can push (`Vista::can_watch()`); the Postgres Vista answers yes and opens a `PgListener`
-on the `product_changed` channel. Each notification drives one reconcile. If the backend *couldn't*
-push, `watch()` would be a no-op and a `refresh_every` timer would carry the load instead — the same
-call is correct either way, which is the point of the capability.
+whether it can push (`Vista::can_watch()`); because we opted in above, the Postgres Vista answers
+yes and opens a `PgListener` on the `product_changed` channel. Each notification drives one
+reconcile. If the backend *couldn't* push, `watch()` would be a no-op and a `refresh_every` timer
+would carry the load instead — the same call is correct either way, which is the point of the
+capability.
 
 ```admonish note title="The server still never writes"
 `dio.watch()` only *reads and reconciles*. Nothing in the server process writes to `product`. That

--- a/docs4/src/intro/step8-sql-notify.md
+++ b/docs4/src/intro/step8-sql-notify.md
@@ -52,7 +52,9 @@ let mut master = db
 ```
 
 That one call is what makes `can_watch()` answer `true` in the next section. Leave it off and
-everything still works — the Dio simply falls back to whatever refresh you configure.
+`dio.watch()` becomes a no-op — which matters here, because this chapter is about to *delete* the
+refresh timer. Push and a `refresh_every` poll are the two ways the cache learns about a write; an
+app that declines both never updates.
 
 ## One line replaces the poll
 

--- a/docs4/src/new-persistence/step8-vista-integration.md
+++ b/docs4/src/new-persistence/step8-vista-integration.md
@@ -630,12 +630,33 @@ At this point your backend should have:
    - `capabilities()` returns a `VistaCapabilities` whose `true` flags exactly match the methods
      you actually overrode.
 
-5. **YAML extras** under `spec.rs`:
+5. **Live subscription** (optional) — `watch_vista` plus `can_subscribe`, if the backend can push
+   changes at all. Four promises bind every implementation:
+   - The stream **may be coarser than the vista**. Subscribing table-wide and letting the consumer
+     discard the rest is a legitimate v1; callers always pass the full vista and never depend on
+     how narrowly you filter, so you can tighten scope later without breaking them.
+   - **Rows you push may fall outside the vista's conditions**, precisely because of the above.
+     Either reconcile in the driver — SurrealDB re-reads each notified id *through* the conditions,
+     so a row that no longer matches surfaces as `Deleted` — or leave it to the consumer, but say
+     which in your docs.
+   - `VistaChange::Invalidated` means **"re-read everything"**. Emit it when you have a signal but
+     no payload; Postgres `LISTEN/NOTIFY` has nothing else to offer.
+   - **Ending the stream is normal.** Consumers resubscribe with backoff and reconcile the gap, so
+     you need no internal reconnect loop.
+
+   Advertise `can_subscribe` only when the feed works with **no further setup**, or when the
+   application has explicitly declared that setup exists. Postgres is the cautionary case: `LISTEN`
+   succeeds on a channel no trigger ever feeds, so its capability is opt-in
+   (`PostgresVistaFactory::with_notify`) rather than inferred from the table being writable. A flag
+   left `true` over a permanently silent stream is worse than one left `false` — consumers cannot
+   tell it apart from an idle table.
+
+6. **YAML extras** under `spec.rs`:
    - `<Driver>TableExtras` and `<Driver>ColumnExtras` — both `deny_unknown_fields`.
    - `<Driver>VistaSpec` type alias resolving the three associated types.
    - Up-front validation of paths, mutual-exclusion rules, etc., as part of spec lowering.
 
-6. **Tests** in `tests/<n>_vista.rs` — gated on `feature = "vista"`, run against a real backend,
+7. **Tests** in `tests/<n>_vista.rs` — gated on `feature = "vista"`, run against a real backend,
    covering typed/YAML construction, read, write (where supported), `add_condition_eq` push-down,
    capability advertisement, and the `Unsupported` vs `Unimplemented` error-kind boundary.
 

--- a/learn-10/src/main.rs
+++ b/learn-10/src/main.rs
@@ -21,7 +21,16 @@ async fn run() -> VantageResult<()> {
 
     // Order the shelf by creation time, so a drink keeps its place as it sells
     // and new deliveries append at the end.
-    let mut master = db.vista_factory().from_table(Product::table(db.clone()))?;
+    //
+    // `with_notify(true)` is us telling the factory that `db::setup` installed
+    // the `product_changed` trigger. Postgres can't be asked whether a trigger
+    // exists, and listening on a channel nobody feeds blocks forever — so the
+    // application declares it, and that declaration is what lets the Vista
+    // advertise `can_watch` below.
+    let mut master = db
+        .vista_factory()
+        .with_notify(true)
+        .from_table(Product::table(db.clone()))?;
     master.add_order("created", SortDirection::Ascending)?;
 
     // Eager cache, and no refresh timer at all: the NOTIFY listener refreshes

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.16 — 2026-07-26
+
+- **Behaviour change:** a Postgres vista no longer advertises `can_subscribe`
+  just because it is writable. `LISTEN` on a channel no trigger ever feeds
+  succeeds and then blocks forever, so the old flag promised a feed that may
+  never arrive — indistinguishable, to a consumer, from a table where nothing
+  happens. Watchability is now opt-in via
+  `PostgresVistaFactory::with_notify(true)`, by which the application declares it
+  installed the `{table}_changed` trigger. Postgres cannot be asked whether that
+  trigger exists, so the application is the only party that can answer honestly.
+  Callers relying on the implicit flag add one builder call; nothing else changes.
+
 ## 0.6.15 — 2026-07-23
 
 - `add_op_condition` pushes non-equality filters into the SQL query for all three

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -11,6 +11,10 @@
   installed the `{table}_changed` trigger. Postgres cannot be asked whether that
   trigger exists, so the application is the only party that can answer honestly.
   Callers relying on the implicit flag add one builder call; nothing else changes.
+- Reference traversal carries that declaration across. `get_ref`,
+  `get_ref_target` and contained-reference traversal each build a fresh factory
+  internally, so without this a relation target came back unwatchable even on a
+  database whose tables all have triggers.
 
 ## 0.6.15 — 2026-07-23
 

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -28,11 +28,16 @@ pub type PostgresSpecResolver = Arc<dyn Fn(&str) -> Option<PostgresVistaSpec> + 
 pub struct PostgresVistaFactory {
     db: PostgresDB,
     resolver: Option<PostgresSpecResolver>,
+    notify: bool,
 }
 
 impl PostgresVistaFactory {
     pub fn new(db: PostgresDB) -> Self {
-        Self { db, resolver: None }
+        Self {
+            db,
+            resolver: None,
+            notify: false,
+        }
     }
 
     /// Attach a spec resolver. Required for YAML-declared references to resolve
@@ -40,6 +45,26 @@ impl PostgresVistaFactory {
     /// `Table` and the next query fails loudly.
     pub fn with_resolver(mut self, resolver: PostgresSpecResolver) -> Self {
         self.resolver = Some(resolver);
+        self
+    }
+
+    /// Declare that this database has `{table}_changed` NOTIFY triggers
+    /// installed, letting the vistas this factory builds advertise
+    /// [`can_subscribe`](VistaCapabilities::can_subscribe).
+    ///
+    /// Off by default, and deliberately explicit: Postgres cannot tell us
+    /// whether a trigger exists. `LISTEN` on a channel nobody ever notifies
+    /// succeeds and then blocks forever, so a vista that advertised
+    /// `can_subscribe` on the strength of being writable would promise a feed
+    /// that is silent — indistinguishable, to a consumer, from a table where
+    /// nothing happens. The trigger is application-installed (see `learn-10`'s
+    /// `db::setup`, and the "Real-Time Push with LISTEN/NOTIFY" chapter), so
+    /// the application is the only party that can honestly answer this.
+    ///
+    /// Applies to every table the factory builds; if only some of them carry
+    /// triggers, use separate factories.
+    pub fn with_notify(mut self, notify: bool) -> Self {
+        self.notify = notify;
         self
     }
 
@@ -69,8 +94,10 @@ impl PostgresVistaFactory {
                 can_update: !read_only,
                 can_delete: !read_only,
                 // Push via LISTEN/NOTIFY on the `{table}_changed` channel, which
-                // the application feeds from a trigger (see learn-10's setup).
-                can_subscribe: !read_only,
+                // the application feeds from a trigger. Opt-in (`with_notify`):
+                // we cannot detect the trigger, and claiming a feed we may never
+                // receive is worse than claiming none.
+                can_subscribe: self.notify && !read_only,
                 can_fetch_window: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -47,6 +47,20 @@ where
             metadata,
         }
     }
+
+    /// Whether the application declared `{table}_changed` triggers for this
+    /// database (see `PostgresVistaFactory::with_notify`).
+    ///
+    /// Traversals build a fresh factory, which would otherwise reset the opt-in
+    /// and leave every relation target silently unwatchable on a database that
+    /// does have triggers. We recover it from our own advertised capability
+    /// rather than storing it twice. A query-sourced parent reads back `false`
+    /// (it is read-only, so it never advertised), which under-advertises a real
+    /// child table — the safe direction: a missed feed degrades to the
+    /// consumer's reconcile path, a phantom one degrades to silence.
+    fn notify_opt_in(&self) -> bool {
+        self.capabilities.can_subscribe
+    }
 }
 
 fn to_cbor_record(record: Record<AnyPostgresType>) -> Record<CborValue> {
@@ -282,7 +296,8 @@ where
             .get_ref_from_row::<EmptyEntity>(relation, &native_row)?;
         let factory = crate::postgres::vista::factory::PostgresVistaFactory::new(
             self.table.data_source().clone(),
-        );
+        )
+        .with_notify(self.notify_opt_in());
         factory.from_table(target)
     }
 
@@ -290,7 +305,8 @@ where
         let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
         let factory = crate::postgres::vista::factory::PostgresVistaFactory::new(
             self.table.data_source().clone(),
-        );
+        )
+        .with_notify(self.notify_opt_in());
         factory.from_table(target)
     }
 
@@ -318,12 +334,15 @@ where
             }
         };
         let db = self.table.data_source().clone();
+        let notify = self.notify_opt_in();
         self.table.get_contained_ref(
             relation,
             row,
             parent_id,
             move |t| {
-                crate::postgres::vista::factory::PostgresVistaFactory::new(db.clone()).from_table(t)
+                crate::postgres::vista::factory::PostgresVistaFactory::new(db.clone())
+                    .with_notify(notify)
+                    .from_table(t)
             },
             parse_json_host,
             |c| CborValue::Text(cbor_to_json(c).to_string()),

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -338,7 +338,13 @@ where
     /// the fine-grained variants instead) — the consumer re-reads the set on each
     /// signal. The channel is `{table}_changed` by convention; the application
     /// installs a trigger that `pg_notify`s it on every write (see learn-10's
-    /// `db::setup`). Advertised via [`VistaCapabilities::can_subscribe`].
+    /// `db::setup`).
+    ///
+    /// `LISTEN` succeeds whether or not that trigger exists, and an un-triggered
+    /// channel simply never fires — so the capability behind this is opt-in via
+    /// [`PostgresVistaFactory::with_notify`](crate::postgres::vista::PostgresVistaFactory::with_notify),
+    /// not inferred from the table being writable. Advertised via
+    /// [`VistaCapabilities::can_subscribe`].
     async fn watch_vista(&self, _vista: &Vista) -> Result<VistaChangeStream> {
         let channel = format!("{}_changed", self.table.table_name());
         let pool = self.table.data_source().pool().clone();

--- a/vantage-sql/tests/postgres/6_vista.rs
+++ b/vantage-sql/tests/postgres/6_vista.rs
@@ -181,8 +181,29 @@ async fn vista_capabilities_advertise_read_write() -> TestResult {
     assert!(caps.can_insert);
     assert!(caps.can_update);
     assert!(caps.can_delete);
-    // A read-write Postgres Vista is watchable via LISTEN/NOTIFY.
-    assert!(caps.can_subscribe);
+    // Being writable says nothing about whether anyone installed the
+    // `{table}_changed` trigger, so watchability is NOT inferred from it.
+    assert!(!caps.can_subscribe);
+    Ok(())
+}
+
+#[tokio::test]
+async fn vista_is_watchable_only_when_notify_is_declared() -> TestResult {
+    let (db, name) = setup("caps_notify").await;
+
+    // Opting in is what makes the LISTEN/NOTIFY feed advertisable — the
+    // application is the only party that knows the trigger exists.
+    let vista = db
+        .vista_factory()
+        .with_notify(true)
+        .from_table(product_table(db.clone(), &name))?;
+    assert!(vista.capabilities().can_subscribe);
+
+    let vista = db
+        .vista_factory()
+        .with_notify(false)
+        .from_table(product_table(db.clone(), &name))?;
+    assert!(!vista.capabilities().can_subscribe);
     Ok(())
 }
 

--- a/vantage-sql/tests/postgres/6_vista.rs
+++ b/vantage-sql/tests/postgres/6_vista.rs
@@ -193,17 +193,13 @@ async fn vista_is_watchable_only_when_notify_is_declared() -> TestResult {
 
     // Opting in is what makes the LISTEN/NOTIFY feed advertisable — the
     // application is the only party that knows the trigger exists.
-    let vista = db
-        .vista_factory()
-        .with_notify(true)
-        .from_table(product_table(db.clone(), &name))?;
-    assert!(vista.capabilities().can_subscribe);
-
-    let vista = db
-        .vista_factory()
-        .with_notify(false)
-        .from_table(product_table(db.clone(), &name))?;
-    assert!(!vista.capabilities().can_subscribe);
+    for notify in [true, false] {
+        let vista = db
+            .vista_factory()
+            .with_notify(notify)
+            .from_table(product_table(db.clone(), &name))?;
+        assert_eq!(vista.capabilities().can_subscribe, notify);
+    }
     Ok(())
 }
 
@@ -366,17 +362,24 @@ async fn setup_clients_orders(suffix: &str) -> (PostgresDB, String, String) {
     (db, client_t, orders_t)
 }
 
-/// YAML-declared `references:` lower to `with_one`/`with_many`, with the target
-/// table resolved by name through a spec resolver attached to the factory.
-#[tokio::test]
-async fn vista_yaml_references_resolve_via_resolver() -> TestResult {
+/// The `client` spec (with a `has_many` to `orders`) plus a resolver that can
+/// find the `orders` target by name. Shared by the traversal tests below.
+#[allow(clippy::type_complexity)]
+fn clients_orders_specs(
+    client_t: &str,
+    orders_t: &str,
+) -> std::result::Result<
+    (
+        vantage_sql::postgres::vista::PostgresVistaSpec,
+        vantage_sql::postgres::vista::PostgresSpecResolver,
+    ),
+    Box<dyn Error>,
+> {
     use indexmap::IndexMap;
     use std::sync::Arc;
     use vantage_sql::postgres::vista::{PostgresSpecResolver, PostgresVistaSpec};
 
-    let (db, client_t, orders_t) = setup_clients_orders("refs").await;
-
-    let client_yaml = format!(
+    let client_spec: PostgresVistaSpec = serde_yaml_ng::from_str(&format!(
         r#"
 name: client
 columns:
@@ -390,8 +393,8 @@ references:
     kind: has_many
     foreign_key: client_id
 "#
-    );
-    let orders_yaml = format!(
+    ))?;
+    let orders_spec: PostgresVistaSpec = serde_yaml_ng::from_str(&format!(
         r#"
 name: orders
 columns:
@@ -401,15 +404,33 @@ columns:
 postgres:
   table: {orders_t}
 "#
-    );
-
-    let client_spec: PostgresVistaSpec = serde_yaml_ng::from_str(&client_yaml)?;
-    let orders_spec: PostgresVistaSpec = serde_yaml_ng::from_str(&orders_yaml)?;
+    ))?;
 
     let map: IndexMap<String, PostgresVistaSpec> =
         [("orders".to_string(), orders_spec)].into_iter().collect();
     let map = Arc::new(map);
     let resolver: PostgresSpecResolver = Arc::new(move |name: &str| map.get(name).cloned());
+    Ok((client_spec, resolver))
+}
+
+/// Read `alice` out of a built `client` vista, for traversing her orders.
+async fn alice_row(
+    clients: &mut vantage_vista::Vista,
+) -> std::result::Result<Record<CborValue>, Box<dyn Error>> {
+    let (_id, alice) = clients
+        .with_id(CborValue::Text("alice".into()))?
+        .get_some_value()
+        .await?
+        .expect("alice exists");
+    Ok(alice)
+}
+
+/// YAML-declared `references:` lower to `with_one`/`with_many`, with the target
+/// table resolved by name through a spec resolver attached to the factory.
+#[tokio::test]
+async fn vista_yaml_references_resolve_via_resolver() -> TestResult {
+    let (db, client_t, orders_t) = setup_clients_orders("refs").await;
+    let (client_spec, resolver) = clients_orders_specs(&client_t, &orders_t)?;
 
     let factory = db.vista_factory().with_resolver(resolver);
     let mut clients = factory.build_from_spec(client_spec)?;
@@ -419,17 +440,47 @@ postgres:
     assert_eq!(refs[0].0, "orders");
     assert_eq!(refs[0].1, vantage_vista::ReferenceKind::HasMany);
 
-    let (_id, alice) = clients
-        .with_id(CborValue::Text("alice".into()))?
-        .get_some_value()
-        .await?
-        .expect("alice exists");
+    let alice = alice_row(&mut clients).await?;
     let alice_orders = clients.get_ref("orders", &alice)?;
     let rows = alice_orders.list_values().await?;
     assert_eq!(rows.len(), 2, "alice has 2 orders");
     assert!(rows.contains_key("o1"));
     assert!(rows.contains_key("o2"));
     assert!(!rows.contains_key("o3"));
+    Ok(())
+}
+
+/// Traversing a reference builds a fresh factory internally, which must carry
+/// the parent's `with_notify` declaration across — otherwise every relation
+/// target on a triggered database comes back silently unwatchable.
+#[tokio::test]
+async fn notify_opt_in_survives_reference_traversal() -> TestResult {
+    let (db, client_t, orders_t) = setup_clients_orders("refs_notify").await;
+    let (client_spec, resolver) = clients_orders_specs(&client_t, &orders_t)?;
+
+    for notify in [true, false] {
+        let mut clients = db
+            .vista_factory()
+            .with_resolver(resolver.clone())
+            .with_notify(notify)
+            .build_from_spec(client_spec.clone())?;
+        assert_eq!(clients.capabilities().can_subscribe, notify);
+
+        let alice = alice_row(&mut clients).await?;
+        let orders = clients.get_ref("orders", &alice)?;
+        assert_eq!(
+            orders.capabilities().can_subscribe,
+            notify,
+            "get_ref target should inherit the parent's notify opt-in"
+        );
+
+        let target = clients.get_ref_target("orders")?;
+        assert_eq!(
+            target.capabilities().can_subscribe,
+            notify,
+            "get_ref_target should inherit the parent's notify opt-in"
+        );
+    }
     Ok(())
 }
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.17 — 2026-07-26
+
+- The live-subscription contract is now written down on `TableShell::watch_vista`:
+  callers always pass the full vista and drivers deliver best-effort, so a
+  consumer never branches on whether a backend filters row-, select- or
+  table-wide. Four promises hold everywhere — the stream may be coarser than the
+  vista; pushed rows may fall outside its conditions (the driver reconciles, or
+  the consumer must); `Invalidated` means re-read everything; ending the stream
+  is normal and consumers resubscribe.
+- `can_subscribe` and `can_invalidate` are documented — the only two
+  `VistaCapabilities` fields that carried no docs. `can_subscribe` states that it
+  is an *attempt* to push, not a delivery guarantee, and that a driver must not
+  advertise it over a feed needing setup nobody has confirmed.
+
 ## 0.6.16 — 2026-07-23
 
 - Conventional Rhai vocabulary gains `add_condition("col", "op", value)` — the

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -18,7 +18,24 @@ pub struct VistaCapabilities {
     pub can_insert: bool,
     pub can_update: bool,
     pub can_delete: bool,
+    /// The driver will *attempt* to push changes via
+    /// [`watch_vista`](crate::TableShell::watch_vista) — see that method for the
+    /// four promises a subscription makes. It is an attempt, not a guarantee of
+    /// delivery: no backend we ship is lossless, so a consumer that must not miss
+    /// a change keeps a reconcile path (a slow poll, a refresh on reconnect)
+    /// rather than relying on push alone.
+    ///
+    /// Advertise `true` only when the driver will push with **no further setup**,
+    /// or when the application has explicitly declared that setup is done (see
+    /// `PostgresVistaFactory::with_notify`, whose `LISTEN/NOTIFY` feed is silent
+    /// until the user installs a trigger). A flag that is `true` while the stream
+    /// stays permanently silent is indistinguishable from "nothing is happening",
+    /// and consumers cannot detect the difference at runtime.
     pub can_subscribe: bool,
+    /// The set can be told to drop any cached state and re-read
+    /// ([`VistaChange::Invalidated`](crate::VistaChange::Invalidated) on the push
+    /// side). Currently set only by `vantage-diorama`'s own Dio shell, which fans
+    /// events out to its sceneries; no persistence driver advertises it.
     pub can_invalidate: bool,
     /// Server-side ordering via `add_order(column, direction)`. When
     /// `true`, individual columns may still refuse — check the per-

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -518,6 +518,33 @@ pub trait TableShell: Send + Sync + 'static {
     /// it to a cache directly. The default produces `Unimplemented` (when
     /// `can_subscribe: true`) or `Unsupported` (when `false`); callers branch on
     /// `vista.capabilities().can_subscribe` first.
+    ///
+    /// # The subscription contract
+    ///
+    /// Callers always pass the full `vista`, and drivers deliver on a best-effort
+    /// basis. A consumer must not need to know whether a given backend filters
+    /// row-, select- or table-wide — that is what keeps consumer code identical
+    /// across drivers, and lets a driver tighten its scope later without
+    /// breaking anyone. Four promises hold for every implementation:
+    ///
+    /// 1. **The stream may be coarser than the vista.** Subscribing table-wide
+    ///    and letting the consumer discard what it doesn't want is a valid
+    ///    implementation; `vista` is a hint about what's interesting, not a
+    ///    filter the driver is obliged to apply.
+    /// 2. **Payload rows may fall outside the vista's conditions**, precisely
+    ///    because of (1). Either the driver reconciles (SurrealDB re-reads each
+    ///    notified id *through* the vista's conditions, so a row that no longer
+    ///    matches surfaces as [`VistaChange::Deleted`]) or the consumer must.
+    ///    Never assume an `Inserted`/`Updated` row belongs in the set.
+    /// 3. **[`VistaChange::Invalidated`] means "re-read everything".** It carries
+    ///    no id and implies nothing about how much changed — a driver with no row
+    ///    payload to offer may emit it for every single write.
+    /// 4. **Stream end is normal, not an error.** Connections drop and sessions
+    ///    expire; consumers resubscribe (with backoff) and reconcile the gap. A
+    ///    driver need not reconnect internally.
+    ///
+    /// Delivery is not guaranteed even while subscribed — see
+    /// [`can_subscribe`](VistaCapabilities::can_subscribe).
     async fn watch_vista(&self, _vista: &Vista) -> Result<VistaChangeStream> {
         Err(self.default_error("watch_vista", "can_subscribe"))
     }

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -512,10 +512,11 @@ pub trait TableShell: Send + Sync + 'static {
     ///
     /// Drivers whose backend can push changes (SurrealDB LIVE, Postgres
     /// `LISTEN/NOTIFY`) override this and advertise
-    /// [`can_subscribe`](VistaCapabilities::can_subscribe). Each emitted change
-    /// carries the record in the same projected shape as
+    /// [`can_subscribe`](VistaCapabilities::can_subscribe). The row-bearing
+    /// variants carry the record in the same projected shape as
     /// [`list_vista_values`](Self::list_vista_values), so a consumer can apply
-    /// it to a cache directly. The default produces `Unimplemented` (when
+    /// them to a cache directly; [`VistaChange::Invalidated`] carries nothing at
+    /// all and means "re-read the set". The default produces `Unimplemented` (when
     /// `can_subscribe: true`) or `Unsupported` (when `false`); callers branch on
     /// `vista.capabilities().can_subscribe` first.
     ///


### PR DESCRIPTION
Groundwork for wiring live change feeds into Vantage UI ([VAN-112](https://linear.app/vantage-ui/issue/VAN-112)). Nothing in the product reads `can_subscribe` today, so this is the last moment the semantics can be fixed without it being a behaviour regression.

Closes [VAN-110](https://linear.app/vantage-ui/issue/VAN-110/define-the-change-subscription-contract-for-all-datasource-drivers).

## Why

`VistaCapabilities::can_subscribe` and `can_invalidate` were the only two fields in the struct with no doc comment — in a type whose own docs promise an "honest contract a driver advertises to consumers". Meanwhile Postgres advertised `can_subscribe` for any writable vista, but the `{table}_changed` feed it points at only exists if the application installed a trigger. `LISTEN` on a channel nobody feeds **succeeds and then blocks forever**, so that flag promised a feed that may never arrive — and a consumer cannot tell that apart from a table where nothing is happening.

## What changed

**The contract is written down** (`TableShell::watch_vista`). Callers always pass the full vista; drivers deliver best-effort. A consumer never branches on whether a backend filters row-, select- or table-wide, which is what keeps consumer code identical across drivers and lets a driver tighten its scope later without breaking anyone. Four promises:

1. The stream may be coarser than the vista — whole-table subscriptions are legal.
2. Pushed rows may fall outside the vista's conditions, precisely because of (1). SurrealDB reconciles driver-side (it re-reads each notified id *through* the conditions, so a row that no longer matches surfaces as `Deleted`); otherwise the consumer must.
3. `Invalidated` means re-read everything.
4. Ending the stream is normal — consumers resubscribe with backoff.

**Postgres is honest now.** `can_subscribe` is opt-in via `PostgresVistaFactory::with_notify(true)`, by which the application declares the trigger exists. Postgres cannot be asked, so the application is the only party that can answer. Off by default.

**`can_subscribe` / `can_invalidate` are documented**, including that `can_subscribe` is an *attempt* to push, not a delivery guarantee — no backend we ship is lossless, so a consumer that must not miss a change keeps a reconcile path rather than relying on push alone.

**Docs.** `learn-10` opts in explicitly (otherwise the LISTEN/NOTIFY tutorial would silently stop pushing), the intro chapter gains a short section explaining why the app has to declare it, and the driver-author guide gains the live-subscription step it never had — with Postgres as the cautionary example.

## Risk

Behaviour change, called out in the vantage-sql changelog: a Postgres vista no longer advertises `can_subscribe` just because it is writable. Callers relying on the implicit flag add one builder call. Nothing consumes it in vantage-ui today, and `learn-10` — the only in-repo caller that watches — is updated here.

## Verification

- `cargo build`, `cargo +1.97.0 clippy --all-targets -D warnings`, `cargo fmt`, and rustdoc with `-D rustdoc::broken_intra_doc_links` all clean for vantage-vista, vantage-sql and learn-10.
- `cargo test --workspace` passes (with a local SurrealDB up for the surreal-client integration tests).
- **Not run locally:** the Postgres integration tests, including the flipped assertion and the new `vista_is_watchable_only_when_notify_is_declared` — they need a server on `localhost:5433` and there is no Postgres or Docker on this machine. CI provides the service.
- **Pre-existing flake, unrelated:** `surreal-client/tests/live_query.rs` fails when its two tests run in parallel and passes with `--test-threads=1`. They use separate databases and tables, so it looks like a race in live-query registration rather than data collision. surreal-client depends only on vantage-types and vantage-core, neither touched here.

## Note for the maintainer

Open PR #361 (`servo-review-fixes`) carries `vantage-diorama` at **0.8.1**, but main is now at **0.8.2** and 0.8.1 was never published. `publish-on-merge.yaml` detects "version changed", not "version increased", so merging #361 as-is would try to publish a version below the one already on crates.io. It needs renumbering to 0.8.3 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in PostgreSQL live updates through `with_notify(true)`.
  * Watchers can receive database change notifications and reconcile affected data automatically.
  * Added clearer subscription behavior, including invalidation and resubscription handling.

* **Bug Fixes**
  * PostgreSQL views no longer advertise live-update support unless notifications are explicitly configured.

* **Documentation**
  * Clarified notification setup, subscription guarantees, polling fallback, and capability behavior.

* **Chores**
  * Updated package versions and changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->