### PR TITLE
diorama: facade Vista honours condition/order/search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama-aggregate"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.1 — 2026-07-26
+
+- Pins diorama 0.8.4, whose facade Vista now honours condition / order / search.
+- Adds coverage for many independent aggregations over one source Dio: several
+  values plus a derived Dio, across two lenses, all reacting to one change, with
+  one dropped mid-run to show the survivors keep tracking. Each engine holds its
+  own bus receiver and its own cache table, so aggregates compose over a Dio the
+  same way views do.
+
 ## 0.6.0 — 2026-07-26
 
 First release. Reactive client-side aggregation over a Diorama: derive a count,

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama-aggregate"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Reactive client-side aggregation over a Vantage Diorama"
@@ -14,7 +14,7 @@ vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.6.17", path = "../vantage-vista" }
-vantage-diorama = { version = "0.8.3", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.8.4", path = "../vantage-diorama" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/tests/multi_aggregate.rs
+++ b/vantage-diorama-aggregate/tests/multi_aggregate.rs
@@ -1,0 +1,84 @@
+mod support;
+use ciborium::Value as CborValue;
+use support::{DEBOUNCE, int, master, record, settle, source, text};
+use vantage_core::Result;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_diorama_aggregate::{AggregateLens, Count, CountWhere, GroupBy, Reduce, Sum};
+use vantage_types::Record;
+use vantage_vista::Column;
+
+fn i(v: Option<CborValue>) -> Option<i64> {
+    match v {
+        Some(CborValue::Integer(x)) => Some(i128::from(x) as i64),
+        _ => None,
+    }
+}
+
+#[tokio::test]
+async fn many_independent_aggregations_over_one_dio() -> Result<()> {
+    let shell = master(&[("status", "String"), ("amount", "i64")]);
+    shell.set_record(
+        "a",
+        record(&[("status", text("open")), ("amount", int(10))]),
+    );
+    shell.set_record("b", record(&[("status", text("done")), ("amount", int(5))]));
+    let src = source(shell.clone()).await;
+
+    // Two different lenses AND two aggregates on one lens, all on one Dio.
+    let l1 = AggregateLens::in_memory().debounce(DEBOUNCE).build()?;
+    let l2 = AggregateLens::in_memory().debounce(DEBOUNCE).build()?;
+
+    let count = l1.value(&src, "count", Count::rows()).await?;
+    let total = l1.value(&src, "total", Sum::new("amount")).await?;
+    let open = l2
+        .value(&src, "open", CountWhere::new().eq("status", text("open")))
+        .await?;
+    let group = l2
+        .derive(
+            &src,
+            "byst",
+            GroupBy::column(
+                "status",
+                Reduce::new(vec![Column::new("n", "i64")], |_k, rows| {
+                    let mut o = Record::new();
+                    o.insert("n".into(), CborValue::Integer((rows.len() as i64).into()));
+                    o
+                }),
+            ),
+        )
+        .await?;
+    settle().await;
+
+    assert_eq!(i(count.value()), Some(2), "count");
+    assert_eq!(i(total.value()), Some(15), "sum");
+    assert_eq!(i(open.value()), Some(1), "filtered count");
+    assert_eq!(group.vista().list_values().await?.len(), 2, "groups");
+
+    // One source change must move all four, independently.
+    shell.set_record("c", record(&[("status", text("open")), ("amount", int(7))]));
+    src.refresh().await?;
+    settle().await;
+
+    assert_eq!(i(count.value()), Some(3), "count after");
+    assert_eq!(i(total.value()), Some(22), "sum after");
+    assert_eq!(i(open.value()), Some(2), "filtered after");
+    let g = group.vista().list_values().await?;
+    assert_eq!(
+        g.get("open").and_then(|r| r.get("n")),
+        Some(&int(2)),
+        "group after"
+    );
+
+    // Dropping one must not disturb the others.
+    drop(total);
+    shell.set_record("d", record(&[("status", text("done")), ("amount", int(1))]));
+    src.refresh().await?;
+    settle().await;
+    assert_eq!(
+        i(count.value()),
+        Some(4),
+        "survivor still tracking after a sibling dropped"
+    );
+    assert_eq!(i(open.value()), Some(2), "other survivor unaffected");
+    Ok(())
+}

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 0.8.4 — 2026-07-26
+
+**The facade Vista honours condition, order and search**
+
+- `dio.vista()` now implements `add_eq_condition`, `add_order` / `clear_orders`
+  and `add_search` / `clear_search`. It previously advertised `can_order` and
+  `can_search` — inherited verbatim from the master — while implementing
+  neither, so a caller that trusted the flags got `Unimplemented`. The flags are
+  now unconditionally true, and honest: the facade pushes a clause into the
+  master when the master can answer it, and answers it over the cache when it
+  cannot.
+
+- **Clauses are tried, not predicted.** A capability flag describes a driver,
+  not whether it accepts one particular column, so each clause is offered to a
+  private clone of the master and whatever it refuses is applied locally. A
+  pushed-down clause is answered over the master's whole set — authoritative,
+  rather than covering only what the cache happens to hold.
+
+- **An augmented Dio always answers from its cache.** Augment columns exist only
+  there, so reading a narrowed master would both drop their values from the rows
+  and make a filter on one match nothing.
+
+- **Every facade column is flagged `ORDERABLE` and `SEARCHABLE`.**
+  `Vista::add_order` refuses a column without the flag, and drivers set it only
+  for columns their own engine can sort — CSV sets it for none. Refusing on that
+  basis would deny a sort the Dio can perfectly well perform over its cache.
+
+- Narrowing is **per handle**: two facades over one Dio sort independently, and
+  `clone_shell` carries the narrowing without sharing it. An unnarrowed facade
+  is unchanged — still a plain cache read.
+
+- Local ordering keeps absent values last in both directions, compares numbers
+  numerically across the integer/float boundary, and breaks ties on id so the
+  same rows always come back in the same order. Conditions resolve dotted paths
+  into nested values.
+
 ## 0.8.3 — 2026-07-26
 
 - **`CacheBackend::list_tables` / `drop_table`** — enumerate the tables inside a

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/impls/table_shell.rs
+++ b/vantage-diorama/src/dio/impls/table_shell.rs
@@ -2,8 +2,9 @@ use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet;
 use vantage_types::Record;
-use vantage_vista::{Column, Reference, TableShell, Vista, VistaCapabilities};
+use vantage_vista::{Column, Reference, SortDirection, TableShell, Vista, VistaCapabilities};
 
 use crate::dio::shell::DioShell;
 use crate::ops::ChangeFlash;
@@ -38,7 +39,7 @@ impl TableShell for DioShell {
         &self,
         _vista: &Vista,
     ) -> Result<IndexMap<String, Record<CborValue>>> {
-        self.dio.cache.list_values().await
+        self.read().await
     }
 
     async fn get_vista_value(
@@ -46,7 +47,13 @@ impl TableShell for DioShell {
         _vista: &Vista,
         id: &String,
     ) -> Result<Option<Record<CborValue>>> {
-        let Some(row) = self.dio.cache.get_value(id).await? else {
+        // A narrowed handle is a smaller set: an id outside it is not found,
+        // rather than found and silently outside the filter.
+        let Some(row) = (if self.query.is_empty() {
+            self.dio.cache.get_value(id).await?
+        } else {
+            self.read().await?.shift_remove(id)
+        }) else {
             return Ok(None);
         };
         let mut rows = IndexMap::from([(id.clone(), row)]);
@@ -58,7 +65,7 @@ impl TableShell for DioShell {
         &self,
         _vista: &Vista,
     ) -> Result<Option<(String, Record<CborValue>)>> {
-        let rows = self.dio.cache.list_values().await?;
+        let rows = self.read().await?;
         let Some((id, row)) = rows.into_iter().next() else {
             return Ok(None);
         };
@@ -68,7 +75,10 @@ impl TableShell for DioShell {
     }
 
     async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
-        self.dio.cache.count().await
+        if self.query.is_empty() {
+            return self.dio.cache.count().await;
+        }
+        Ok(self.read().await?.len() as i64)
     }
 
     async fn fetch_window(
@@ -77,11 +87,58 @@ impl TableShell for DioShell {
         offset: usize,
         limit: usize,
     ) -> Result<Vec<(String, Record<CborValue>)>> {
-        let all = self.dio.cache.list_values().await?;
+        let all = self.read().await?;
         let mut rows: IndexMap<String, Record<CborValue>> =
             all.into_iter().skip(offset).take(limit).collect();
         self.hydrate(&mut rows).await?;
         Ok(rows.into_iter().collect())
+    }
+
+    // ---- Narrowing -----------------------------------------------------------
+    //
+    // Recorded here and routed at read time (see `DioShell::plan`): pushed into
+    // the master when it can answer them, applied over the cache when it
+    // cannot. Accrete/replace semantics match `Vista`'s: conditions accumulate,
+    // order and search replace.
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        self.query
+            .conditions
+            .push((field.to_string(), value.clone()));
+        Ok(())
+    }
+
+    fn add_order(&mut self, field: &str, dir: SortDirection) -> Result<()> {
+        self.query.order = Some((field.to_string(), dir));
+        Ok(())
+    }
+
+    fn clear_orders(&mut self) -> Result<()> {
+        self.query.order = None;
+        Ok(())
+    }
+
+    fn add_search(&mut self, text: &str) -> Result<()> {
+        self.query.search = Some(text.to_string());
+        Ok(())
+    }
+
+    fn clear_search(&mut self) -> Result<()> {
+        self.query.search = None;
+        Ok(())
+    }
+
+    /// Clones carry the narrowing but stay independent, so narrowing a derived
+    /// handle never disturbs the one it came from.
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        Some(Box::new(DioShell {
+            dio: self.dio.clone(),
+            capabilities: self.capabilities.clone(),
+            columns: self.columns.clone(),
+            references: self.references.clone(),
+            id_column: self.id_column.clone(),
+            query: self.query.clone(),
+        }))
     }
 
     // ---- Writes — enqueue + return synthesized record ------------------------
@@ -150,6 +207,60 @@ impl TableShell for DioShell {
 }
 
 impl DioShell {
+    /// The rows this handle sees, narrowing included.
+    ///
+    /// An unnarrowed handle reads the cache, exactly as before. A narrowed one
+    /// asks the master for whatever the master can answer — that result is
+    /// authoritative over the whole set, not over whatever the cache happens to
+    /// hold — and applies the rest here. See [`DioShell::plan`] for the routing.
+    async fn read(&self) -> Result<IndexMap<String, Record<CborValue>>> {
+        let (narrowed, local) = self.plan();
+        let mut rows = match narrowed {
+            Some(master) => master.list_values().await?,
+            None => self.dio.cache.list_values().await?,
+        };
+
+        rows.retain(|_, row| {
+            local
+                .conditions
+                .iter()
+                .all(|(field, expected)| record_get(row, field) == Some(expected))
+        });
+        if let Some(text) = &local.search {
+            let needle = text.to_lowercase();
+            rows.retain(|_, row| {
+                row.values().any(|value| match value {
+                    CborValue::Text(text) => text.to_lowercase().contains(&needle),
+                    _ => false,
+                })
+            });
+        }
+        if let Some((column, direction)) = &local.order {
+            let descending = matches!(direction, SortDirection::Descending);
+            let mut ordered: Vec<(String, Record<CborValue>)> = rows.into_iter().collect();
+            ordered.sort_by(|(a_id, a), (b_id, b)| {
+                // Absent values last in both directions, and ties broken on id
+                // so the same rows always come back in the same order.
+                let ordering = match (record_get(a, column), record_get(b, column)) {
+                    (None, None) => std::cmp::Ordering::Equal,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (Some(left), Some(right)) => {
+                        let ordering = cbor_cmp(left, right);
+                        if descending {
+                            ordering.reverse()
+                        } else {
+                            ordering
+                        }
+                    }
+                };
+                ordering.then_with(|| a_id.cmp(b_id))
+            });
+            rows = ordered.into_iter().collect();
+        }
+        Ok(rows)
+    }
+
     /// Facade reads hydrate what they return: any row still missing its
     /// augment columns runs the Dio's detail pass before the read
     /// resolves. No augmentations configured → no-op.
@@ -175,6 +286,47 @@ impl DioShell {
             })
             .await
             .map_err(|e| error!("Dio write queue closed", detail = e.to_string()))
+    }
+}
+
+/// Resolve a column, descending dotted paths into nested CBOR maps so a
+/// belongs-to leaf (`client.name`) narrows like any other column.
+fn record_get<'a>(record: &'a Record<CborValue>, path: &str) -> Option<&'a CborValue> {
+    if let Some(value) = record.get(path) {
+        return Some(value);
+    }
+    let mut segments = path.split('.');
+    let mut current = record.get(segments.next()?)?;
+    for segment in segments {
+        let CborValue::Map(entries) = current else {
+            return None;
+        };
+        current = entries.iter().find_map(|(key, value)| match key {
+            CborValue::Text(name) if name == segment => Some(value),
+            _ => None,
+        })?;
+    }
+    Some(current)
+}
+
+/// Numbers compare numerically across the integer/float boundary — never by
+/// their debug rendering, which ranks `657.96` above `1826.19`. `NaN` compares
+/// equal rather than panicking the sort.
+fn cbor_cmp(a: &CborValue, b: &CborValue) -> std::cmp::Ordering {
+    fn number(value: &CborValue) -> Option<f64> {
+        match value {
+            CborValue::Integer(i) => Some(i128::from(*i) as f64),
+            CborValue::Float(f) => Some(*f),
+            _ => None,
+        }
+    }
+    match (a, b) {
+        (CborValue::Text(l), CborValue::Text(r)) => l.cmp(r),
+        (CborValue::Bool(l), CborValue::Bool(r)) => l.cmp(r),
+        _ => match (number(a), number(b)) {
+            (Some(l), Some(r)) => l.partial_cmp(&r).unwrap_or(std::cmp::Ordering::Equal),
+            _ => std::cmp::Ordering::Equal,
+        },
     }
 }
 

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -1,9 +1,28 @@
 use std::sync::Arc;
 
