### PR TITLE
docs4: add the Live Data reference — what each backend does about freshness (VAN-115)

### DIFF
--- a/docs4/src/SUMMARY.md
+++ b/docs4/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Model-Driven Architecture](./mda.md)
   - [Three Paths for Developers](./three-paths.md)
 - [Config-Driven Vistas: YAML & Rhai](./config-driven-vistas.md)
+- [Live Data: Push, Poll & Freshness](./live-data.md)
 - [Adding a New Persistence](./new-persistence.md)
   - [Step 1: Type System](./new-persistence/step1-types.md)
   - [Step 2: Expressions](./new-persistence/step2-expressions.md)

--- a/docs4/src/intro/step9-surreal.md
+++ b/docs4/src/intro/step9-surreal.md
@@ -113,9 +113,15 @@ The `product` shelf has now run behind three backends, and the app above `make_d
 Poll, coarse push, fine push — the same `dio.watch()` call, chosen transparently from what the Vista
 advertises. You pick the database your problem has; the freshness you get is the best that database
 can offer, and the code that consumes it is the code you already wrote.
+
+Note the asymmetry in what each one costs you: SurrealDB is watchable the moment you build the
+Vista, while the PostgreSQL row above assumes the trigger from the previous chapter *and* the
+`with_notify(true)` that declares it. Every other backend Vantage speaks polls today — see
+[Live Data](../live-data.md) for the full picture.
 ```
 
 From here the reference half of the book takes over — [SurrealDB](../surrealdb.md) for the driver
 details, [SQL](../sql.md) for the dialects, [Config-Driven Vistas](../config-driven-vistas.md) for
-declaring all of this from YAML, and [Adding a New Persistence](../new-persistence.md) when your
-backend isn't one Vantage already speaks.
+declaring all of this from YAML, [Live Data](../live-data.md) for what every backend does about
+freshness, and [Adding a New Persistence](../new-persistence.md) when your backend isn't one Vantage
+already speaks.

