### PR TITLE
diorama: publish one visible map on refresh, and let the detail sweep converge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.8.8 — 2026-07-27
+
+**An augmented grid stops flickering, and its detail sweep converges**
+
+Three defects on the two-pass path, all visible on one screen: a grid over ~870
+rows whose default filter chip narrows on an augmented column, so the whole
+index has to hydrate before the predicate can be evaluated.
+
+- **`refresh_index` published the unfiltered row set before the filtered one.**
+  It wrote the raw index-order map into the visible map and only then awaited
+  `reseed_filtered` to replace it. `row_count` and `row` read that map
+  directly, and the reseed's per-id cache reads take ~80ms over an 870-row
+  index — so for that window a refined grid served its entire *unfiltered*
+  candidate set in source order (872 rows where the filter kept 37), headed by
+  a row the filter exists to hide. A consumer repainting on a timer while rows
+  hydrate lands inside the window about half the time, which reads as rows
+  briefly reordering and the first row's values blanking, then snapping back.
+
+  It now publishes exactly one map: a refined view's is the filtered, sorted
+  set; an unrefined view's is the index's own order. Same off-to-the-side
+  discipline the function already applied to the index spine.
+
+- **Rows with no detail record were re-fetched forever.** A row that hydrates
+  and finds nothing keeps its augment gap, so the gap rule re-enqueued it on
+  the next sweep: hydrate → still gapped → generation bump → sweep → hydrate.
+  Where absences are common that is a permanent background sweep — measured at
+  ~33 detail fetches/sec that never finish, each rewriting its row and
+  broadcasting `RecordChanged`, i.e. a continuously repainting consumer.
+
+  `DioInner::augment_settled_empty` remembers them. The periodic ticker no
+  longer clears it — `Dio::refresh` (explicit) re-probes, the ticker does not,
+  because a scheduled re-pull of the master is no evidence the detail source
+  changed. Clearing on a timer defeated the set entirely: every settled-empty
+  row was un-settled, re-fetched, found empty again, re-settled, and wiped
+  again on the next tick.
+
+- **The sweep re-derived what it already knew, once per row per pass.** Its
+  skip rule is "`Complete` and no augment gap", and the gap half can only be
+  answered from the record — one cache read per row, on every pass, including
+  for rows long since settled. Hydrating 835 rows cost ~120k reads, and it made
+  false the "dedups against already-`Complete` rows" assumption that a
+  consumer's viewport re-issue on each generation bump relies on.
+
+  `DioInner::augment_settled` memoizes the rule, so a settled row costs a
+  lookup rather than a read. It memoizes the whole rule rather than standing in
+  for it, which is what keeps it sound — `CacheStatus` alone would not be, since
+  a cache warmed by plain inserts stores rows `Complete` without ever running
+  the detail pass. Cleared on every refresh, unlike `augment_settled_empty`:
+  the refresh pass demotes changed rows to `Incomplete` to drive their refetch,
+  and a memo saying "settled" would mask that.
+
+- The event bus logs when it drops events. A lagged reactor re-derives the
+  whole set, which was previously indistinguishable from a legitimate
+  whole-set refresh; a steady trickle means some producer is outrunning the
+  reactor.
+
 ## 0.8.7 — 2026-07-26
 
 - **Stop the test suite asserting on speed.** `wait_for_gen` allowed 500ms for a

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/augment_passes.rs
+++ b/vantage-diorama/src/dio/augment_passes.rs
@@ -17,6 +17,22 @@ use crate::dio::Dio;
 use crate::lens::CacheStatus;
 use crate::ops::QueryDescriptor;
 
+/// What prompted a refresh — the two differ in how much they are entitled to
+/// assume about the DETAIL source.
+///
+/// A scheduled tick re-pulls the master on a timer; it learns nothing about
+/// whether a detail source gained records, so it must not invalidate
+/// conclusions already reached about it. An explicit request is the user
+/// saying "re-check everything", and pays for a full re-probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RefreshKind {
+    /// The periodic ticker (`refresh_interval`).
+    Scheduled,
+    /// Someone asked — a Refresh button, `Dio::refresh`, a scenery's
+    /// `request_refresh`.
+    Requested,
+}
+
 /// Capability-aware **list pass**: push the `[offset, offset+limit)` window down
 /// to the master when it advertises `can_fetch_window`, otherwise list the whole
 /// set and window it locally so sequential paging still terminates.