+use ciborium::Value as CborValue;
 use indexmap::IndexMap;
-use vantage_vista::{Column, Reference, VistaCapabilities};
+use vantage_vista::{Column, Reference, SortDirection, Vista, VistaCapabilities, flags};
 
 use super::DioInner;
+
+/// Narrowing applied to a facade handle.
+///
+/// Held whole rather than pre-split, because whether a clause can be pushed
+/// into the master is decided at read time by *trying* it — capability flags
+/// describe a driver in general, not whether it accepts one particular column.
+#[derive(Default, Clone)]
+pub(crate) struct FacadeQuery {
+    pub(crate) conditions: Vec<(String, CborValue)>,
+    pub(crate) order: Option<(String, SortDirection)>,
+    pub(crate) search: Option<String>,
+}
+
+impl FacadeQuery {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.conditions.is_empty() && self.order.is_none() && self.search.is_none()
+    }
+}
 
 /// `TableShell` impl that backs the Vista returned by `Dio::vista()`.
 ///
@@ -19,13 +38,35 @@ pub struct DioShell {
     pub(crate) columns: IndexMap<String, Column>,
     pub(crate) references: IndexMap<String, Reference>,
     pub(crate) id_column: Option<String>,
+    /// This handle's narrowing. Per-handle, and cloned rather than shared, so
+    /// narrowing one facade never reorders another's view of the same Dio.
+    pub(crate) query: FacadeQuery,
 }
 
 impl DioShell {
     pub(crate) fn new(dio: Arc<DioInner>) -> Self {
         let master = dio.master.read().unwrap();
         let master_caps = master.capabilities().clone();
-        let columns = master.source.columns().clone();
+        // Every column becomes orderable and searchable, whatever the master
+        // says. `Vista::add_order` refuses a column without the `ORDERABLE`
+        // flag, and most drivers only set it for columns their *engine* can
+        // sort — CSV sets it for none. But the facade can always fall back to
+        // ordering the cache, so refusing here would deny a sort the Dio is
+        // perfectly able to perform.
+        let columns = master
+            .source
+            .columns()
+            .iter()
+            .map(|(name, column)| {
+                let mut column = column.clone();
+                for flag in [flags::ORDERABLE, flags::SEARCHABLE] {
+                    if !column.has_flag(flag) {
+                        column = column.with_flag(flag);
+                    }
+                }
+                (name.clone(), column)
+            })
+            .collect();
         let references = master.source.references().clone();
         let id_column = master.source.id_column().map(str::to_string);
         drop(master);
@@ -44,10 +85,13 @@ impl DioShell {
             can_delete: write_caps.can_delete,
             can_subscribe: true,
             can_invalidate: master_caps.can_invalidate || has_on_event,
-            // Read-side query controls reflect the cache today. Stage 5b
-            // will swap in cache-aware truth for these.
-            can_order: master_caps.can_order,
-            can_search: master_caps.can_search,
+            // Ordering and search are always available: the facade pushes
+            // them into the master when it can answer them, and orders or
+            // searches the cache itself when it cannot. Advertising the
+            // master's flags here used to promise what `DioShell` then
+            // refused — the flag was true and the method `Unimplemented`.
+            can_order: true,
+            can_search: true,
             // Whether operator filters (`!=`, `<`, `in`, …) can be pushed into
             // the master's query. When false the Dio still filters locally over
             // the cache — the caller just can't bake the condition into a
@@ -74,6 +118,71 @@ impl DioShell {
             columns,
             references,
             id_column,
+            query: FacadeQuery::default(),
         }
+    }
+
+    /// Split this handle's narrowing into "the master will do it" and "we do it
+    /// over the cache", and build the narrowed master if anything pushed down.
+    ///
+    /// The rule, in order:
+    ///
+    /// 1. **An augmented Dio always reads its cache.** Augment columns exist
+    ///    only there — the master has never heard of them — so both a filter on
+    ///    one and the *values* of one would be lost by reading the master. Every
+    ///    clause stays local.
+    /// 2. Otherwise each clause is offered to a private clone of the master.
+    ///    Whatever it accepts is answered at the source, authoritatively over
+    ///    the whole set rather than over whatever the cache happens to hold.
+    /// 3. Whatever it refuses is applied here.
+    ///
+    /// Clauses are *tried* rather than predicted from capability flags: a flag
+    /// describes a driver, not whether it accepts one particular column.
+    pub(crate) fn plan(&self) -> (Option<Vista>, FacadeQuery) {
+        if self.query.is_empty() {
+            return (None, FacadeQuery::default());
+        }
+        if self.dio.is_two_pass() {
+            return (None, self.query.clone());
+        }
+
+        let master = self.dio.master.read().unwrap();
+        let Some(shell) = master.source.clone_shell() else {
+            // A master that cannot be cloned cannot be narrowed privately, and
+            // narrowing the shared one would leak into every other reader.
+            return (None, self.query.clone());
+        };
+        let mut narrowed = Vista::new(master.name(), shell);
+        drop(master);
+
+        let mut local = FacadeQuery::default();
+        let mut pushed = false;
+
+        for (field, value) in &self.query.conditions {
+            if narrowed
+                .add_condition_eq(field.clone(), value.clone())
+                .is_ok()
+            {
+                pushed = true;
+            } else {
+                local.conditions.push((field.clone(), value.clone()));
+            }
+        }
+        if let Some((column, direction)) = &self.query.order {
+            if narrowed.add_order(column, *direction).is_ok() {
+                pushed = true;
+            } else {
+                local.order = Some((column.clone(), *direction));
+            }
+        }
+        if let Some(text) = &self.query.search {
+            if narrowed.add_search(text.clone()).is_ok() {
+                pushed = true;
+            } else {
+                local.search = Some(text.clone());
+            }
+        }
+
+        (pushed.then_some(narrowed), local)
     }
 }

--- a/vantage-diorama/tests/facade_query.rs
+++ b/vantage-diorama/tests/facade_query.rs
@@ -1,0 +1,309 @@
+//! Facade narrowing: `dio.vista()` honours condition / order / search,
+//! pushing each into the master where it can answer it and applying it over
+//! the cache where it cannot.
+//!
+//! The CSV cases are the ones that matter most. CSV is the canonical
+//! capability-poor master — it advertises neither `can_order` nor `can_search`,
+//! and its factory flags no column `ORDERABLE` — so every one of these
+//! narrowings is served entirely by the Dio. A mock master with the flags set
+//! by hand would pass while the real thing failed.
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_csv::Csv;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Dio, Lens};
+use vantage_table::table::Table;
+use vantage_types::{EmptyEntity, Record};
+use vantage_vista::{
+    Column, SortDirection, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell,
+};
+
+// ---- fixtures --------------------------------------------------------------
+
+/// `tests/fixtures/products.csv` — Espresso 4, Cappuccino 5, Latte 6,
+/// Flat White 5, in that file order.
+fn csv_master() -> Result<Vista> {
+    let dir = format!("{}/tests/fixtures", env!("CARGO_MANIFEST_DIR"));
+    let csv = Csv::new(dir);
+    let table = Table::<Csv, EmptyEntity>::new("products", csv.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price");
+    csv.vista_factory().from_table(table)
+}
+
+fn row(name: &str, price: i64) -> Record<CborValue> {
+    let mut record = Record::new();
+    record.insert("name".to_string(), CborValue::Text(name.to_string()));
+    record.insert("price".to_string(), CborValue::Integer(price.into()));
+    record
+}
+
+/// A master that *can* order and search server-side, for the push-down side.
+fn capable_master() -> MockShell {
+    MockShell::new()
+        .with_metadata(
+            VistaMetadata::new()
+                .with_column(Column::new("id", "String").with_flag("id"))
+                .with_column(
+                    Column::new("name", "String").with_flag(vantage_vista::flags::ORDERABLE),
+                )
+                .with_column(Column::new("price", "i64").with_flag(vantage_vista::flags::ORDERABLE))
+                .with_id_column("id"),
+        )
+        .with_capabilities(VistaCapabilities {
+            can_order: true,
+            can_search: true,
+            ..Default::default()
+        })
+}
+
+async fn eager_dio(master: Vista) -> Result<Dio> {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("lens"),
+    );
+    lens.make_dio(master).await
+}
+
+fn names(rows: &IndexMap<String, Record<CborValue>>) -> Vec<String> {
+    rows.values()
+        .filter_map(|r| match r.get("name") {
+            Some(CborValue::Text(t)) => Some(t.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// ---- CSV: a master that can do none of this --------------------------------
+
+/// Sorting a CSV-backed Dio. The CSV driver cannot order, and flags no column
+/// orderable — before this, `add_order` was refused outright.
+#[tokio::test]
+async fn csv_sorts_over_the_cache() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+    assert!(
+        !dio.master().capabilities().can_order,
+        "the CSV master genuinely cannot order — that is the point of this test",
+    );
+
+    let mut by_name = dio.vista();
+    by_name.add_order("name", SortDirection::Ascending)?;
+    assert_eq!(
+        names(&by_name.list_values().await?),
+        vec!["Cappuccino", "Espresso", "Flat White", "Latte"],
+    );
+
+    let mut by_price = dio.vista();
+    by_price.add_order("price", SortDirection::Descending)?;
+    assert_eq!(
+        names(&by_price.list_values().await?),
+        // 6, then the two 5s (tie broken on id: p2 before p4), then 4.
+        vec!["Latte", "Cappuccino", "Flat White", "Espresso"],
+    );
+    Ok(())
+}
+
+/// Prices are integers; ordering them must be numeric. A comparison that fell
+/// through to a debug-string compare would rank `10` below `4`.
+#[tokio::test]
+async fn csv_sorts_numbers_numerically() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+    // A double-digit price alongside the single-digit fixture rows.
+    dio.patched("p9", row("Magnum", 10)).await?;
+
+    let mut by_price = dio.vista();
+    by_price.add_order("price", SortDirection::Ascending)?;
+    assert_eq!(
+        names(&by_price.list_values().await?)
+            .last()
+            .map(String::as_str),
+        Some("Magnum"),
+        "10 must sort above 6, not below 4",
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn csv_filters_and_searches_over_the_cache() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+
+    let mut fivers = dio.vista();
+    fivers.add_condition_eq("price", CborValue::Integer(5.into()))?;
+    let mut got = names(&fivers.list_values().await?);
+    got.sort();
+    assert_eq!(got, vec!["Cappuccino", "Flat White"]);
+    assert_eq!(fivers.get_count().await?, 2, "count reflects the narrowing");
+
+    let mut searched = dio.vista();
+    searched.add_search("latte")?;
+    assert_eq!(names(&searched.list_values().await?), vec!["Latte"]);
+    Ok(())
+}
+
+/// Conditions accrete and combine with an order, all locally.
+#[tokio::test]
+async fn csv_combines_condition_and_order() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+    let mut narrowed = dio.vista();
+    narrowed.add_condition_eq("price", CborValue::Integer(5.into()))?;
+    narrowed.add_order("name", SortDirection::Descending)?;
+    assert_eq!(
+        names(&narrowed.list_values().await?),
+        vec!["Flat White", "Cappuccino"],
+    );
+    Ok(())
+}
+
+/// A narrowed handle is a smaller set: an id outside it is simply not there.
+#[tokio::test]
+async fn csv_narrowing_hides_rows_from_get() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+    let mut cheap = dio.vista();
+    cheap.add_condition_eq("price", CborValue::Integer(4.into()))?;
+
+    assert!(cheap.get_value("p1").await?.is_some(), "Espresso is 4");
+    assert!(
+        cheap.get_value("p3").await?.is_none(),
+        "Latte is 6 — outside the set"
+    );
+    Ok(())
+}
+
+// ---- the capability contract -----------------------------------------------
+
+/// The regression this change exists for: the facade advertised `can_order` /
+/// `can_search` and then refused them with `Unimplemented`.
+#[tokio::test]
+async fn the_facade_honours_the_capabilities_it_advertises() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+    let facade = dio.vista();
+    assert!(facade.capabilities().can_order);
+    assert!(facade.capabilities().can_search);
+
+    let mut facade = facade;
+    facade.add_order("name", SortDirection::Ascending)?;
+    facade.add_search("esp")?;
+    assert_eq!(names(&facade.list_values().await?), vec!["Espresso"]);
+    Ok(())
+}
+
+// ---- push-down side ---------------------------------------------------------
+
+/// The same calls against a master that *can* order and search are answered at
+/// the source instead. Observable because the master holds a row the cache
+/// never received.
+#[tokio::test]
+async fn a_capable_master_answers_the_narrowing_itself() -> Result<()> {
+    let shell = capable_master();
+    shell.set_record("a", row("gamma", 3));
+    shell.set_record("b", row("alpha", 1));
+    let dio = eager_dio(Vista::new("items", Box::new(shell.clone()))).await?;
+
+    // Appears upstream only — the cache does not have it.
+    shell.set_record("c", row("beta", 2));
+
+    let mut ordered = dio.vista();
+    ordered.add_order("name", SortDirection::Ascending)?;
+    assert_eq!(
+        names(&ordered.list_values().await?),
+        vec!["alpha", "beta", "gamma"],
+        "a pushed-down order is answered over the master's whole set",
+    );
+
+    assert_eq!(
+        dio.vista().list_values().await?.len(),
+        2,
+        "while an unnarrowed read still comes from the cache",
+    );
+    Ok(())
+}
+
+// ---- independence -----------------------------------------------------------
+
+/// Narrowing is per-handle. Two facades over one Dio must not disturb each
+/// other — the shared-mutation trap an in-place setter falls into.
+#[tokio::test]
+async fn two_facades_narrow_independently() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+
+    let mut ascending = dio.vista();
+    ascending.add_order("name", SortDirection::Ascending)?;
+    let mut descending = dio.vista();
+    descending.add_order("name", SortDirection::Descending)?;
+
+    assert_eq!(
+        names(&ascending.list_values().await?)
+            .first()
+            .map(String::as_str),
+        Some("Cappuccino")
+    );
+    assert_eq!(
+        names(&descending.list_values().await?)
+            .first()
+            .map(String::as_str),
+        Some("Latte")
+    );
+    assert_eq!(
+        dio.vista().list_values().await?.len(),
+        4,
+        "a fresh facade is unnarrowed"
+    );
+    Ok(())
+}
+
+/// `clone_shell` carries the narrowing but stays independent.
+#[tokio::test]
+async fn a_cloned_facade_inherits_but_does_not_share() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+
+    let mut base = dio.vista();
+    base.add_condition_eq("price", CborValue::Integer(5.into()))?;
+    let mut cloned = Vista::new(
+        "products",
+        base.source.clone_shell().expect("dio shells clone"),
+    );
+    cloned.add_order("name", SortDirection::Descending)?;
+
+    assert_eq!(
+        names(&cloned.list_values().await?),
+        vec!["Flat White", "Cappuccino"],
+        "the clone inherited the filter and added its own order",
+    );
+    assert_eq!(
+        base.list_values().await?.len(),
+        2,
+        "the base kept its own (unordered) view"
+    );
+    Ok(())
+}
+
+/// An unnarrowed facade is untouched: still a plain cache read.
+#[tokio::test]
+async fn an_unnarrowed_facade_reads_the_cache() -> Result<()> {
+    let shell = capable_master();
+    shell.set_record("a", row("gamma", 3));
+    let dio = eager_dio(Vista::new("items", Box::new(shell.clone()))).await?;
+
+    shell.set_record("z", row("zeta", 9));
+    assert_eq!(
+        dio.vista().list_values().await?.len(),
+        1,
+        "the cache-first contract is unchanged for an unnarrowed handle",
+    );
+    Ok(())
+}


