### PR TITLE
diorama: set_sort and set_search take effect on a two-pass scenery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -28,6 +28,13 @@
 - No behaviour change for single-pass sceneries, for two-pass views opened with
   a query, or for `titles_only` pickers (which keep raw list order).
 
+- The existing `sort_change_restarts_augmentation_without_scrolling` test had
+  encoded the defect: after sorting by `branch` ascending it asserted the row
+  order the fixture lists in, which is only what you see when the sort is
+  discarded. It now expects the sorted order, and waits on that order rather
+  than on the row merely being `Fresh` — the pre-resort map already satisfies
+  the latter, which is how the stale expectation went unnoticed.
+
 ## 0.8.5 — 2026-07-26
 
 Review fixes for the 0.8.0 draft-servo release (never shipped as 0.8.1),

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.8.5 — 2026-07-26
+
+**`set_sort` and `set_search` work on a two-pass scenery**
+
+- On an augmented (two-pass) table, changing the sort on a live scenery did
+  nothing. A grid opened without a sort could never be sorted at all; one opened
+  *with* a sort picked up a change only if some unrelated `RecordChanged`
+  happened to fire afterwards. `set_search` had the same defect. Header clicks
+  and a page's `default_sort` both go through this path, so on an augmented
+  table neither had any effect.
+
+  Two causes, both fixed:
+
+  - `resort` — the handler for a live `set_sort` — rebuilt the visible map from
+    the query index in the index's own order, and never called
+    `reseed_filtered`, which is the only code that applies a condition, sort or
+    search over the cache. It now does, for a refined view.
+
+  - `local_refine` was a `bool` computed once when the scenery opened and never
+    revisited, so a view opened with no query stayed "unrefined" for life — and
+    the two other call sites that would have applied the new order are gated on
+    it. It is now derived from the query as it stands, and the stored field is
+    gone. A value that is a function of mutable state should not have been
+    cached beside it.
+
+- No behaviour change for single-pass sceneries, for two-pass views opened with
+  a query, or for `titles_only` pickers (which keep raw list order).
+
 ## 0.8.4 — 2026-07-26
 
 **The facade Vista honours condition, order and search**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -226,18 +226,10 @@ impl TableSceneryBuilder {
         // keyed by the master Vista's index_key over the scenery's conditions +
         // sort, so reopening the same variant reuses the already-built index.
         let two_pass = dio.is_two_pass();
-        // Two-pass can't push conditions/sort to its list pass, so any
-        // condition/sort means the visible set must be refined locally over the
-        // cache (this is also the only way an augmented-column filter can work —
-        // the column exists only after hydration). A picker (`titles_only`) keeps
-        // raw list order — it never hydrates, so it can't evaluate augmented
-        // predicates anyway.
-        let local_refine = two_pass
-            && !titles_only
-            && (!conditions.is_empty()
-                || !op_conditions.is_empty()
-                || sort.is_some()
-                || search.is_some());
+        // Whether the visible set is refined locally is derived from the query
+        // as it stands — see `TableSceneryState::local_refine`. It is not
+        // captured here: `set_sort` / `set_search` change the answer, and a
+        // value frozen at open made a later sort a silent no-op.
         let index = if two_pass {
             let vista_sort = sort.as_ref().map(|(col, dir)| {
                 let dir = match dir {
@@ -292,7 +284,6 @@ impl TableSceneryBuilder {
             load_push_count: AtomicUsize::new(0),
             master_capabilities,
             two_pass,
-            local_refine,
             titles_only,
             demand,
             index: RwLock::new(index),
@@ -325,7 +316,7 @@ impl TableSceneryBuilder {
             // Locally-refined views filter/sort the just-seeded rows over the
             // cache. With an augmented-column condition this yields an empty set
             // until hydration confirms matches.
-            if state.local_refine {
+            if state.local_refine() {
                 super::two_pass::reseed_filtered(&state).await;
                 state.bump_generation();
             }

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -172,7 +172,7 @@ impl TableScenery for TableSceneryImpl {
     fn row_count(&self) -> usize {
         // A locally-refined view's visible map is authoritative — the index may
         // hold more ids than match the filter.
-        if self.inner.local_refine {
+        if self.inner.local_refine() {
             return self.inner.rows.read().unwrap().len();
         }
         if let Some(index) = self.inner.index() {
@@ -203,7 +203,7 @@ impl TableScenery for TableSceneryImpl {
     fn has_more(&self) -> bool {
         // A locally-refined view materializes its whole visible set from the
         // (already-listed) index, so there is no further page to ask for.
-        if self.inner.local_refine {
+        if self.inner.local_refine() {
             return false;
         }
         // Two-pass / sequential no-total: more pages exist until the list pass
@@ -220,7 +220,7 @@ impl TableScenery for TableSceneryImpl {
     }
 
     fn estimated_total(&self) -> Option<usize> {
-        if self.inner.local_refine {
+        if self.inner.local_refine() {
             return Some(self.inner.rows.read().unwrap().len());
         }
         // Two-pass: the running index length is the best estimate; it grows as

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -88,14 +88,6 @@ pub(crate) struct TableSceneryState {
     // the legacy single-pass path.
     /// Whether this scenery drives two-pass (list + detail) loading.
     pub(crate) two_pass: bool,
-    /// Two-pass only: whether the visible set is *locally refined* — its rows are
-    /// filtered/sorted over the cache rather than served in raw index order.
-    /// Engaged when the query carries conditions/sort the list pass can't push to
-    /// the master (today, any condition/sort in two-pass — augmented columns in
-    /// particular, which only exist after hydration). When set, the visible
-    /// `rows` map is authoritative for `row_count` (the index may hold more ids
-    /// than match the filter).
-    pub(crate) local_refine: bool,
     /// Dropdown / autocomplete projection: serve the cheap list columns and
     /// **skip the detail pass** even on a two-pass table. The list pass still
     /// runs (rows carry id + title columns); per-row hydration never fires.
@@ -160,6 +152,28 @@ impl TableSceneryState {
         let changed = *guard != total;
         *guard = total;
         changed
+    }
+
+    /// Whether the visible set is *locally refined* — filtered and ordered over
+    /// the cache rather than served in the index's own order.
+    ///
+    /// Engaged when a two-pass view carries any condition, sort or search: the
+    /// list pass can't push those down (and an augmented column doesn't exist
+    /// until a row hydrates), so the visible map — not the index — is
+    /// authoritative for `row_count`.
+    ///
+    /// **Derived, never stored.** It used to be a `bool` computed once in the
+    /// builder, which made `set_sort` on a view opened without one a permanent
+    /// no-op: the flag stayed `false`, so every path that would have applied
+    /// the new order skipped it.
+    pub(crate) fn local_refine(&self) -> bool {
+        if !self.two_pass || self.titles_only {
+            return false;
+        }
+        !self.conditions.read().unwrap().is_empty()
+            || !self.op_conditions.read().unwrap().is_empty()
+            || self.sort.read().unwrap().is_some()
+            || self.search.read().unwrap().is_some()
     }
 
     /// Current two-pass index (cloned `Arc`), or `None` in single-pass mode.

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -341,32 +341,41 @@ pub(crate) async fn resort(state: Arc<TableSceneryState>) {
         run_list_page(state.clone()).await;
     }
 
-    // 3. Rebuild the sparse map from the index in one atomic swap, so the new
-    //    order replaces the old in a single write — the grid never blanks to an
-    //    empty map mid-reorder. Each row shows `Fresh`/`Incomplete` per its
-    //    cached status.
-    let ids = new_index.ids();
-    let mut rows = std::collections::BTreeMap::new();
-    let mut id_to_idx = std::collections::HashMap::new();
-    for (i, id) in ids.iter().enumerate() {
-        let Some((rec, status)) = dio_inner
-            .cache
-            .get_value_with_status(id)
-            .await
-            .ok()
-            .flatten()
-        else {
-            continue;
-        };
-        let enriched = match status {
-            CacheStatus::Complete => EnrichedRecord::fresh(rec),
-            CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
-        };
-        rows.insert(i, Arc::new(enriched));
-        id_to_idx.insert(id.clone(), i);
+    // 3. Rebuild the sparse map in one atomic swap, so the new order replaces
+    //    the old in a single write — the grid never blanks mid-reorder. Each row
+    //    shows `Fresh`/`Incomplete` per its cached status.
+    //
+    //    A refined view is rebuilt by `reseed_filtered`, which is the only code
+    //    that applies the condition/sort/search over the cache. Rebuilding from
+    //    the index directly — as this used to do unconditionally — presented the
+    //    index's own order and silently dropped the sort the caller had just
+    //    asked for.
+    if state.local_refine() {
+        reseed_filtered(&state).await;
+    } else {
+        let ids = new_index.ids();
+        let mut rows = std::collections::BTreeMap::new();
+        let mut id_to_idx = std::collections::HashMap::new();
+        for (i, id) in ids.iter().enumerate() {
+            let Some((rec, status)) = dio_inner
+                .cache
+                .get_value_with_status(id)
+                .await
+                .ok()
+                .flatten()
+            else {
+                continue;
+            };
+            let enriched = match status {
+                CacheStatus::Complete => EnrichedRecord::fresh(rec),
+                CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
+            };
+            rows.insert(i, Arc::new(enriched));
+            id_to_idx.insert(id.clone(), i);
+        }
+        *state.rows.write().unwrap() = rows;
+        *state.id_to_idx.write().unwrap() = id_to_idx;
     }
-    *state.rows.write().unwrap() = rows;
-    *state.id_to_idx.write().unwrap() = id_to_idx;
     // Ids enqueued for the previous order stay queued — the scheduler's
     // settled recheck makes any that no longer need hydration free no-ops.
     state.bump_generation();
@@ -391,7 +400,7 @@ pub(crate) async fn update_row_from_cache(state: &Arc<TableSceneryState>, id: &s
     // visible-map lookup below can't gate it: a matching row that wasn't
     // visible yet has no slot. Re-derive the whole visible set whenever the
     // id belongs to this view's candidate index at all.
-    if state.local_refine {
+    if state.local_refine() {
         if !state.index().map(|ix| ix.contains(id)).unwrap_or(false) {
             return;
         }
@@ -516,7 +525,7 @@ pub(crate) async fn refresh_index(state: &Arc<TableSceneryState>) {
     state.set_index(Some(fresh));
     *state.rows.write().unwrap() = rows;
     *state.id_to_idx.write().unwrap() = id_to_idx;
-    if state.local_refine {
+    if state.local_refine() {
         reseed_filtered(state).await;
     }
     state.bump_generation();
@@ -561,7 +570,7 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     // column). A condition/sort on a *native* (list-pass) column needs no extra
     // hydration — `reseed_filtered` already orders/filters the cheap cache rows —
     // so it keeps normal viewport-driven hydration.
-    let range = if state.local_refine && references_augmented_column(&state, &dio_inner) {
+    let range = if state.local_refine() && references_augmented_column(&state, &dio_inner) {
         0..index.len()
     } else {
         range
@@ -593,7 +602,7 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
         // SIBLING scenery — whose run_list_page seeded only its own map.
         // The viewport pass reads the cache row anyway; putting it on screen
         // is free. (Locally-refined views own their map wholesale — skip.)
-        if !state.local_refine
+        if !state.local_refine()
             && let Some((row, status)) = &cached
             && !state.rows.read().unwrap().contains_key(&idx)
         {
@@ -631,7 +640,7 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
 /// stamp — their visible set is re-derived wholesale, same as the old inline
 /// pass.
 pub(crate) fn mark_detail_failed(state: &Arc<TableSceneryState>, id: &str, error: &str) {
-    if state.local_refine {
+    if state.local_refine() {
         return;
     }
     let Some(i) = state.id_to_idx.read().unwrap().get(id).copied() else {

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -265,9 +265,15 @@ async fn sort_change_restarts_augmentation_without_scrolling() {
     // viewport, so `list` stayed flat and augmentation was dead.
     scenery.set_sort(Some("branch".to_string()), SortDir::Asc);
 
-    eventually("new sort variant is listed", || {
+    // The fixture's branches are r0=main, r1=dev, so ascending by `branch` puts
+    // r1 first. Wait on the resulting *order*, not merely on "row 0 is Fresh":
+    // the pre-resort map already satisfies the latter, so a status-only wait can
+    // be satisfied before the reorder has landed. (That race is why this test
+    // asserted the unsorted `full-r0` and still passed on some machines, back
+    // when `resort` dropped the sort entirely.)
+    eventually("new sort variant is listed and applied", || {
         count_with_prefix(&log, "list") > list_before
-            && matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && detail_of(&scenery, 0).as_deref() == Some("full-r1")
     })
     .await;
 
@@ -281,7 +287,11 @@ async fn sort_change_restarts_augmentation_without_scrolling() {
         scenery.row(0).is_some(),
         "row 0 stays present across the resort"
     );
-    assert_eq!(detail_of(&scenery, 0).as_deref(), Some("full-r0"));
+    assert_eq!(
+        detail_of(&scenery, 0).as_deref(),
+        Some("full-r1"),
+        "ascending by branch puts dev (r1) above main (r0)"
+    );
 
     // Reverting to a variant already listed reorders straight from cache — its
     // index exists and its rows are `Complete`, so neither a list nor a detail
@@ -289,8 +299,11 @@ async fn sort_change_restarts_augmentation_without_scrolling() {
     let list_after_sort = count_with_prefix(&log, "list");
     let detail_after_sort = count_with_prefix(&log, "detail");
     scenery.set_sort(None, SortDir::Asc);
+    // Back to the index's own order, so r0 leads again — waiting on the order
+    // rather than the status, for the same reason as above.
     eventually("revert reseeds from cache", || {
         matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+            && detail_of(&scenery, 0).as_deref() == Some("full-r0")
     })
     .await;
     tokio::time::sleep(Duration::from_millis(20)).await;

--- a/vantage-diorama/tests/two_pass_sort.rs
+++ b/vantage-diorama/tests/two_pass_sort.rs
@@ -1,0 +1,103 @@
+//! Live `set_sort` / `set_search` on a two-pass (augmented) scenery.
+//!
+//! The builder's `.sort(..)` path is covered elsewhere; what these cover is
+//! changing the order on an already-open handle, which is what a grid header
+//! click does.
+
+mod support;
+
+use support::{MockView, bucket_dio};
+use vantage_diorama::SortDir;
+
+/// Ids in display order.
+fn order(view: &MockView) -> Vec<String> {
+    (0..view.row_count())
+        .filter_map(|i| view.col_at(i, "id"))
+        .collect()
+}
+
+/// A grid opened with no sort, then sorted by a header click.
+///
+/// `kind` is a native list-pass column, present on the cheap rows from the
+/// moment they land — nothing here needs hydration to be sortable.
+#[tokio::test]
+async fn set_sort_orders_a_scenery_opened_without_one() {
+    let dio = bucket_dio().await;
+    let view = MockView::open(&dio, 10).await;
+    view.settle_until("rows listed", |v| v.row_count() == 3)
+        .await;
+    assert_eq!(order(&view), vec!["o1", "o2", "o3"], "native list order");
+
+    // red, red, blue → o1, o3, o2. Different from native, so the assertion
+    // can't pass by accident.
+    view.scenery()
+        .set_sort(Some("kind".to_string()), SortDir::Desc);
+    view.settle_until("sorted by kind desc", |v| {
+        order(v) == vec!["o1", "o3", "o2"]
+    })
+    .await;
+}
+
+/// Changing the sort on a handle that already had one.
+#[tokio::test]
+async fn set_sort_replaces_an_existing_order() {
+    let dio = bucket_dio().await;
+    let view = MockView::open_with(&dio, 10, |b| b.sort("kind", SortDir::Asc)).await;
+    view.settle_until("sorted by kind asc", |v| order(v) == vec!["o2", "o1", "o3"])
+        .await;
+
+    view.scenery()
+        .set_sort(Some("kind".to_string()), SortDir::Desc);
+    view.settle_until("re-sorted by kind desc", |v| {
+        order(v) == vec!["o1", "o3", "o2"]
+    })
+    .await;
+}
+
+/// Sorting by an augmented column. The values arrive with hydration, so the
+/// order settles once the rows are complete.
+#[tokio::test]
+async fn set_sort_orders_by_an_augmented_column() {
+    let dio = bucket_dio().await;
+    let view = MockView::open(&dio, 10).await;
+    view.viewport(0..10);
+    view.settle_until("hydrated", |v| v.loaded_rows() == 3)
+        .await;
+
+    // Jane, John, John → o2 first.
+    view.scenery()
+        .set_sort(Some("name".to_string()), SortDir::Asc);
+    view.settle_until("sorted by name asc", |v| order(v) == vec!["o2", "o1", "o3"])
+        .await;
+}
+
+/// Clearing the sort returns the view to the index's own order.
+#[tokio::test]
+async fn clearing_the_sort_restores_list_order() {
+    let dio = bucket_dio().await;
+    let view = MockView::open_with(&dio, 10, |b| b.sort("kind", SortDir::Desc)).await;
+    view.settle_until("sorted", |v| order(v) == vec!["o1", "o3", "o2"])
+        .await;
+
+    view.scenery().set_sort(None, SortDir::Asc);
+    view.settle_until("back to list order", |v| order(v) == vec!["o1", "o2", "o3"])
+        .await;
+}
+
+/// `set_search` on a handle opened without one narrows the visible set.
+#[tokio::test]
+async fn set_search_narrows_a_scenery_opened_without_one() {
+    let dio = bucket_dio().await;
+    let view = MockView::open(&dio, 10).await;
+    view.viewport(0..10);
+    view.settle_until("hydrated", |v| v.loaded_rows() == 3)
+        .await;
+
+    view.scenery().set_search(Some("blue".to_string()));
+    view.settle_until("narrowed to the blue row", |v| order(v) == vec!["o2"])
+        .await;
+
+    view.scenery().set_search(None);
+    view.settle_until("widened again", |v| v.row_count() == 3)
+        .await;
+}


### PR DESCRIPTION
On an augmented (two-pass) table, changing the sort on a live scenery did nothing.

- A grid opened **without** a sort could never be sorted at all.
- One opened **with** a sort picked up a change only if some unrelated `RecordChanged` happened to fire afterwards.
- `set_search` had the same defect.

Both a grid header click (`grid_dio.rs` → `scenery.set_sort`) and a page's `default_sort` (`routing.rs` → `scenery.set_sort`) go through this path, so on an augmented table neither had any effect — while the header arrow still moved. This is the "sorting on augmented columns is unreliable" report, and it turns out to be a bug rather than a tuning problem.

## Two causes

**`resort` never applied the order.** It is the handler for a live `set_sort`, and it rebuilt the visible map from the query index *in the index's own order*. `reseed_filtered` is the only code that applies a condition/sort/search over the cache, and `resort` never called it. It now does, for a refined view — reusing `reseed_filtered` rather than rebuilding from the index and then reseeding over the top.

**`local_refine` was frozen at open.** A `bool` computed once in `TableSceneryBuilder::open` and never revisited, so a view opened with no query stayed "unrefined" for its whole life. The other `reseed_filtered` call sites are gated on it, which is why nothing later rescued the sort. It is now derived from the query as it stands and the stored field is gone — a value that is a function of mutable state should not have been cached beside it.

## Relationship to #361

#361 landed `TableScenery::set_filters` and hit the same stale-flag problem from the other direction: filter chips also arrive after open, so it added a `locally_refined()` wrapper that ORed the frozen flag with `!ui_filters.is_empty()`.

Deriving the whole answer subsumes that. The merge keeps `ui_filters` and folds it into the single `local_refine()` derivation, so chips, conditions, op-conditions, sort and search are all one rule instead of a flag plus a special case. #361's `ui_filter_narrows_on_an_augmented_column` passes unchanged.

Its redundant rebuild in `resort` (rebuild from the index, then `reseed_filtered` over the result) is replaced by the if/else, which skips the wasted pass.

## Tests

`tests/two_pass_sort.rs`, 5 tests, written against `bucket_dio()` (a real augmented Dio: native `kind` column, `name` augmented from a detail source). All four of the new ones fail on `main`:

```
test set_sort_orders_a_scenery_opened_without_one ... FAILED
test set_sort_replaces_an_existing_order ... FAILED
test set_sort_orders_by_an_augmented_column ... FAILED
test set_search_narrows_a_scenery_opened_without_one ... FAILED
test clearing_the_sort_restores_list_order ... ok
```

Covered: sorting a view opened without one; replacing an existing sort; sorting by an *augmented* column (values arrive with hydration); clearing back to list order; and `set_search` narrowing then widening. Orders are chosen so they differ from the native list order — none can pass by accident.

No behaviour change for single-pass sceneries, for two-pass views opened with a query, or for `titles_only` pickers.

Post-merge: full diorama suite green (32 binaries, 184 tests), `vantage-diorama-aggregate` green, `cargo fmt`, and `clippy --workspace --all-targets -- -D warnings` on 1.97.0.

Bumps diorama to **0.8.6** (0.8.5 went to #361).

## Scope

No vantage-ui changes. With this in, a header click on an augmented grid actually reorders the data. The remaining known gap on that path is the one from the review that this does *not* address: `TableSceneryState::rows` keys one map by source offset for the loader and by display rank for the view, so a client-side sort still only covers the loaded window on a lazily-paged source.