--- a/docs4/src/live-data.md
+++ b/docs4/src/live-data.md
@@ -1,0 +1,123 @@
+# Live Data: Push, Poll & Freshness
+
+A cache only stays correct if it finds out when the underlying data changes. There are two ways it
+can: it asks (**poll**), or the database tells it (**push**). `dio.watch()` is the same call either
+way — it asks the master Vista whether it can push, subscribes if so, and quietly does nothing if
+not.
+
+That last part is the bit worth knowing before you pick a backend. `watch()` returning `Ok(())` does
+not mean you have a live feed; it means nothing went wrong. This page says exactly what each shipped
+driver delivers today, and what — if anything — you have to do to get it.
+
+<!-- toc -->
+
+---
+
+## Three freshness models
+
+Every backend answers two questions, and the pair decides what you get:
+
+1. **Can it tell you something changed at all?** A file on disk cannot. A database server can.
+2. **When it does, does it hand you the row, or only a signal?**
+
+| Model          | What arrives                                | What the Dio does                     |
+| -------------- | ------------------------------------------- | ------------------------------------- |
+| **poll**       | nothing — you re-read on a timer            | re-lists the whole set                |
+| **coarse push** | "something changed", no payload             | re-reads the set to find out what     |
+| **fine push**  | the action *and* the affected record        | applies that one row to the cache     |
+
+Fine push is the only model where a change costs you no query. Coarse push still beats polling: you
+re-read *because something happened*, not on the off-chance.
+
+## What each backend delivers today
+
+| Backend        | Mechanism                              | Model       | Setup required                          |
+| -------------- | -------------------------------------- | ----------- | --------------------------------------- |
+| SurrealDB      | `LIVE SELECT` over WebSocket           | fine push   | none — but the URL must be `ws://`/`wss://` |
+| PostgreSQL     | `LISTEN/NOTIFY` on `{table}_changed`   | coarse push | a trigger **and** an explicit opt-in    |
+| SQLite         | —                                      | poll        | —                                       |
+| MySQL          | —                                      | poll        | —                                       |
+| MongoDB        | —                                      | poll        | —                                       |
+| CSV files      | —                                      | poll        | —                                       |
+| REST / GraphQL | —                                      | poll        | —                                       |
+| AWS            | —                                      | poll        | —                                       |
+| Kubernetes     | —                                      | poll        | —                                       |
+| CLI tools      | —                                      | poll        | —                                       |
+| Append logs    | — (write-only sink)                    | n/a         | —                                       |
+
+Only two drivers implement `watch_vista` at all. Everything in the poll rows inherits the trait
+default, which reports the capability as unsupported and leaves
+[`can_subscribe`](vantage_vista::VistaCapabilities) `false` — so `dio.watch()` on those is a no-op
+and a `refresh_every` timer carries the load.
+
+```admonish note title="Poll is a supported answer, not a failure"
+A polled backend is not broken, and you do not need different application code for it. The Lens keeps
+its `refresh_every`, the scenery is content-aware, and an unchanged re-read bumps no generation and
+repaints nothing. The cost is latency and a query you didn't strictly need — not correctness.
+```
+
+## SurrealDB — fine push, no setup
+
+`LIVE SELECT` delivers a typed per-row notification: the action (`CREATE` / `UPDATE` / `DELETE`) and
+the affected record. The driver re-reads each notified id *through the vista's own conditions*, so a
+row that no longer belongs to a filtered set arrives as a delete rather than silently lingering. A
+real table is watchable the moment you build it; only query-sourced vistas (`rhai:` / `base:`) are
+not.
+
+```admonish warning title="Live queries need a WebSocket connection"
+This is the one case where the capability can overstate what you'll get. `LIVE SELECT` is only
+implemented by the WebSocket engine — point a SurrealDB datasource at an `http://` URL and the Vista
+will still advertise that it can subscribe, then fail when `watch()` actually tries. Use `ws://` or
+`wss://` for anything that watches.
+```
+
+## PostgreSQL — coarse push, and why you must ask for it
+
+Postgres has no built-in change feed. It has `LISTEN/NOTIFY`, a general-purpose pub/sub channel, and
+a trigger you install yourself decides what gets announced. The driver listens on `{table}_changed`
+and yields a payload-less invalidation for every notification.
+
+Because you install that trigger, only you know whether it exists — and `LISTEN` on a channel nobody
+ever feeds *succeeds*, then blocks forever. A Vista that assumed it could push merely because the
+table is writable would advertise a feed that may never arrive, which a consumer cannot tell apart
+from a table where nothing happens. So it is opt-in:
+
+```rust
+let master = db
+    .vista_factory()
+    .with_notify(true)   // yes, I installed the trigger
+    .from_table(Product::table(db.clone()))?;
+```
+
+The trigger itself, and the full walkthrough, are in
+[Real-Time Push with LISTEN/NOTIFY](./intro/step8-sql-notify.md). The declaration applies to every
+table a factory builds, so if only some of your tables carry triggers, use separate factories. It
+also carries across reference traversal — a relation target inherits the parent's opt-in rather than
+silently reverting to unwatchable.
+
+## What a consumer must assume
+
+Push is best-effort, and the contract is deliberately loose so that a driver can tighten its scope
+later without breaking anyone. Callers always hand over the full Vista; the driver delivers what it
+can. Four things hold everywhere:
+
+- **The stream may be coarser than your Vista.** Watching the whole table and letting the consumer
+  discard the rest is a legitimate implementation.
+- **A pushed row may fall outside your conditions**, precisely because of the above. Either the
+  driver reconciles or you must.
+- **An invalidation means "re-read everything."** It carries no id and implies nothing about how much
+  changed.
+- **The stream ending is normal.** Connections drop; consumers resubscribe with backoff and reconcile
+  the gap. `Dio::watch()` already does this for you.
+
+The consequence worth internalising: [`can_subscribe`](vantage_vista::VistaCapabilities) advertises
+an *attempt* to push, not a guarantee of delivery. No shipped backend is lossless, so anything that
+must not miss a change keeps a reconcile path — a slow timer, a refresh on reconnect — rather than
+trusting push alone.
+
+## Adding push to a driver
+
+If you are implementing a backend, the driver-side contract — what you must promise when you
+override `watch_vista`, and when you may honestly advertise the capability — is step 8 of
+[Adding a New Persistence](./new-persistence/step8-vista-integration.md). Start with the capability
+`false`; turning it on the day the feed works is a healthier state than shipping a flag that lies.


### PR DESCRIPTION
Documentation only — no crate touched, so no version bumps. Part of [VAN-115](https://linear.app/vantage-ui/issue/VAN-115).

## Why

We ship 11 datasource kinds and exactly **two** of them can push changes. Nothing told a reader which, so "reactive" read as a blanket promise. The only place the distinction existed was an `admonish` block at the end of the SurrealDB chapter comparing three backends — and after [#363](https://github.com/romaninsh/vantage/pull/363) made Postgres NOTIFY opt-in, even that block was quietly out of date.

## What this adds

A new leaf reference page, `docs4/src/live-data.md`, registered between *Config-Driven Vistas* and *Adding a New Persistence* — it is the bridge between "declare a Vista from YAML" and "implement a driver", and it matches the four existing standalone reference pages in shape.

It covers:

- **Three freshness models** — poll, coarse push, fine push — and what the Dio does with each.
- **A per-backend table**: mechanism, model, and setup required. Only SurrealDB and Postgres push; everything else inherits the trait default and polls.
- **SurrealDB** — fine push with no setup, including the driver's condition-aware re-read (a row leaving a filtered set arrives as a delete).
- **PostgreSQL** — coarse push, and a plain explanation of *why* it has to be opt-in rather than inferred.
- **The consumer contract** — the four promises from #363, and the point that `can_subscribe` advertises an attempt, not a delivery guarantee.

## One thing worth a second look

The page carries a **warning about SurrealDB over HTTP**: `LIVE SELECT` is only implemented by the WebSocket engine (`surreal-client/src/engine.rs:31-37` returns a protocol error by default), so a datasource on an `http://` URL will advertise `can_subscribe: true` and then fail when `watch()` runs. That is the same class of dishonest capability #363 just fixed for Postgres, and arguably wants a code fix rather than only a doc note — I have not touched it here, but it is worth its own ticket.

## Also fixed

The step-9 admonition now says the PostgreSQL row assumes both the trigger *and* `with_notify(true)`, and points forward to the new page. The "reference half takes over" paragraph links to it too.

## Verification

`mdbook build` clean. Also built the way CI does — `sed`-enabling the `rustdoc-links` preprocessor, which is commented out locally — because a broken intra-doc link reds the build without failing on a normal local build. 104 links resolved, 0 unconverted; the new page's `can_subscribe` references land on the versioned `docs.rs/vantage_vista/0.6.17` URLs. `book.toml` restored afterwards.