### PR DESCRIPTION
`dio.vista()` advertised `can_order` and `can_search` — inherited verbatim from the master — while implementing neither. A caller that trusted the flags got `Unimplemented`:

```
FACADE can_order=true
FACADE add_order -> Err("'can_order' is advertised as VistaCapability for 'DioShell'
                         but implementation for 'add_order' is missing")
```

This implements them, with the routing rule: **prefer the master; fall back to the cache.**

## How clauses are routed

Each clause is offered to a *private clone* of the master; whatever it refuses is applied over the cache. Clauses are **tried, not predicted** — a capability flag describes a driver, not whether it accepts one particular column, and this codebase has already been bitten by flags that lie.

A pushed-down clause is answered over the master's whole set, so it is authoritative rather than covering only what the cache happens to hold. There is a test for this: the master gains a row the cache never received, and a pushed-down order returns it.

**An augmented Dio always answers from its cache.** Augment columns exist only there, so reading a narrowed master would both drop their values from the returned rows and make a filter on one match nothing.

## Every facade column becomes ORDERABLE / SEARCHABLE

`Vista::add_order` refuses a column without the `ORDERABLE` flag, and drivers set it only for columns their own *engine* can sort — CSV sets it for none. Refusing on that basis would deny a sort the Dio can perfectly well perform over its cache.

