### PR TITLE
docs4: correct the SurrealDB transport note — http is rejected at connect, not at watch

### DIFF
--- a/docs4/src/live-data.md
+++ b/docs4/src/live-data.md
@@ -33,7 +33,7 @@ re-read *because something happened*, not on the off-chance.
 
 | Backend        | Mechanism                              | Model       | Setup required                          |
 | -------------- | -------------------------------------- | ----------- | --------------------------------------- |
-| SurrealDB      | `LIVE SELECT` over WebSocket           | fine push   | none — but the URL must be `ws://`/`wss://` |
+| SurrealDB      | `LIVE SELECT` over WebSocket           | fine push   | none                                    |
 | PostgreSQL     | `LISTEN/NOTIFY` on `{table}_changed`   | coarse push | a trigger **and** an explicit opt-in    |
 | SQLite         | —                                      | poll        | —                                       |
 | MySQL          | —                                      | poll        | —                                       |
@@ -64,11 +64,11 @@ row that no longer belongs to a filtered set arrives as a delete rather than sil
 real table is watchable the moment you build it; only query-sourced vistas (`rhai:` / `base:`) are
 not.
 
-```admonish warning title="Live queries need a WebSocket connection"
-This is the one case where the capability can overstate what you'll get. `LIVE SELECT` is only
-implemented by the WebSocket engine — point a SurrealDB datasource at an `http://` URL and the Vista
-will still advertise that it can subscribe, then fail when `watch()` actually tries. Use `ws://` or
-`wss://` for anything that watches.
+```admonish note title="Live queries ride the WebSocket connection"
+`LIVE SELECT` needs a transport the server can push frames down, which means WebSocket. That is not a
+trap you can fall into: `SurrealConnection::connect` accepts only `ws://`, `wss://` and `cbor://` and
+rejects anything else outright, so every SurrealDB connection you can actually open is one that can
+carry live queries.
 ```
 
 ## PostgreSQL — coarse push, and why you must ask for it


### PR DESCRIPTION
Fixes an inaccuracy I introduced in [#364](https://github.com/romaninsh/vantage/pull/364). Docs only.

## What was wrong

The Live Data page carried a `warning` claiming that pointing a SurrealDB datasource at an `http://` URL would advertise `can_subscribe: true` and then fail when `watch()` ran — presented as a capability that can lie.

That is not what happens. `SurrealConnection::connect` (`surreal-client/src/connection.rs:310-317`) matches on the URL scheme and accepts only `ws`, `wss` and `cbor`, returning `Unsupported protocol. Use ws://, wss://, or cbor://` for anything else. **You cannot open an HTTP-connected SurrealDB client at all**, so no vista can ever be built on one, and the capability cannot overstate itself by this route.

The misreading came from the trait default on `Engine::register_live` (`surreal-client/src/engine.rs:30-37`), which does return "live queries are not supported by this engine". But its own doc comment describes it as scaffolding for "request/response-only engines (mocks, HTTP)" — and no such production engine exists. The only real engines are `WsCborEngine`, which implements `register_live` (`engines/ws_cbor.rs:367`), and `DebugEngine`, which delegates to its inner engine (`engines/debug.rs:67`).

## Change

The `warning` becomes a `note` that states the actual situation: live queries need WebSocket, and every connection you can open is a WebSocket one, so there is nothing to avoid. The backends table row for SurrealDB now reads `none` under "setup required" rather than carrying a caveat about URL schemes.

## Consequence for VAN-131

[VAN-131](https://linear.app/vantage-ui/issue/VAN-131) was filed on this premise and is not a real defect — closing it. SurrealDB's `can_subscribe: !read_only` is honest as written.

`mdbook build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SurrealDB live-query setup requirements.
  * Documented that `LIVE SELECT` uses WebSocket transport.
  * Clarified the supported connection URL schemes and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->