@@ -111,16 +127,21 @@ pub(crate) async fn hydrate_one(inner: &std::sync::Arc<super::DioInner>, id: &st
         .cache
         .insert_value_with_status(id, &merged, CacheStatus::Complete)
         .await?;
-    // A row still gapped AFTER hydration has no detail record to fill it
-    // (legitimate absence). Remember it so the sweep stops re-fetching —
-    // otherwise gap → hydrate → still gapped → generation bump → sweep is
-    // a busy loop. The refresh pass clears this set.
+    // Record which way this row settled. Gapped AFTER hydration means the
+    // detail source has no record to fill it (legitimate absence); filled
+    // means it is done. Either way the sweep must be able to skip it without
+    // reading it back — otherwise gap → hydrate → still gapped → generation
+    // bump → sweep is a busy loop, and even a filled row costs a cache read
+    // on every sweep to re-establish what we already know here. Both sets are
+    // cleared by the refresh pass.
     if gap_aware && has_augment_gap(&merged, &augmented) {
         inner
             .augment_settled_empty
             .lock()
             .unwrap()
             .insert(id.to_string());
+    } else {
+        inner.augment_settled.lock().unwrap().insert(id.to_string());
     }
     let _ = inner
         .event_bus
@@ -185,14 +206,51 @@ pub(crate) async fn hydrate_gaps(
 /// staleness lives out-of-band in [`CacheStatus`]: `Incomplete` is what drives
 /// the detail pass, so the cell never has to blank to signal the gap. Blank is
 /// reserved for rows that were never filled.
-pub(crate) async fn refresh(dio: &Dio) -> Result<()> {
+pub(crate) async fn refresh(dio: &Dio, kind: RefreshKind) -> Result<()> {
     let fresh = dio.master().list_values().await?;
     let cache = dio.cache();
     let existing = cache.list_values_with_status().await?;
     let augmented = dio.inner.augmented_columns.read().unwrap().clone();
     // A refreshed detail source may have gained records for rows that
-    // previously settled empty — let them fetch again.
-    dio.inner.augment_settled_empty.lock().unwrap().clear();
+    // previously settled empty — let them fetch again. Only on an explicit
+    // request, though.
+    //
+    // Doing it on the scheduled tick makes the sweep unable to converge
+    // whenever absences are common: every settled-empty row is un-settled,
+    // re-fetched, found empty again, and re-settled — then the next tick wipes
+    // the answer and asks again. With a 2s cadence and a detail source that
+    // legitimately has no record for most rows, that is a permanent background
+    // sweep (measured: ~33 detail fetches/sec that never finish), and every
+    // hydration writes the row back and broadcasts `RecordChanged`, so the UI
+    // repaints continuously. The set exists precisely to stop that, and
+    // clearing it on a timer defeated it.
+    //
+    // Cost of the narrower rule: a detail record that appears *after* a row
+    // settled empty is not picked up by the ticker alone. That is the right
+    // trade — a scheduled re-pull of the MASTER is no evidence the DETAIL
+    // source changed, and an explicit refresh (which is what a user reaches
+    // for when data looks stale) still re-probes everything.
+    // The FILLED memo goes on every refresh, scheduled or not: the reconcile
+    // below demotes changed rows to `Incomplete` precisely to make the detail
+    // pass refetch them, and a memo saying "settled" would have the sweep skip
+    // them forever. Costs one re-read per row on the next sweep, no fetches.
+    dio.inner.augment_settled.lock().unwrap().clear();
+
+    if matches!(kind, RefreshKind::Requested) {
+        let cleared = {
+            let mut settled = dio.inner.augment_settled_empty.lock().unwrap();
+            let n = settled.len();
+            settled.clear();
+            n
+        };
+        if cleared > 0 {
+            tracing::debug!(
+                target: "vantage_diorama::augment",
+                cleared,
+                "explicit refresh — re-probing rows that previously had no detail record",
+            );
+        }
+    }
 
     for (id, list_row) in &fresh {
         // A row with a flash in flight keeps its staged value — this

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -176,6 +176,32 @@ pub(crate) struct DioInner {
     /// sweep → hydrate, a busy loop. Cleared by the refresh pass so a
     /// detail source that GAINS a record is picked up on the next refresh.
     pub(crate) augment_settled_empty: std::sync::Mutex<std::collections::HashSet<String>>,
+    /// Rows the detail pass hydrated and FILLED — the other half of the
+    /// settled set, and a pure memo of the sweep's own skip rule (`Complete`
+    /// AND no augment gap).
+    ///
+    /// The sweep can only answer the gap half from the record, which costs a
+    /// cache read per row. On a view whose predicate forces whole-index
+    /// hydration that is O(n) reads to advance a handful of rows, re-run on
+    /// every generation bump — and it makes false the "dedups against
+    /// already-`Complete` rows" assumption a consumer's viewport re-issue
+    /// relies on. Recording the answer here costs one lookup instead.
+    ///
+    /// Because it memoizes the whole rule rather than standing in for it, it
+    /// is exactly as trustworthy as the check — which is why both the sweep
+    /// (when it pays for a read) and `hydrate_one` (when it fills a row) may
+    /// write it. Memoizing `CacheStatus` alone would NOT be sound: a cache
+    /// warmed by plain inserts (an `on_start` sync pump) stores rows
+    /// `Complete` without ever running the detail pass, and the gap half of
+    /// the rule is what catches that.
+    ///
+    /// Cleared on EVERY refresh, unlike
+    /// [`augment_settled_empty`](Self::augment_settled_empty), which survives
+    /// a scheduled tick: the refresh pass demotes changed rows to `Incomplete`
+    /// precisely to drive their refetch, and a memo saying "settled" would
+    /// mask that. The two sets answer different questions and are invalidated
+    /// by different events.
+    pub(crate) augment_settled: std::sync::Mutex<std::collections::HashSet<String>>,
 }
 
 impl Drop for DioInner {
@@ -728,11 +754,29 @@ impl Dio {
     /// to the caller (the scheduled refresh task only logs them).
     ///
     /// Returns `Ok(())` immediately when no `on_refresh` is registered.
+    ///
+    /// This is the *requested* path: an augmenting Dio re-probes rows that
+    /// previously found no detail record. The periodic ticker takes an
+    /// internal scheduled path instead, which deliberately does not — a
+    /// timed re-pull of the master is no evidence the detail source changed.
     pub async fn refresh(&self) -> Result<()> {
+        self.refresh_with(augment_passes::RefreshKind::Requested)
+            .await
+    }
+
+    /// The periodic ticker's refresh. Identical to [`Self::refresh`] except it
+    /// leaves settled-empty augment rows alone, so a detail source that
+    /// legitimately has no record for a row isn't re-queried every tick.
+    pub(crate) async fn refresh_scheduled(&self) -> Result<()> {
+        self.refresh_with(augment_passes::RefreshKind::Scheduled)
+            .await
+    }
+
+    async fn refresh_with(&self, kind: augment_passes::RefreshKind) -> Result<()> {
         let _ = self.inner.event_bus.send(DioEvent::Refreshing);
         let result = if self.inner.has_dio_augment() {
             // Dio owns augmentation → run its reconciling refresh pass.
-            augment_passes::refresh(self).await
+            augment_passes::refresh(self, kind).await
         } else if let Some(cb) = self.inner.lens.callbacks.on_refresh.as_ref() {
             cb(self).await
         } else {

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -61,6 +61,7 @@ impl Lens {
             augment_scheduler: Arc::new(crate::dio::augment_scheduler::AugmentScheduler::new()),
             augment_worker_handles: std::sync::Mutex::new(Vec::new()),
             augment_settled_empty: std::sync::Mutex::new(std::collections::HashSet::new()),
+            augment_settled: std::sync::Mutex::new(std::collections::HashSet::new()),
         });
         let dio = Dio { inner };
 
@@ -148,13 +149,16 @@ async fn refresh_loop(
             continue;
         }
         let dio = Dio { inner: strong };
-        // Delegate to `dio.refresh()` so the auto ticker and the manual path
-        // share one definition: it announces `Refreshing`, runs `on_refresh`,
-        // and publishes `DatasetChanged` *only* when the refresh succeeds. A failed
-        // tick (e.g. the source 503s) must not invalidate — that would reseed
-        // sceneries from stale cache and drop rows added since the last good
-        // refresh.
-        if let Err(e) = dio.refresh().await {
+        // Delegate to the same body as the manual path: it announces
+        // `Refreshing`, runs `on_refresh`, and publishes `DatasetChanged`
+        // *only* when the refresh succeeds. A failed tick (e.g. the source
+        // 503s) must not invalidate — that would reseed sceneries from stale
+        // cache and drop rows added since the last good refresh.
+        //
+        // `refresh_scheduled`, not `refresh`: the one thing the ticker must NOT
+        // do is re-probe augment rows already known to have no detail record.
+        // Doing so every tick prevents the detail sweep from ever converging.
+        if let Err(e) = dio.refresh_scheduled().await {
             tracing::error!(error = %e, "on_refresh callback failed");
         }
     }

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -90,7 +90,17 @@ pub(crate) async fn reload_loop(
                     | Ok(DioEvent::RangeLoaded { .. })
                     | Ok(DioEvent::LoadFailed { .. })
                     | Ok(DioEvent::Hydrating { .. }) => {}
-                    Err(broadcast::error::RecvError::Lagged(_)) => {
+                    // Dropped events: the reactor fell behind the bus, so it
+                    // cannot know what it missed and re-derives the whole set.
+                    // Worth a line — an overflow is otherwise indistinguishable
+                    // from a legitimate whole-set refresh, and a steady trickle
+                    // of them means some producer is outrunning this loop.
+                    Err(broadcast::error::RecvError::Lagged(missed)) => {
+                        tracing::debug!(
+                            target: "vantage_diorama::augment",
+                            missed,
+                            "event bus lagged — re-deriving the whole set",
+                        );
                         refresh(&state).await;
                     }
                     Err(broadcast::error::RecvError::Closed) => return,

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -501,40 +501,53 @@ pub(crate) async fn refresh_index(state: &Arc<TableSceneryState>) {
     }
     *state.list_in_flight.lock().unwrap() = false;
 
-    // Read the rows for the new spine before touching anything visible; each
-    // shows `Fresh`/`Incomplete` per its cached status.
-    let ids = fresh.ids();
-    let mut rows = std::collections::BTreeMap::new();
-    let mut id_to_idx = std::collections::HashMap::new();
-    for (i, id) in ids.iter().enumerate() {
-        let Some((rec, status)) = dio_inner
-            .cache
-            .get_value_with_status(id)
-            .await
-            .ok()
-            .flatten()
-        else {
-            continue;
-        };
-        let enriched = match status {
-            CacheStatus::Complete => EnrichedRecord::fresh(rec),
-            CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
-        };
-        rows.insert(i, Arc::new(enriched));
-        id_to_idx.insert(id.clone(), i);
-    }
-
-    // Swap in one motion: shared registry, scenery index, sparse map.
+    // Register the new spine first: `reseed_filtered` derives the visible set
+    // from the scenery's index, so it has to be the fresh one.
     dio_inner
         .query_indexes
         .lock()
         .unwrap()
         .insert(key, fresh.clone());
-    state.set_index(Some(fresh));
-    *state.rows.write().unwrap() = rows;
-    *state.id_to_idx.write().unwrap() = id_to_idx;
+    state.set_index(Some(fresh.clone()));
+
+    // Publish EXACTLY ONE visible map. A refined view's is the filtered,
+    // sorted set; an unrefined view presents the index's own order.
+    //
+    // This used to write the raw index-order map and let `reseed_filtered`
+    // replace it a moment later. `state.rows` is what `row_count` and `row`
+    // read, and the reseed's per-id cache reads take ~80ms over an 872-row
+    // index — so for that window a refined grid served its whole UNFILTERED
+    // candidate set in source order (872 rows where the filter keeps 37),
+    // headed by a row the filter exists to hide. The fast repaint tick that
+    // runs while rows are still hydrating lands inside that window about half
+    // the time, which is the reorder flicker: the head changes, then snaps
+    // back. Building off to the side is the same discipline this function
+    // already applies to the index spine above.
     if state.local_refine() {
         reseed_filtered(state).await;
+    } else {
+        let ids = fresh.ids();
+        let mut rows = std::collections::BTreeMap::new();
+        let mut id_to_idx = std::collections::HashMap::new();
+        for (i, id) in ids.iter().enumerate() {
+            let Some((rec, status)) = dio_inner
+                .cache
+                .get_value_with_status(id)
+                .await
+                .ok()
+                .flatten()
+            else {
+                continue;
+            };
+            let enriched = match status {
+                CacheStatus::Complete => EnrichedRecord::fresh(rec),
+                CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
+            };
+            rows.insert(i, Arc::new(enriched));
+            id_to_idx.insert(id.clone(), i);
+        }
+        *state.rows.write().unwrap() = rows;
+        *state.id_to_idx.write().unwrap() = id_to_idx;
     }
     state.bump_generation();
 
@@ -595,10 +608,43 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
 
     let mut pending = Vec::new();
     let mut seeded = false;
+    // Sweep census, for the log line below. A detail pass that keeps enqueueing
+    // the same rows every time it runs is the signature of a hydration loop,
+    // and without these counts it is indistinguishable from ordinary scrolling.
+    let mut settled_empty_skips = 0usize;
+    let mut already_complete = 0usize;
+    let mut memo_skips = 0usize;
+    let requested = range.len();
+    // Hoisted: `local_refine` reads five locks to answer, and the query cannot
+    // change under a sweep that never yields to a mutator.
+    let local_refine = state.local_refine();
     for idx in range {
         let Some(id) = index.id_at(idx) else {
             continue;
         };
+        // Memo fast path. Establishing "settled" from the record costs a cache
+        // read, and this loop runs over the WHOLE index on a view whose
+        // predicate touches an augmented column — re-derived on every
+        // generation bump, so every batch of hydrations pays for the entire
+        // table again. Both settled sets are decided answers; consult them
+        // before reading.
+        //
+        // Gated on the slot already existing for an unrefined view: that view
+        // still has to materialize slots a SIBLING scenery's list pass seeded
+        // into its own map only, and that genuinely needs the record. A
+        // refined view owns its map wholesale and never seeds here.
+        if local_refine || state.rows.read().unwrap().contains_key(&idx) {
+            let settled = dio_inner.augment_settled.lock().unwrap().contains(&id)
+                || dio_inner
+                    .augment_settled_empty
+                    .lock()
+                    .unwrap()
+                    .contains(&id);
+            if settled {
+                memo_skips += 1;
+                continue;
+            }
+        }
         let cached = dio_inner
             .cache
             .get_value_with_status(&id)
@@ -610,7 +656,7 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
         // SIBLING scenery — whose run_list_page seeded only its own map.
         // The viewport pass reads the cache row anyway; putting it on screen
         // is free. (Locally-refined views own their map wholesale — skip.)
-        if !state.local_refine()
+        if !local_refine
             && let Some((row, status)) = &cached
             && !state.rows.read().unwrap().contains_key(&idx)
         {
@@ -626,16 +672,26 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
             let no_gap =
                 !gap_aware || !crate::dio::augment_passes::has_augment_gap(row, &augmented);
             if no_gap {
+                already_complete += 1;
+                // Remember the answer we just paid a read for. This is the
+                // path that populates the memo for a cache warmed before this
+                // process started — `hydrate_one` only ever runs for rows the
+                // sweep enqueues, so it alone would leave a fully-hydrated
+                // persisted cache re-reading every row on every sweep.
+                dio_inner.augment_settled.lock().unwrap().insert(id.clone());
                 continue;
             }
-            // Hydrated but legitimately empty (no detail record exists) —
-            // don't re-fetch until a refresh clears the settled set.
+            // Hydrated but legitimately empty (no detail record exists) — don't
+            // re-fetch until an EXPLICIT refresh clears the settled set (the
+            // scheduled ticker deliberately leaves it alone; see
+            // `augment_passes::RefreshKind`).
             if dio_inner
                 .augment_settled_empty
                 .lock()
                 .unwrap()
                 .contains(&id)
             {
+                settled_empty_skips += 1;
                 continue;
             }
         }
@@ -644,6 +700,15 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     if seeded {
         state.bump_generation();
     }
+    tracing::debug!(
+        target: "vantage_diorama::augment",
+        requested,
+        pending = pending.len(),
+        already_complete,
+        settled_empty_skips,
+        memo_skips,
+        "detail pass census",
+    );
     if pending.is_empty() {
         return;
     }

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -65,6 +65,44 @@ async fn seed_rows(
     }
 }
 
+/// Publish the visible map for an **unrefined** view: the index's ids in the
+/// index's own order, each row read from the cache and stamped
+/// `Fresh`/`Incomplete` per its status. Built detached and swapped in one
+/// write, so the map never passes through a partial state a concurrent
+/// `row`/`row_count` could observe.
+///
+/// The refined counterpart is [`reseed_filtered`], which applies the
+/// conditions/filters/sort over the cache instead. Every path that replaces the
+/// spine — [`resort`] and [`refresh_index`] — picks one of the two and calls
+/// exactly one of them.
+async fn publish_index_order(
+    state: &Arc<TableSceneryState>,
+    dio_inner: &Arc<crate::dio::DioInner>,
+    ids: &[String],
+) {
+    let mut rows = std::collections::BTreeMap::new();
+    let mut id_to_idx = std::collections::HashMap::new();
+    for (i, id) in ids.iter().enumerate() {
+        let Some((rec, status)) = dio_inner
+            .cache
+            .get_value_with_status(id)
+            .await
+            .ok()
+            .flatten()
+        else {
+            continue;
+        };
+        let enriched = match status {
+            CacheStatus::Complete => EnrichedRecord::fresh(rec),
+            CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
+        };
+        rows.insert(i, Arc::new(enriched));
+        id_to_idx.insert(id.clone(), i);
+    }
+    *state.rows.write().unwrap() = rows;
+    *state.id_to_idx.write().unwrap() = id_to_idx;
+}
+
 /// Whether this scenery's conditions or sort touch a column produced by
 /// augmentation — the case that needs full-index hydration before the predicate
 /// can be evaluated. A native (list-pass) column is already present on the cheap
@@ -361,28 +399,7 @@ pub(crate) async fn resort(state: Arc<TableSceneryState>) {
     if state.local_refine() {
         reseed_filtered(&state).await;
     } else {
-        let ids = new_index.ids();
-        let mut rows = std::collections::BTreeMap::new();
-        let mut id_to_idx = std::collections::HashMap::new();
-        for (i, id) in ids.iter().enumerate() {
-            let Some((rec, status)) = dio_inner
-                .cache
-                .get_value_with_status(id)
-                .await
-                .ok()
-                .flatten()
-            else {
-                continue;
-            };
-            let enriched = match status {
-                CacheStatus::Complete => EnrichedRecord::fresh(rec),
-                CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
-            };
-            rows.insert(i, Arc::new(enriched));
-            id_to_idx.insert(id.clone(), i);
-        }
-        *state.rows.write().unwrap() = rows;
-        *state.id_to_idx.write().unwrap() = id_to_idx;
+        publish_index_order(&state, &dio_inner, &new_index.ids()).await;
     }
     // Ids enqueued for the previous order stay queued — the scheduler's
     // settled recheck makes any that no longer need hydration free no-ops.
@@ -526,28 +543,7 @@ pub(crate) async fn refresh_index(state: &Arc<TableSceneryState>) {
     if state.local_refine() {
         reseed_filtered(state).await;
     } else {
-        let ids = fresh.ids();
-        let mut rows = std::collections::BTreeMap::new();
-        let mut id_to_idx = std::collections::HashMap::new();
-        for (i, id) in ids.iter().enumerate() {
-            let Some((rec, status)) = dio_inner
-                .cache
-                .get_value_with_status(id)
-                .await
-                .ok()
-                .flatten()
-            else {
-                continue;
-            };
-            let enriched = match status {
-                CacheStatus::Complete => EnrichedRecord::fresh(rec),
-                CacheStatus::Incomplete => EnrichedRecord::incomplete(rec),
-            };
-            rows.insert(i, Arc::new(enriched));
-            id_to_idx.insert(id.clone(), i);
-        }
-        *state.rows.write().unwrap() = rows;
-        *state.id_to_idx.write().unwrap() = id_to_idx;
+        publish_index_order(state, &dio_inner, &fresh.ids()).await;
     }
     state.bump_generation();
 

--- a/vantage-diorama/tests/augment_settled_empty.rs
+++ b/vantage-diorama/tests/augment_settled_empty.rs
@@ -1,0 +1,229 @@
+//! A detail source that legitimately has no record for a row must be asked
+//! once, not forever.
+//!
+//! When a row hydrates and the detail source returns nothing, the Dio records
+//! it in its settled-empty set so the detail sweep stops re-fetching it. That
+//! set is what stops `gap → hydrate → still gapped → sweep again` from becoming
+//! a permanent background loop.
+//!
+//! The regression these tests pin: the refresh pass used to clear the whole set
+//! unconditionally, so the *scheduled* ticker wiped the answer every few
+//! seconds and the sweep re-asked the same absent rows for the life of the
+//! process. Harmless when every row has a detail record (the set is empty, so
+//! clearing it costs nothing) — which is why same-source augmentation never
+//! showed it. With a cross-source augment whose records are mostly absent, it
+//! is a continuous re-fetch of every missing row, each one rewriting its row
+//! and broadcasting `RecordChanged`, i.e. a permanently repainting UI.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_diorama::{
+    Augmentation, Detail, Dio, Fetch, Lens, MergeRule, RowStatus, Source, TableScenery,
+};
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Vista, VistaMetadata};
+use vantage_vista_factory::VistaCatalog;
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.into())
+}
+
+fn record(pairs: &[(&str, &str)]) -> Record<CborValue> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), text(v)))
+        .collect()
+}
+
+fn meta(columns: &[&str]) -> VistaMetadata {
+    let mut m = VistaMetadata::new();
+    for c in columns {
+        let col = if *c == "id" {
+            Column::new("id", "String").with_flag("id")
+        } else {
+            Column::new(*c, "String")
+        };
+        m = m.with_column(col);
+    }
+    m.with_id_column("id")
+}
+
+/// Master: two rows, cheap columns only.
+fn master_vista() -> Vista {
+    let shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("branch", "main")]))
+        .with_record("r1", record(&[("id", "r1"), ("branch", "dev")]))
+        .with_metadata(meta(&["id", "branch"]));
+    Vista::new("runs", Box::new(shell))
+}
+
+/// Detail source with a record for `r0` ONLY. `r1` is the row that settles
+/// empty — the shape a cross-source augment hits constantly (an evidence row
+/// with no matching bucket folder).
+fn partial_detail_vista() -> Vista {
+    let shell = MockShell::new()
+        .with_record("r0", record(&[("id", "r0"), ("detail", "full-r0")]))
+        .with_metadata(meta(&["id", "detail"]));
+    Vista::new("runs-detail", Box::new(shell))
+}
+
+/// A catalog whose loader counts how many times the detail vista is built —
+/// `Augmentation::base_vista` builds one per fetch, so this is an exact count
+/// of detail fetches attempted.
+fn counting_catalog(hits: Arc<AtomicUsize>) -> Arc<VistaCatalog> {
+    let mut c = VistaCatalog::new();
+    c.register(
+        "runs-detail",
+        Arc::new(move || {
+            hits.fetch_add(1, Ordering::SeqCst);
+            Ok(partial_detail_vista())
+        }),
+    );
+    Arc::new(c)
+}
+
+fn aug() -> Augmentation {
+    Augmentation {
+        detail: Detail::Catalog("runs-detail".into()),
+        source: Source::Id,
+        fetch: Fetch::PerRow,
+        merge: MergeRule {
+            columns: vec!["detail".to_string()],
+        },
+    }
+}
+
+/// `refresh_every` only spawns the ticker when an `on_refresh` callback exists,
+/// so register a no-op one. An augmenting Dio never calls it — it runs its own
+/// reconciling pass — but its presence is what starts the timer, which is the
+/// path under test.
+async fn open_with_ticker(tmp: &TempDir, hits: Arc<AtomicUsize>, tick: Option<Duration>) -> Dio {
+    let mut lens = Lens::new()
+        .cache_at(tmp.path().join("cache.redb"))
+        .viewport_debounce(Duration::from_millis(1));
+    if let Some(tick) = tick {
+        lens = lens
+            .refresh_every(tick)
+            .on_refresh(|_dio: &Dio| async move { Ok(()) });
+    }
+    let lens = Arc::new(lens.build().expect("lens builds"));
+    let dio = lens.make_dio(master_vista()).await.expect("make_dio");
+    dio.augment(counting_catalog(hits), vec![aug()])
+}
+
+fn status_of(s: &Arc<dyn TableScenery>, i: usize) -> Option<RowStatus> {
+    s.row(i).map(|r| r.status.clone())
+}
+
+fn col_of(s: &Arc<dyn TableScenery>, i: usize, c: &str) -> Option<String> {
+    s.row(i).and_then(|r| match r.record.get(c) {
+        Some(CborValue::Text(t)) => Some(t.clone()),
+        _ => None,
+    })
+}
+
+async fn eventually(label: &str, f: impl Fn() -> bool) {
+    for _ in 0..200 {
+        if f() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    panic!("condition '{label}' not met within timeout");
+}
+
+/// Bring both rows through the detail pass once and return the fetch count.
+async fn hydrate_both(dio: &Dio, hits: &AtomicUsize) -> (Arc<dyn TableScenery>, usize) {
+    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    scenery.set_viewport(0..2);
+    eventually("r0 hydrated", || {
+        matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
+    })
+    .await;
+    // r1 has no detail record — it reaches Complete-in-cache carrying only its
+    // list columns, so wait on the absence settling rather than on a status.
+    eventually("detail pass quiesced", || {
+        let before = hits.load(Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(30));
+        hits.load(Ordering::SeqCst) == before
+    })
+    .await;
+    let settled = hits.load(Ordering::SeqCst);
+    (scenery, settled)
+}
+
+/// The premise: a row whose detail source has no record still hydrates its
+/// cheap columns, and the augmented column simply stays absent.
+#[tokio::test]
+async fn a_row_with_no_detail_record_keeps_its_list_columns() {
+    let tmp = TempDir::new().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let dio = open_with_ticker(&tmp, hits.clone(), None).await;
+    let (scenery, _) = hydrate_both(&dio, &hits).await;
+
+    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+    assert_eq!(
+        col_of(&scenery, 1, "detail"),
+        None,
+        "r1's detail source has no record — the column stays absent",
+    );
+    assert_eq!(
+        col_of(&scenery, 1, "branch").as_deref(),
+        Some("dev"),
+        "the cheap list columns survive a detail miss",
+    );
+}
+
+/// THE REGRESSION. With the ticker running, a settled-empty row must not be
+/// re-fetched on every tick.
+///
+/// Before the fix this failed loudly: the scheduled refresh cleared the
+/// settled-empty set, so each tick re-fetched `r1` and the count climbed
+/// without bound for as long as the process ran.
+#[tokio::test]
+async fn the_scheduled_ticker_does_not_re_probe_a_settled_empty_row() {
+    let tmp = TempDir::new().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    // A 50ms tick: several refreshes land inside the observation window below.
+    let dio = open_with_ticker(&tmp, hits.clone(), Some(Duration::from_millis(50))).await;
+    let (_scenery, after_hydration) = hydrate_both(&dio, &hits).await;
+    assert!(
+        after_hydration >= 2,
+        "both rows should have been fetched once: {after_hydration}",
+    );
+
+    // Let the ticker fire many times over.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        after_hydration,
+        "the scheduled refresh re-probed a row already known to have no detail \
+         record — that is the sweep-never-converges loop",
+    );
+}
+
+/// The other half of the contract: an EXPLICIT refresh is the user saying
+/// "re-check everything", so it does re-probe. Without this the fix would just
+/// be "never look again", and a detail record that appears later would be
+/// unreachable.
+#[tokio::test]
+async fn an_explicit_refresh_re_probes_a_settled_empty_row() {
+    let tmp = TempDir::new().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let dio = open_with_ticker(&tmp, hits.clone(), None).await;
+    let (scenery, after_hydration) = hydrate_both(&dio, &hits).await;
+
+    dio.refresh().await.expect("refresh");
+    scenery.set_viewport(0..2);
+
+    eventually("explicit refresh re-probed", || {
+        hits.load(Ordering::SeqCst) > after_hydration
+    })
+    .await;
+}

--- a/vantage-diorama/tests/augment_settled_empty.rs
+++ b/vantage-diorama/tests/augment_settled_empty.rs
@@ -15,43 +15,21 @@
 //! is a continuous re-fetch of every missing row, each one rewriting its row
 //! and broadcasting `RecordChanged`, i.e. a permanently repainting UI.
 
+mod support;
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use ciborium::Value as CborValue;
+use support::chunk::col_at;
+use support::{meta, record};
 use tempfile::TempDir;
 use vantage_diorama::{
     Augmentation, Detail, Dio, Fetch, Lens, MergeRule, RowStatus, Source, TableScenery,
 };
-use vantage_types::Record;
+use vantage_vista::Vista;
 use vantage_vista::mocks::MockShell;
-use vantage_vista::{Column, Vista, VistaMetadata};
 use vantage_vista_factory::VistaCatalog;
-
-fn text(s: &str) -> CborValue {
-    CborValue::Text(s.into())
-}
-
-fn record(pairs: &[(&str, &str)]) -> Record<CborValue> {
-    pairs
-        .iter()
-        .map(|(k, v)| ((*k).to_string(), text(v)))
-        .collect()
-}
-
-fn meta(columns: &[&str]) -> VistaMetadata {
-    let mut m = VistaMetadata::new();
-    for c in columns {
-        let col = if *c == "id" {
-            Column::new("id", "String").with_flag("id")
-        } else {
-            Column::new(*c, "String")
-        };
-        m = m.with_column(col);
-    }
-    m.with_id_column("id")
-}
 
 /// Master: two rows, cheap columns only.
 fn master_vista() -> Vista {
@@ -120,13 +98,6 @@ fn status_of(s: &Arc<dyn TableScenery>, i: usize) -> Option<RowStatus> {
     s.row(i).map(|r| r.status.clone())
 }
 
-fn col_of(s: &Arc<dyn TableScenery>, i: usize, c: &str) -> Option<String> {
-    s.row(i).and_then(|r| match r.record.get(c) {
-        Some(CborValue::Text(t)) => Some(t.clone()),
-        _ => None,
-    })
-}
-
 async fn eventually(label: &str, f: impl Fn() -> bool) {
     for _ in 0..200 {
         if f() {
@@ -166,14 +137,14 @@ async fn a_row_with_no_detail_record_keeps_its_list_columns() {
     let dio = open_with_ticker(&tmp, hits.clone(), None).await;
     let (scenery, _) = hydrate_both(&dio, &hits).await;
 
-    assert_eq!(col_of(&scenery, 0, "detail").as_deref(), Some("full-r0"));
+    assert_eq!(col_at(&scenery, 0, "detail").as_deref(), Some("full-r0"));
     assert_eq!(
-        col_of(&scenery, 1, "detail"),
+        col_at(&scenery, 1, "detail"),
         None,
         "r1's detail source has no record — the column stays absent",
     );
     assert_eq!(
-        col_of(&scenery, 1, "branch").as_deref(),
+        col_at(&scenery, 1, "branch").as_deref(),
         Some("dev"),
         "the cheap list columns survive a detail miss",
     );


### PR DESCRIPTION
Three defects on the two-pass augmentation path, all reproduced on one screen: a
grid over ~870 rows whose default filter chip narrows on an *augmented* column,
so the whole index has to hydrate before the predicate can be evaluated.

## `refresh_index` published the unfiltered row set before the filtered one

It wrote the raw index-order map into the visible map and only then awaited
`reseed_filtered` to replace it. `row_count` and `row` read that map directly,
and the reseed's per-id cache reads take ~80ms over an 870-row index — so for
that window a refined grid served its entire **unfiltered** candidate set in
source order (872 rows where the filter kept 37), headed by a row the filter
exists to hide.

A consumer repainting on a timer while rows hydrate lands inside that window
about half the time. Measured from the running app:

```
15.225  refresh_index raw publish (UNFILTERED)  rows=872  head → name=Tag(6, Null)
15.302  reseed_filtered (filtered + sorted)     rows=37   head → name=Armando
```

It now publishes exactly one map: a refined view's is the filtered, sorted set;
an unrefined view's is the index's own order. Same off-to-the-side discipline
the function already applied to the index spine directly above.

## Rows with no detail record were re-fetched forever

A row that hydrates and finds nothing keeps its augment gap, so the gap rule
re-enqueued it on the next sweep: hydrate → still gapped → generation bump →
sweep → hydrate. Where absences are common that is a permanent background sweep
— measured at ~33 detail fetches/sec that never finish, each rewriting its row
and broadcasting `RecordChanged`, i.e. a continuously repainting consumer.

`DioInner::augment_settled_empty` remembers them. The periodic ticker no longer
clears it: `Dio::refresh` (explicit) re-probes, the ticker does not, because a
scheduled re-pull of the *master* is no evidence the *detail* source changed.
Clearing on a timer defeated the set entirely — every settled-empty row was
un-settled, re-fetched, found empty again, re-settled, and wiped again on the
next tick.

Cost of the narrower rule: a detail record appearing *after* a row settled empty
is not picked up by the ticker alone. That is the right trade — an explicit
refresh, which is what a user reaches for when data looks stale, still re-probes
everything.

## The sweep re-derived what it already knew, once per row per pass

Its skip rule is "`Complete` and no augment gap", and the gap half can only be
answered from the record — one cache read per row, on every pass, including for
rows long since settled. Hydrating 835 rows cost ~120k reads. It also made false
the "dedups against already-`Complete` rows" assumption that a consumer's
viewport re-issue on each generation bump relies on.

`DioInner::augment_settled` memoizes the rule, so a settled row costs a lookup
rather than a read.

Two things that keep it sound:

- It memoizes the **whole** rule rather than standing in for it, so it is
  exactly as trustworthy as the check. Memoizing `CacheStatus` alone would not
  be: a cache warmed by plain inserts (an `on_start` sync pump) stores rows
  `Complete` without ever running the detail pass, and the gap half is what
  catches that. This is also why both the sweep (when it pays for a read) and
  `hydrate_one` (when it fills a row) may write it — `hydrate_one` alone would
  leave a warm persisted cache re-reading every row forever, since it only runs
  for rows the sweep enqueues.
- It is cleared on **every** refresh, unlike `augment_settled_empty`. The
  refresh pass demotes changed rows to `Incomplete` precisely to drive their
  refetch, and a memo saying "settled" would mask that. The asymmetry is
  deliberate: the two sets answer different questions and are invalidated by
  different events.

`local_refine()` is also hoisted out of the sweep loop — it takes five read
locks to answer and was called twice per row. Behaviour-neutral.

## Tests

`tests/augment_settled_empty.rs` covers the settled-empty set: a sweep over a
detail source with no record for most rows converges instead of re-fetching, and
an explicit refresh re-probes while a scheduled tick does not.

No test yet for the `refresh_index` publish. The bug is a transient between two
writes, so a deterministic test needs a hook that observes mid-refresh rather
than an assertion on the settled state — worth doing, but not bolted on flaky
here.

## Verification

Full suite green (33 binaries), `cargo fmt`, `clippy --workspace --all-targets`
clean, and rustdoc clean with `-D rustdoc::broken_intra_doc_links -D
rustdoc::private_intra_doc_links` both with and without `--document-private-items`
— the last of which caught a public `Dio::refresh` doc comment linking to
private items. All on 1.97.0.

Bumps diorama to **0.8.8**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented grid flicker and row reordering during augmented data refreshes.
  * Stopped rows without matching detail records from being repeatedly re-fetched during scheduled refreshes.
  * Improved refresh behavior so explicit refreshes can re-check previously empty detail records.
  * Reduced unnecessary repeated lookups for already-settled rows.
  * Added visibility into missed event-bus updates through diagnostic logging.

* **Tests**
  * Added regression coverage for scheduled and explicit refresh behavior.

* **Chores**
  * Bumped the release version to 0.8.8 and updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up commit: deduplication

SonarCloud's quality gate failed the first push on `new_duplicated_lines_density`
(14.9% against a 3% threshold); every other condition, including the three
ratings, was clean. Two real duplications:

- `refresh_index`'s new `else` branch was a line-for-line copy of `resort`'s.
  The duplication pre-existed, but moving the block into an `else` rewrote those
  lines, so they counted as new. Both now call a single `publish_index_order`.

  This is worth having independent of the gate. The bug fixed above exists
  *because* those two paths diverged — 0.8.6 fixed the interim publish in
  `resort` and left it in `refresh_index`. Consolidating them makes "every
  spine-replacing path calls exactly one of `publish_index_order` or
  `reseed_filtered`" an invariant of the code rather than a convention.

- `tests/augment_settled_empty.rs` re-declared `text`/`record`/`meta`/`col_of`,
  byte-identical to what `tests/support` already exports. It now uses
  `mod support;` like `two_pass_sort.rs` does.

Gate is now green at 0.0% duplication.