This is the part a mock-based test would have missed. I originally wrote the suite against `MockShell` with the flags set by hand; it passed while the real thing would have failed at the `add_order` guard. The CSV cases exist to prevent that.

## Testing

`tests/facade_query.rs`, 10 tests. The CSV ones carry the weight — CSV advertises neither capability and flags no column orderable, so every narrowing there is served entirely by the Dio:

- sorting by text and by number, ascending and descending, over `tests/fixtures/products.csv`
- numeric ordering (a `10` must sort above `6`, not below `4` — the 0.6.13 debug-string regression in miniature)
- eq-condition, search, and the two combined
- a narrowed handle hides rows from `get_value` — it is a smaller set, not a filtered view
- push-down verified against a capable master, observable via a row only the master has
- two facades over one Dio sort independently; `clone_shell` inherits the narrowing without sharing it
- an unnarrowed facade still reads the cache and does not see upstream rows

Local ordering keeps absent values last in both directions and breaks ties on id, so repeated reads are byte-identical. Conditions resolve dotted paths into nested values.

Full diorama suite green (31 binaries), `cargo fmt`, and `clippy --workspace --all-targets -- -D warnings` on 1.97.0.

## Also here

`vantage-diorama-aggregate` 0.6.1 — pins 0.8.4, plus a test confirming many independent aggregations over one source Dio (several values and a derived Dio across two lenses, one dropped mid-run to show the survivors keep tracking).

## Scope

No vantage-ui changes.

Worth being explicit that this does **not** by itself fix grid sorting: the grid goes `perform_sort` → `scenery.set_sort()` → `TableScenery`'s own machinery, which never touches `DioShell`. This makes the facade honest and gives ordering a single place to live; consolidating the scenery onto it is separate work. The load-bearing UI bug remains the two-pass `set_sort` no-op — `local_refine` is fixed at open and `resort` never applies the client order — which is next.