### PR TITLE
Window totals, in-memory aggregates, and load-shape correctness under a shared lens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5470,7 +5470,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5641,7 +5641,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama-aggregate"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-diorama = { version = "0.9", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.9 — 2026-07-28
+
+- Every REST round trip is timed. Over a second it logs `slow REST GET` at info
+  with the URL and elapsed time; otherwise `REST GET done` at debug. Both carry
+  `count_probe`, which distinguishes a request for rows from one made only to
+  learn a total — the distinction that identified an 8.5s startup as a separate
+  count query on the open path.
+
 ## 0.6.8 — 2026-07-23
 
 - REST and GraphQL `TableShell`s implement `get_ref_target` — the bare,

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.8"
+version = "0.6.9"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -29,7 +29,7 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -295,27 +295,14 @@ impl RestApi {
     /// Fetch a single half-open row window `[offset, offset+limit)` — the
     /// primitive a paged, lazily-loaded grid drives on scroll (offset is
     /// an absolute row index, not a page number).
-    pub(crate) async fn fetch_window_records<'a>(
-        &self,
-        table_name: &str,
-        id_field: Option<&str>,
-        offset: i64,
-        limit: i64,
-        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
-    ) -> Result<IndexMap<String, Record<CborValue>>> {
-        self.fetch_windowed(table_name, id_field, Some((offset, limit)), conditions)
-            .await
-            .map(|(records, _total)| records)
-    }
-
-    /// [`Self::fetch_window_records`], plus the envelope's `total_key` when
+    /// Fetch one half-open row window, plus the envelope's `total_key` when
     /// the response carries one.
     ///
     /// The total comes out of the **same response as the rows**. Every paged
-    /// endpoint reports it on every reply, so a caller that wants both a
-    /// window and a grand total should use this rather than pairing
-    /// `fetch_window_records` with [`Self::fetch_total`] — that pairing costs
-    /// a second round trip for a number already in hand.
+    /// endpoint reports it on every reply, so a caller wanting both a window
+    /// and a grand total takes them together here rather than pairing a
+    /// window fetch with [`Self::fetch_total`] — that pairing costs a second
+    /// round trip for a number already in hand.
     pub(crate) async fn fetch_window_records_counted<'a>(
         &self,
         table_name: &str,
@@ -784,10 +771,17 @@ mod tests {
             .expect("fetch_total");
         assert!(total.is_some_and(|n| n > 0), "expected a positive count");
 
-        let rows = api
-            .fetch_window_records("launches/?mode=detailed", Some("id"), 0, 3, [])
+        let (rows, window_total) = api
+            .fetch_window_records_counted("launches/?mode=detailed", Some("id"), 0, 3, [])
             .await
-            .expect("fetch_window_records");
+            .expect("fetch_window_records_counted");
         assert_eq!(rows.len(), 3, "expected the requested 3-row window");
+        // The whole point of the counted window: the same response that
+        // carried the rows also carried the count, so `fetch_total`'s extra
+        // round trip buys nothing a caller couldn't already have.
+        assert_eq!(
+            window_total, total,
+            "the window's envelope total should match the dedicated count",
+        );
     }
 }

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -403,10 +403,22 @@ impl RestApi {
             request = request.header("Authorization", auth);
         }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| error!("API request failed", url = url, detail = e))?;
+        // Time every round trip, unconditionally — a remote API is the one part
+        // of a read the process cannot bound, and a slow page is far more often
+        // one slow GET than anything local. Reported regardless of `debug` so
+        // the cost is attributable from a default log; a request over a second
+        // is worth an operator's attention, hence `info` at that point.
+        let started = std::time::Instant::now();
+        let response = request.send().await.map_err(|e| {
+            tracing::warn!(
+                target: "vantage_api_client::rest",
+                table = table_name,
+                url = %url,
+                ms = started.elapsed().as_millis() as u64,
+                "REST GET failed",
+            );
+            error!("API request failed", url = url, detail = e)
+        })?;
 
         if !response.status().is_success() {
             return Err(error!(
@@ -420,6 +432,28 @@ impl RestApi {
             .json()
             .await
             .map_err(|e| error!("Failed to parse API response as JSON", detail = e))?;
+
+        let ms = started.elapsed().as_millis() as u64;
+        let probe = window == Some((0, 1));
+        if ms >= 1000 {
+            tracing::info!(
+                target: "vantage_api_client::rest",
+                table = table_name,
+                url = %url,
+                ms,
+                count_probe = probe,
+                "slow REST GET",
+            );
+        } else {
+            tracing::debug!(
+                target: "vantage_api_client::rest",
+                table = table_name,
+                url = %url,
+                ms,
+                count_probe = probe,
+                "REST GET done",
+            );
+        }
 
         Ok((body, client_filters))
     }

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -289,6 +289,7 @@ impl RestApi {
         let window = pagination.map(|p| (p.skip(), p.limit()));
         self.fetch_windowed(table_name, id_field, window, conditions)
             .await
+            .map(|(records, _total)| records)
     }
 
     /// Fetch a single half-open row window `[offset, offset+limit)` — the
@@ -302,6 +303,27 @@ impl RestApi {
         limit: i64,
         conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
     ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.fetch_windowed(table_name, id_field, Some((offset, limit)), conditions)
+            .await
+            .map(|(records, _total)| records)
+    }
+
+    /// [`Self::fetch_window_records`], plus the envelope's `total_key` when
+    /// the response carries one.
+    ///
+    /// The total comes out of the **same response as the rows**. Every paged
+    /// endpoint reports it on every reply, so a caller that wants both a
+    /// window and a grand total should use this rather than pairing
+    /// `fetch_window_records` with [`Self::fetch_total`] — that pairing costs
+    /// a second round trip for a number already in hand.
+    pub(crate) async fn fetch_window_records_counted<'a>(
+        &self,
+        table_name: &str,
+        id_field: Option<&str>,
+        offset: i64,
+        limit: i64,
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> Result<(IndexMap<String, Record<CborValue>>, Option<i64>)> {
         self.fetch_windowed(table_name, id_field, Some((offset, limit)), conditions)
             .await
     }
@@ -415,23 +437,32 @@ impl RestApi {
         Ok((body, client_filters))
     }
 
+    /// Also reports the envelope total when `total_key` is configured and the
+    /// body carries it. Unlike [`Self::fetch_total`] this never errors on a
+    /// missing total: the rows are the point here, and a caller that needs a
+    /// definitive count can still ask for one.
     async fn fetch_windowed<'a>(
         &self,
         table_name: &str,
         id_field: Option<&str>,
         window: Option<(i64, i64)>,
         conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
-    ) -> Result<IndexMap<String, Record<CborValue>>> {
+    ) -> Result<(IndexMap<String, Record<CborValue>>, Option<i64>)> {
         // Non-paginating endpoints return the whole list on the first
         // window; a later window would just re-deliver the same rows and the
         // perpetual grid would never mark itself exhausted. Short-circuit any
         // window past the start to empty so the grid sees the chunk shrink
         // and stops asking for more.
         if self.no_pagination && window.is_some_and(|(offset, _)| offset > 0) {
-            return Ok(IndexMap::new());
+            return Ok((IndexMap::new(), None));
         }
 
         let (body, client_filters) = self.fetch_raw_body(table_name, window, conditions).await?;
+        let total = self
+            .total_key
+            .as_deref()
+            .and_then(|key| body.get(key))
+            .and_then(|v| v.as_i64());
         let data = self.extract_array(&body, table_name)?;
 
         let mut records = IndexMap::new();
@@ -476,9 +507,13 @@ impl RestApi {
                         None => true,
                     })
             });
+            // The envelope counted what the SERVER matched, before these rows
+            // were dropped here — reporting it now would size a grid to rows
+            // it will never be given. No total is better than a wrong one.
+            return Ok((records, None));
         }
 
-        Ok(records)
+        Ok((records, total))
     }
 }
 

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -139,15 +139,27 @@ impl TableShell for RestApiTableShell {
 
     async fn fetch_window(
         &self,
-        _vista: &Vista,
+        vista: &Vista,
         offset: usize,
         limit: usize,
     ) -> Result<Vec<(String, Record<CborValue>)>> {
+        Ok(self.fetch_window_counted(vista, offset, limit).await?.0)
+    }
+
+    /// A REST envelope reports `total_key` on every reply, so the window
+    /// fetch already knows the grand total — handing it back here is what
+    /// lets a grid size its scrollbar without a second `limit=1` request.
+    async fn fetch_window_counted(
+        &self,
+        _vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<i64>)> {
         let id_field = self.table.id_field().map(|c| c.name().to_string());
-        let records = self
+        let (records, total) = self
             .table
             .data_source()
-            .fetch_window_records(
+            .fetch_window_records_counted(
                 self.table.table_name(),
                 id_field.as_deref(),
                 offset as i64,
@@ -162,7 +174,7 @@ impl TableShell for RestApiTableShell {
         for (_, rec) in records.iter_mut() {
             self.table.apply_lazy_expressions(rec).await?;
         }
-        Ok(records)
+        Ok((records, total))
     }
 
     fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.3 — 2026-07-28
+
+- Track vantage-diorama 0.10.
+- **A paged source no longer leaves every aggregate at zero.** The engine
+  ignored `RangeLoaded`, and a chunk load emits no per-row event — so on a cold
+  cache the figures derived from a paged table never recomputed and sat at their
+  starting values. They now recompute as each window lands, which is what makes
+  a figure over a paged table climb as its pages arrive rather than appearing
+  finished and wrong.
+
 ## 0.6.2 — 2026-07-27
 
 - Track vantage-diorama 0.9. The facade Vista no longer lifts `can_search`, so a

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6.17", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
 vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
 
 async-trait = "0.1"

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama-aggregate"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Reactive client-side aggregation over a Vantage Diorama"
@@ -14,7 +14,7 @@ vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.6.17", path = "../vantage-vista" }
-vantage-diorama = { version = "0.9", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/src/builtin/as_rows.rs
+++ b/vantage-diorama-aggregate/src/builtin/as_rows.rs
@@ -1,0 +1,155 @@
+//! Presenting a scalar reduction as the one-row set it actually is.
+//!
+//! `count(*)` in SQL yields a table with one row and one column, not a bare
+//! number, and everything downstream is simpler when we agree with SQL: a
+//! scalar aggregate mounts as an ordinary table, so a grid, a chart and a
+//! single-figure tile all observe it through the one contract they already
+//! have. Without this, a scalar needs a parallel "value" path at every layer —
+//! its own scenery type, its own observation, and a special case in every
+//! component that might display it.
+
+use ciborium::Value as CborValue;
+use vantage_types::Record;
+use vantage_vista::{Column, flags};
+
+use crate::aggregation::{Aggregation, DerivedRows, Rows};
+
+/// The id of a scalar aggregate's only row. Stable, so a recomputation
+/// updates that row rather than replacing one row with another.
+const ROW_ID: &str = "value";
+
+/// Wraps a scalar aggregation so it produces a one-row [`DerivedRows`] whose
+/// single column is named by `alias`.
+pub struct AsRows<A> {
+    alias: String,
+    inner: A,
+}
+
+impl<A> AsRows<A> {
+    pub fn new(alias: impl Into<String>, inner: A) -> Self {
+        Self {
+            alias: alias.into(),
+            inner,
+        }
+    }
+}
+
+impl<A: Aggregation<Output = CborValue>> Aggregation for AsRows<A> {
+    type Output = DerivedRows;
+
+    fn compute(&self, rows: &Rows) -> DerivedRows {
+        let value = self.inner.compute(rows);
+        let column = Column::new(self.alias.clone(), column_type(&value)).with_flag(flags::ID);
+        let mut record = Record::new();
+        record.insert(self.alias.clone(), value);
+        DerivedRows::new(vec![(ROW_ID.to_string(), record)], vec![column])
+    }
+}
+
+/// The declared type of the single column, read from the value.
+///
+/// A reduction whose result changes kind — a `sum` that was integral until a
+/// fractional row arrived — reports a schema change, which is honest: the
+/// column really did change type. Reductions in practice stay in one kind.
+fn column_type(value: &CborValue) -> &'static str {
+    match value {
+        CborValue::Integer(_) => "i64",
+        CborValue::Float(_) => "f64",
+        CborValue::Bool(_) => "bool",
+        _ => "String",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtin::{Conditions, Count, Sum, Where};
+
+    fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
+        let mut r = Record::new();
+        for (k, v) in pairs {
+            r.insert((*k).to_string(), v.clone());
+        }
+        r
+    }
+
+    fn text(s: &str) -> CborValue {
+        CborValue::Text(s.to_string())
+    }
+
+    fn events() -> Rows {
+        vec![
+            record(&[("Event", text("opened")), ("Size", CborValue::Integer(10.into()))]),
+            record(&[("Event", text("failed")), ("Size", CborValue::Integer(20.into()))]),
+            record(&[("Event", text("opened")), ("Size", CborValue::Integer(30.into()))]),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(i, r)| (i.to_string(), r))
+        .collect()
+    }
+
+    /// The contract: one row, one column, named by the alias.
+    #[test]
+    fn a_scalar_becomes_a_one_row_one_column_table() {
+        let derived = AsRows::new("total", Count::rows()).compute(&events());
+        assert_eq!(derived.len(), 1);
+        assert_eq!(derived.columns.len(), 1);
+        assert_eq!(derived.columns[0].name, "total");
+        let (_, row) = &derived.rows[0];
+        assert_eq!(row.get("total"), Some(&CborValue::Integer(3.into())));
+    }
+
+    /// Diorama addresses rows by id, so the derived table needs one — and the
+    /// single column has to carry it, there being no other.
+    #[test]
+    fn the_only_column_is_the_id_column() {
+        let derived = AsRows::new("total", Count::rows()).compute(&events());
+        assert!(
+            derived.columns[0].flags.contains(&flags::ID.to_string()),
+            "columns: {:?}",
+            derived.columns
+        );
+    }
+
+    /// A stable row id means a recomputation UPDATES the row rather than
+    /// deleting one and inserting another — which a subscribed grid would
+    /// otherwise see as the row vanishing and reappearing.
+    #[test]
+    fn the_row_id_is_stable_across_recomputations() {
+        let agg = AsRows::new("total", Count::rows());
+        let first = agg.compute(&events());
+        let second = agg.compute(&Rows::new());
+        assert_eq!(first.rows[0].0, second.rows[0].0);
+        assert_eq!(
+            second.rows[0].1.get("total"),
+            Some(&CborValue::Integer(0.into())),
+            "an empty source still yields one row, holding zero",
+        );
+    }
+
+    /// Composition is the point: narrowing and reduction stay separate, and
+    /// this only changes the shape of the answer.
+    #[test]
+    fn it_wraps_a_narrowed_reduction_unchanged() {
+        let agg = AsRows::new(
+            "opened_bytes",
+            Where::new(
+                Conditions::new().eq("Event", text("opened")),
+                Sum::new("Size"),
+            ),
+        );
+        let derived = agg.compute(&events());
+        assert_eq!(
+            derived.rows[0].1.get("opened_bytes"),
+            Some(&CborValue::Integer(40.into())),
+        );
+        assert_eq!(derived.columns[0].name, "opened_bytes");
+    }
+
+    #[test]
+    fn the_column_type_follows_the_value() {
+        let ints = AsRows::new("n", Count::rows()).compute(&events());
+        assert_eq!(ints.columns[0].original_type, "i64");
+    }
+}

--- a/vantage-diorama-aggregate/src/builtin/as_rows.rs
+++ b/vantage-diorama-aggregate/src/builtin/as_rows.rs
@@ -79,9 +79,18 @@ mod tests {
 
     fn events() -> Rows {
         vec![
-            record(&[("Event", text("opened")), ("Size", CborValue::Integer(10.into()))]),
-            record(&[("Event", text("failed")), ("Size", CborValue::Integer(20.into()))]),
-            record(&[("Event", text("opened")), ("Size", CborValue::Integer(30.into()))]),
+            record(&[
+                ("Event", text("opened")),
+                ("Size", CborValue::Integer(10.into())),
+            ]),
+            record(&[
+                ("Event", text("failed")),
+                ("Size", CborValue::Integer(20.into())),
+            ]),
+            record(&[
+                ("Event", text("opened")),
+                ("Size", CborValue::Integer(30.into())),
+            ]),
         ]
         .into_iter()
         .enumerate()

--- a/vantage-diorama-aggregate/src/builtin/count.rs
+++ b/vantage-diorama-aggregate/src/builtin/count.rs
@@ -3,7 +3,7 @@
 use ciborium::Value as CborValue;
 
 use crate::aggregation::{Aggregation, Rows};
-use crate::cmp;
+use crate::builtin::filter::{Conditions, Where};
 
 /// Number of rows.
 ///
@@ -54,15 +54,14 @@ impl Default for CountWhere {
 impl Aggregation for CountWhere {
     type Output = CborValue;
 
+    /// Delegates to [`Where`]`<`[`Count`]`>` — the narrowing lives with the
+    /// other combinators so a filtered count and a filtered sum can never
+    /// disagree about what a term means.
     fn compute(&self, rows: &Rows) -> CborValue {
-        let count = rows
-            .values()
-            .filter(|record| {
-                self.conditions.iter().all(|(column, expected)| {
-                    cmp::column(record, column).is_some_and(|actual| actual == expected)
-                })
-            })
-            .count();
-        CborValue::Integer((count as i64).into())
+        let mut conditions = Conditions::new();
+        for (column, expected) in &self.conditions {
+            conditions = conditions.eq(column.clone(), expected.clone());
+        }
+        Where::new(conditions, Count::rows()).compute(rows)
     }
 }

--- a/vantage-diorama-aggregate/src/builtin/filter.rs
+++ b/vantage-diorama-aggregate/src/builtin/filter.rs
@@ -133,9 +133,18 @@ mod tests {
 
     fn events() -> Rows {
         rows(vec![
-            record(&[("Event", text("opened")), ("Size", CborValue::Integer(10.into()))]),
-            record(&[("Event", text("failed")), ("Size", CborValue::Integer(20.into()))]),
-            record(&[("Event", text("opened")), ("Size", CborValue::Integer(30.into()))]),
+            record(&[
+                ("Event", text("opened")),
+                ("Size", CborValue::Integer(10.into())),
+            ]),
+            record(&[
+                ("Event", text("failed")),
+                ("Size", CborValue::Integer(20.into())),
+            ]),
+            record(&[
+                ("Event", text("opened")),
+                ("Size", CborValue::Integer(30.into())),
+            ]),
         ])
     }
 

--- a/vantage-diorama-aggregate/src/builtin/filter.rs
+++ b/vantage-diorama-aggregate/src/builtin/filter.rs
@@ -1,0 +1,213 @@
+//! Narrowing the rows an aggregation sees.
+//!
+//! Every reduction in this crate answers over "the rows it was given", so
+//! restricting *which* rows is a separate, orthogonal concern — not something
+//! each reduction should re-implement. [`Where`] wraps any
+//! [`Aggregation`](crate::Aggregation) and hands it a narrowed set, so `sum of
+//! Size where Event = opened` composes out of the two pieces already here
+//! instead of needing a `SumWhere`.
+
+use ciborium::Value as CborValue;
+use vantage_types::Record;
+
+use crate::aggregation::{Aggregation, Rows};
+use crate::cmp;
+
+/// Equality terms, ANDed together.
+///
+/// # Matching
+///
+/// A term matches when the row's value equals the expected value, compared
+/// first as CBOR and then — only if that fails — as rendered scalars. The
+/// second pass is what makes configuration-driven conditions usable: a YAML
+/// file says `code: 200` with no way to know whether the backend sends
+/// `200` or `"200"`, and a filter that silently matched nothing because the
+/// column was text would be a wrong answer rather than an error.
+///
+/// A term naming a column the row doesn't have never matches. Absence is not
+/// a value, so treating a missing column as a pass would let a typo silently
+/// widen the aggregation to every row.
+#[derive(Debug, Clone, Default)]
+pub struct Conditions {
+    terms: Vec<(String, CborValue)>,
+}
+
+impl Conditions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add `column == value`. The column may be a dotted path into a nested
+    /// record (`Message.Headers.Subject`).
+    pub fn eq(mut self, column: impl Into<String>, value: impl Into<CborValue>) -> Self {
+        self.terms.push((column.into(), value.into()));
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.terms.is_empty()
+    }
+
+    /// Whether one row satisfies every term.
+    pub fn matches(&self, record: &Record<CborValue>) -> bool {
+        self.terms.iter().all(|(column, expected)| {
+            cmp::column(record, column).is_some_and(|actual| value_eq(actual, expected))
+        })
+    }
+
+    /// Narrow a row set to the rows that match. Returns the input untouched
+    /// when there are no terms, so an unconditioned aggregation pays nothing.
+    pub fn narrow<'a>(&self, rows: &'a Rows) -> std::borrow::Cow<'a, Rows> {
+        if self.is_empty() {
+            return std::borrow::Cow::Borrowed(rows);
+        }
+        std::borrow::Cow::Owned(
+            rows.iter()
+                .filter(|(_, record)| self.matches(record))
+                .map(|(id, record)| (id.clone(), record.clone()))
+                .collect(),
+        )
+    }
+}
+
+/// CBOR equality, falling back to comparing scalar renderings so a
+/// configured `"200"` matches an integer `200`. See [`Conditions`].
+fn value_eq(actual: &CborValue, expected: &CborValue) -> bool {
+    if actual == expected {
+        return true;
+    }
+    match (cmp::scalar_text(actual), cmp::scalar_text(expected)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// Run `inner` over only the rows matching `conditions`.
+///
+/// Works with any aggregation, scalar or row-producing — a filtered
+/// `GroupBy` is `Where::new(conditions, GroupBy::column(..))` and needs no
+/// special support from either side.
+pub struct Where<A> {
+    conditions: Conditions,
+    inner: A,
+}
+
+impl<A> Where<A> {
+    pub fn new(conditions: Conditions, inner: A) -> Self {
+        Self { conditions, inner }
+    }
+}
+
+impl<A: Aggregation> Aggregation for Where<A> {
+    type Output = A::Output;
+
+    fn compute(&self, rows: &Rows) -> Self::Output {
+        self.inner.compute(&self.conditions.narrow(rows))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builtin::{Count, Sum};
+
+    fn record(pairs: &[(&str, CborValue)]) -> Record<CborValue> {
+        let mut r = Record::new();
+        for (k, v) in pairs {
+            r.insert((*k).to_string(), v.clone());
+        }
+        r
+    }
+
+    fn rows(records: Vec<Record<CborValue>>) -> Rows {
+        records
+            .into_iter()
+            .enumerate()
+            .map(|(i, r)| (i.to_string(), r))
+            .collect()
+    }
+
+    fn text(s: &str) -> CborValue {
+        CborValue::Text(s.to_string())
+    }
+
+    fn events() -> Rows {
+        rows(vec![
+            record(&[("Event", text("opened")), ("Size", CborValue::Integer(10.into()))]),
+            record(&[("Event", text("failed")), ("Size", CborValue::Integer(20.into()))]),
+            record(&[("Event", text("opened")), ("Size", CborValue::Integer(30.into()))]),
+        ])
+    }
+
+    #[test]
+    fn where_narrows_a_count() {
+        let agg = Where::new(Conditions::new().eq("Event", text("opened")), Count::rows());
+        assert_eq!(agg.compute(&events()), CborValue::Integer(2.into()));
+    }
+
+    /// The reason this is a combinator and not a `CountWhere` twin: the same
+    /// conditions narrow any reduction.
+    #[test]
+    fn where_narrows_a_sum() {
+        let agg = Where::new(
+            Conditions::new().eq("Event", text("opened")),
+            Sum::new("Size"),
+        );
+        // 10 + 30, not 60.
+        assert_eq!(agg.compute(&events()), CborValue::Integer(40.into()));
+    }
+
+    #[test]
+    fn no_conditions_passes_every_row_through() {
+        let agg = Where::new(Conditions::new(), Count::rows());
+        assert_eq!(agg.compute(&events()), CborValue::Integer(3.into()));
+    }
+
+    #[test]
+    fn a_term_on_an_absent_column_matches_nothing() {
+        let agg = Where::new(Conditions::new().eq("Nope", text("opened")), Count::rows());
+        assert_eq!(agg.compute(&events()), CborValue::Integer(0.into()));
+    }
+
+    /// Configuration carries strings; the data may not. Matching only on CBOR
+    /// equality would make `code: 200` in a YAML file silently count zero.
+    #[test]
+    fn a_text_term_matches_a_numeric_column() {
+        let numeric = rows(vec![
+            record(&[("code", CborValue::Integer(200.into()))]),
+            record(&[("code", CborValue::Integer(500.into()))]),
+        ]);
+        let agg = Where::new(Conditions::new().eq("code", text("200")), Count::rows());
+        assert_eq!(agg.compute(&numeric), CborValue::Integer(1.into()));
+    }
+
+    #[test]
+    fn terms_reach_into_nested_records_by_dotted_path() {
+        let nested = rows(vec![
+            record(&[(
+                "Message",
+                CborValue::Map(vec![(text("Transport"), text("smtp"))]),
+            )]),
+            record(&[(
+                "Message",
+                CborValue::Map(vec![(text("Transport"), text("api"))]),
+            )]),
+        ]);
+        let agg = Where::new(
+            Conditions::new().eq("Message.Transport", text("smtp")),
+            Count::rows(),
+        );
+        assert_eq!(agg.compute(&nested), CborValue::Integer(1.into()));
+    }
+
+    #[test]
+    fn terms_are_anded() {
+        let agg = Where::new(
+            Conditions::new()
+                .eq("Event", text("opened"))
+                .eq("Size", CborValue::Integer(30.into())),
+            Count::rows(),
+        );
+        assert_eq!(agg.compute(&events()), CborValue::Integer(1.into()));
+    }
+}

--- a/vantage-diorama-aggregate/src/builtin/mod.rs
+++ b/vantage-diorama-aggregate/src/builtin/mod.rs
@@ -3,11 +3,13 @@
 //! Each is a small [`Aggregation`](crate::Aggregation) impl and nothing more —
 //! the same surface anything you write yourself uses.
 
+mod as_rows;
 mod count;
 mod filter;
 mod group;
 mod stats;
 
+pub use as_rows::AsRows;
 pub use count::{Count, CountWhere};
 pub use filter::{Conditions, Where};
 pub use group::{GroupBy, GroupReducer, Reduce};

--- a/vantage-diorama-aggregate/src/builtin/mod.rs
+++ b/vantage-diorama-aggregate/src/builtin/mod.rs
@@ -4,9 +4,11 @@
 //! the same surface anything you write yourself uses.
 
 mod count;
+mod filter;
 mod group;
 mod stats;
 
 pub use count::{Count, CountWhere};
+pub use filter::{Conditions, Where};
 pub use group::{GroupBy, GroupReducer, Reduce};
 pub use stats::{Avg, Distinct, Max, Min, Sum};

--- a/vantage-diorama-aggregate/src/catalog.rs
+++ b/vantage-diorama-aggregate/src/catalog.rs
@@ -1,0 +1,238 @@
+//! Building an aggregation from a *name*, so configuration can declare one.
+//!
+//! The typed constructors ([`Count`], [`Sum`], …) are the API for Rust callers
+//! who know at compile time what they want. Configuration doesn't: a YAML file
+//! says `op: sum`, and something has to turn that string into an
+//! [`Aggregation`]. Doing it with a match at the call site means every consumer
+//! grows the same six-arm match, and none of them can be extended with an
+//! aggregation the crate doesn't ship.
+//!
+//! [`AggregationCatalog`] is that lookup — the same shape as
+//! [`VistaCatalog`](vantage_vista_factory::VistaCatalog), which resolves a
+//! vista by name for exactly the same reason.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use vantage_core::{Result, error};
+
+use crate::aggregation::{Aggregation, Rows};
+use crate::builtin::{Avg, Conditions, Count, Distinct, Max, Min, Sum, Where};
+
+/// A scalar aggregation whose concrete type isn't known until runtime.
+///
+/// [`AggregateLens::value`](crate::AggregateLens::value) is generic, which
+/// suits a caller naming its aggregation in code; a caller reading one from
+/// configuration needs a single type to hand over, and this is it.
+pub type ScalarAggregation = Box<dyn Aggregation<Output = CborValue>>;
+
+/// So a boxed aggregation can be passed anywhere a concrete one can — in
+/// particular to `AggregateLens::value`, without it needing a `dyn` variant.
+impl Aggregation for ScalarAggregation {
+    type Output = CborValue;
+
+    fn compute(&self, rows: &Rows) -> CborValue {
+        (**self).compute(rows)
+    }
+}
+
+/// What a builder is handed: everything a declared aggregation can say about
+/// itself besides its name.
+pub struct AggregationSpec {
+    /// The column the reduction reads. `None` for reductions over whole rows.
+    pub column: Option<String>,
+    /// Rows the reduction is restricted to. Applied by the catalog, not by
+    /// each builder — narrowing is orthogonal to reducing (see [`Where`]).
+    pub conditions: Conditions,
+}
+
+impl AggregationSpec {
+    /// The column, or a clear error naming the op that needed one.
+    pub fn require_column(&self, op: &str) -> Result<String> {
+        self.column.clone().ok_or_else(|| {
+            error!(
+                "aggregation requires a `column` to reduce",
+                op = op.to_string()
+            )
+        })
+    }
+}
+
+/// Builds one aggregation from its spec.
+pub type AggregationBuilder =
+    Arc<dyn Fn(&str, &AggregationSpec) -> Result<ScalarAggregation> + Send + Sync>;
+
+/// Name → aggregation.
+pub struct AggregationCatalog {
+    builders: HashMap<String, AggregationBuilder>,
+}
+
+impl AggregationCatalog {
+    /// An empty catalog. Prefer [`with_builtins`](Self::with_builtins) unless
+    /// you specifically want to control which names exist.
+    pub fn new() -> Self {
+        Self {
+            builders: HashMap::new(),
+        }
+    }
+
+    /// Every reduction this crate ships, under its lowercase name: `count`,
+    /// `sum`, `avg`, `min`, `max`, `distinct`.
+    pub fn with_builtins() -> Self {
+        let mut catalog = Self::new();
+        catalog.register("count", |_, _| Ok(Box::new(Count::rows()) as ScalarAggregation));
+        catalog.register("sum", |op, spec| {
+            Ok(Box::new(Sum::new(spec.require_column(op)?)) as ScalarAggregation)
+        });
+        catalog.register("avg", |op, spec| {
+            Ok(Box::new(Avg::new(spec.require_column(op)?)) as ScalarAggregation)
+        });
+        catalog.register("min", |op, spec| {
+            Ok(Box::new(Min::new(spec.require_column(op)?)) as ScalarAggregation)
+        });
+        catalog.register("max", |op, spec| {
+            Ok(Box::new(Max::new(spec.require_column(op)?)) as ScalarAggregation)
+        });
+        catalog.register("distinct", |op, spec| {
+            Ok(Box::new(Distinct::new(spec.require_column(op)?)) as ScalarAggregation)
+        });
+        catalog
+    }
+
+    /// Register (or replace) the aggregation built for `name`. This is the
+    /// extension point: an application with its own reduction makes it
+    /// declarable by registering it here, with no change to this crate.
+    pub fn register<F>(&mut self, name: impl Into<String>, builder: F)
+    where
+        F: Fn(&str, &AggregationSpec) -> Result<ScalarAggregation> + Send + Sync + 'static,
+    {
+        self.builders.insert(name.into(), Arc::new(builder));
+    }
+
+    /// The names this catalog can build, sorted — for error messages and for
+    /// a config validator listing what's available.
+    pub fn names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.builders.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// Build the named aggregation, wrapping it in the spec's conditions.
+    ///
+    /// The narrowing is applied here rather than inside each builder, so every
+    /// aggregation — including one an application registered itself — supports
+    /// `where` without writing any code for it.
+    pub fn build(&self, name: &str, spec: AggregationSpec) -> Result<ScalarAggregation> {
+        let Some(builder) = self.builders.get(name) else {
+            return Err(error!(
+                "unknown aggregation",
+                op = name.to_string(),
+                known = self.names().join(", ")
+            ));
+        };
+        let inner = builder(name, &spec)?;
+        if spec.conditions.is_empty() {
+            return Ok(inner);
+        }
+        Ok(Box::new(Where::new(spec.conditions, inner)) as ScalarAggregation)
+    }
+}
+
+impl Default for AggregationCatalog {
+    fn default() -> Self {
+        Self::with_builtins()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vantage_types::Record;
+
+    fn rows() -> Rows {
+        let mut a = Record::new();
+        a.insert("Event".into(), CborValue::Text("opened".into()));
+        a.insert("Size".into(), CborValue::Integer(10.into()));
+        let mut b = Record::new();
+        b.insert("Event".into(), CborValue::Text("failed".into()));
+        b.insert("Size".into(), CborValue::Integer(20.into()));
+        [("a".to_string(), a), ("b".to_string(), b)]
+            .into_iter()
+            .collect()
+    }
+
+    fn spec(column: Option<&str>, conditions: Conditions) -> AggregationSpec {
+        AggregationSpec {
+            column: column.map(str::to_string),
+            conditions,
+        }
+    }
+
+    #[test]
+    fn builds_a_named_reduction() {
+        let catalog = AggregationCatalog::with_builtins();
+        let agg = catalog
+            .build("sum", spec(Some("Size"), Conditions::new()))
+            .unwrap();
+        assert_eq!(agg.compute(&rows()), CborValue::Integer(30.into()));
+    }
+
+    /// Conditions are applied by the catalog, so they work for every name
+    /// including ones registered from outside this crate.
+    #[test]
+    fn applies_conditions_to_any_named_reduction() {
+        let catalog = AggregationCatalog::with_builtins();
+        let agg = catalog
+            .build(
+                "sum",
+                spec(
+                    Some("Size"),
+                    Conditions::new().eq("Event", CborValue::Text("opened".into())),
+                ),
+            )
+            .unwrap();
+        assert_eq!(agg.compute(&rows()), CborValue::Integer(10.into()));
+    }
+
+    #[test]
+    fn an_unknown_name_lists_what_is_available() {
+        let catalog = AggregationCatalog::with_builtins();
+        // `unwrap_err` would need `Debug` on a boxed trait object; match instead.
+        let err = match catalog.build("median", spec(Some("Size"), Conditions::new())) {
+            Ok(_) => panic!("an unknown op must not build"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains("median"), "names the bad op: {err}");
+        assert!(err.contains("distinct"), "lists the known ops: {err}");
+    }
+
+    /// `count` is the only builtin that reduces whole rows; the rest must say
+    /// what they reduce, and saying so badly is an error, not a zero.
+    #[test]
+    fn a_reduction_without_its_column_fails_loudly() {
+        let catalog = AggregationCatalog::with_builtins();
+        assert!(catalog.build("sum", spec(None, Conditions::new())).is_err());
+        assert!(catalog.build("count", spec(None, Conditions::new())).is_ok());
+    }
+
+    #[test]
+    fn a_registered_aggregation_becomes_declarable() {
+        let mut catalog = AggregationCatalog::with_builtins();
+        catalog.register("always_seven", |_, _| {
+            Ok(Box::new(Sevens) as ScalarAggregation)
+        });
+        let agg = catalog
+            .build("always_seven", spec(None, Conditions::new()))
+            .unwrap();
+        assert_eq!(agg.compute(&rows()), CborValue::Integer(7.into()));
+    }
+
+    struct Sevens;
+    impl Aggregation for Sevens {
+        type Output = CborValue;
+        fn compute(&self, _rows: &Rows) -> CborValue {
+            CborValue::Integer(7.into())
+        }
+    }
+}

--- a/vantage-diorama-aggregate/src/catalog.rs
+++ b/vantage-diorama-aggregate/src/catalog.rs
@@ -84,7 +84,9 @@ impl AggregationCatalog {
     /// `sum`, `avg`, `min`, `max`, `distinct`.
     pub fn with_builtins() -> Self {
         let mut catalog = Self::new();
-        catalog.register("count", |_, _| Ok(Box::new(Count::rows()) as ScalarAggregation));
+        catalog.register("count", |_, _| {
+            Ok(Box::new(Count::rows()) as ScalarAggregation)
+        });
         catalog.register("sum", |op, spec| {
             Ok(Box::new(Sum::new(spec.require_column(op)?)) as ScalarAggregation)
         });
@@ -150,14 +152,24 @@ impl AggregationCatalog {
     /// grouped `sum` and a top-level `sum` cannot disagree — same reduction,
     /// different row set — and an application-registered aggregation is
     /// groupable the moment it is registered.
+    // The nesting is the point: the caller gets a concrete `GroupBy<Reduce<_>>`
+    // it can compose further, not a boxed closure. Clippy's advice — factor the
+    // type into an alias — cannot apply, because the reduction is a
+    // return-position `impl Fn` and a `type` alias may not hold one on stable.
+    #[allow(clippy::type_complexity)]
     pub fn group_by(
         &self,
         key_column: impl Into<String>,
         op: &str,
         alias: impl Into<String>,
         spec: AggregationSpec,
-    ) -> Result<GroupBy<Reduce<impl Fn(&CborValue, &[&Record<CborValue>]) -> Record<CborValue> + Send + Sync + 'static>>>
-    {
+    ) -> Result<
+        GroupBy<
+            Reduce<
+                impl Fn(&CborValue, &[&Record<CborValue>]) -> Record<CborValue> + Send + Sync + 'static,
+            >,
+        >,
+    > {
         let alias = alias.into();
         // Built once, up front: a bad declaration must surface now, not once
         // per group on every recomputation.
@@ -254,7 +266,11 @@ mod tests {
     fn a_reduction_without_its_column_fails_loudly() {
         let catalog = AggregationCatalog::with_builtins();
         assert!(catalog.build("sum", spec(None, Conditions::new())).is_err());
-        assert!(catalog.build("count", spec(None, Conditions::new())).is_ok());
+        assert!(
+            catalog
+                .build("count", spec(None, Conditions::new()))
+                .is_ok()
+        );
     }
 
     #[test]

--- a/vantage-diorama-aggregate/src/catalog.rs
+++ b/vantage-diorama-aggregate/src/catalog.rs
@@ -17,8 +17,11 @@ use std::sync::Arc;
 use ciborium::Value as CborValue;
 use vantage_core::{Result, error};
 
+use vantage_types::Record;
+use vantage_vista::Column;
+
 use crate::aggregation::{Aggregation, Rows};
-use crate::builtin::{Avg, Conditions, Count, Distinct, Max, Min, Sum, Where};
+use crate::builtin::{Avg, Conditions, Count, Distinct, GroupBy, Max, Min, Reduce, Sum, Where};
 
 /// A scalar aggregation whose concrete type isn't known until runtime.
 ///
@@ -139,6 +142,44 @@ impl AggregationCatalog {
     }
 }
 
+impl AggregationCatalog {
+    /// Build a `group_by`: one row per distinct value of `key_column`, each
+    /// carrying the key plus the named reduction over that group's rows.
+    ///
+    /// The per-group reduction is built through this same catalog, so a
+    /// grouped `sum` and a top-level `sum` cannot disagree — same reduction,
+    /// different row set — and an application-registered aggregation is
+    /// groupable the moment it is registered.
+    pub fn group_by(
+        &self,
+        key_column: impl Into<String>,
+        op: &str,
+        alias: impl Into<String>,
+        spec: AggregationSpec,
+    ) -> Result<GroupBy<Reduce<impl Fn(&CborValue, &[&Record<CborValue>]) -> Record<CborValue> + Send + Sync + 'static>>>
+    {
+        let alias = alias.into();
+        // Built once, up front: a bad declaration must surface now, not once
+        // per group on every recomputation.
+        let reduction = self.build(op, spec)?;
+        let out_name = alias.clone();
+        let columns = vec![Column::new(alias, "f64")];
+        Ok(GroupBy::column(
+            key_column,
+            Reduce::new(columns, move |_key, members| {
+                let rows: Rows = members
+                    .iter()
+                    .enumerate()
+                    .map(|(i, record)| (i.to_string(), (*record).clone()))
+                    .collect();
+                let mut out = Record::new();
+                out.insert(out_name.clone(), reduction.compute(&rows));
+                out
+            }),
+        ))
+    }
+}
+
 impl Default for AggregationCatalog {
     fn default() -> Self {
         Self::with_builtins()
@@ -226,6 +267,53 @@ mod tests {
             .build("always_seven", spec(None, Conditions::new()))
             .unwrap();
         assert_eq!(agg.compute(&rows()), CborValue::Integer(7.into()));
+    }
+
+    /// Grouping routes through the same catalog as a top-level reduction, so
+    /// the groups must add up to the whole. If these ever diverge, two copies
+    /// of "sum" have appeared.
+    #[test]
+    fn the_groups_agree_with_the_ungrouped_reduction() {
+        let catalog = AggregationCatalog::with_builtins();
+        let grouped = catalog
+            .group_by(
+                "Event",
+                "sum",
+                "bytes",
+                spec(Some("Size"), Conditions::new()),
+            )
+            .unwrap()
+            .compute(&rows());
+        let total = catalog
+            .build("sum", spec(Some("Size"), Conditions::new()))
+            .unwrap()
+            .compute(&rows());
+
+        assert_eq!(grouped.len(), 2, "one row per distinct Event");
+        let summed: i64 = grouped
+            .rows
+            .iter()
+            .filter_map(|(_, row)| match row.get("bytes") {
+                Some(CborValue::Integer(i)) => Some(i128::from(*i) as i64),
+                _ => None,
+            })
+            .sum();
+        assert_eq!(CborValue::Integer(summed.into()), total);
+    }
+
+    /// The key column comes back on every row — a breakdown you can't label
+    /// isn't one.
+    #[test]
+    fn every_group_carries_its_key() {
+        let catalog = AggregationCatalog::with_builtins();
+        let grouped = catalog
+            .group_by("Event", "count", "n", spec(None, Conditions::new()))
+            .unwrap()
+            .compute(&rows());
+        for (_, row) in &grouped.rows {
+            assert!(row.get("Event").is_some(), "row without its key: {row:?}");
+            assert!(row.get("n").is_some());
+        }
     }
 
     struct Sevens;

--- a/vantage-diorama-aggregate/src/cmp.rs
+++ b/vantage-diorama-aggregate/src/cmp.rs
@@ -27,6 +27,24 @@ pub fn column<'a>(record: &'a Record<CborValue>, path: &str) -> Option<&'a CborV
     Some(current)
 }
 
+/// Render a CBOR scalar as text, or `None` for shapes that aren't scalars
+/// (maps, arrays, bytes, null). Tags are transparent — a tagged datetime or
+/// record id renders as whatever it wraps.
+///
+/// Used to compare a configured value against a column whose CBOR type is
+/// unknown to the configuration; deliberately `Option` so a non-scalar never
+/// silently compares equal to an empty string.
+pub fn scalar_text(value: &CborValue) -> Option<String> {
+    match value {
+        CborValue::Text(s) => Some(s.clone()),
+        CborValue::Integer(i) => Some(i128::from(*i).to_string()),
+        CborValue::Float(f) => Some(f.to_string()),
+        CborValue::Bool(b) => Some(b.to_string()),
+        CborValue::Tag(_, inner) => scalar_text(inner),
+        _ => None,
+    }
+}
+
 /// Total order over CBOR scalars.
 ///
 /// Numbers compare numerically across the integer/float boundary — never by

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -145,9 +145,19 @@ enum Wake {
 ///
 /// Two kinds of event are excluded, for different reasons.
 ///
-/// **Loading events** (`ViewportChanged`, `RangeLoaded`, `LoadFailed`,
-/// `Hydrating`) describe a viewport moving, not rows changing. Any row they
-/// bring in arrives as its own `RecordChanged`.
+/// **Loading events** (`ViewportChanged`, `LoadFailed`, `Hydrating`) describe a
+/// viewport moving or a pass making progress, not rows changing. Two-pass
+/// hydration emits `RecordChanged` for every row it fills in, so nothing is
+/// missed by ignoring them.
+///
+/// `RangeLoaded` is NOT among them, though it reads like one. A single-pass
+/// chunk load writes its rows through [`ChunkSink::push`], straight into the
+/// cache — it emits no per-row event, and `RangeLoaded` is the only thing it
+/// announces. Ignoring it meant a paged source could load its whole first page
+/// and every aggregate over it would still be reporting the empty set it was
+/// derived over: a dashboard opening on a cold cache showed three zeros and
+/// kept showing them. It is also what makes an aggregate *progressive* — each
+/// page that lands recomputes over everything held so far.
 ///
 /// **`Refreshing`** announces that a refresh has *started*. It is emitted
 /// before the source's `on_refresh` runs, and the common shape of that callback
@@ -163,7 +173,6 @@ async fn wait(bus: &mut broadcast::Receiver<DioEvent>, nudge: &Notify) -> Wake {
             _ = nudge.notified() => return Wake::Changed,
             received = bus.recv() => match received {
                 Ok(DioEvent::ViewportChanged { .. })
-                | Ok(DioEvent::RangeLoaded { .. })
                 | Ok(DioEvent::LoadFailed { .. })
                 | Ok(DioEvent::Hydrating { .. })
                 | Ok(DioEvent::Refreshing) => continue,

--- a/vantage-diorama-aggregate/src/lens.rs
+++ b/vantage-diorama-aggregate/src/lens.rs
@@ -147,6 +147,33 @@ impl AggregateLens {
         }))
     }
 
+    /// Mount a **scalar** reduction as a one-row Dio — the shape SQL gives a
+    /// `count(*)`, and the shape every consumer here already handles.
+    ///
+    /// Prefer this to [`value`](Self::value) when the result is going to be
+    /// observed like data. `value` hands back a bare number, which forces a
+    /// parallel scenery/observation path all the way up the stack; this hands
+    /// back a table with one row and one column named `alias`, so a grid, a
+    /// chart and a single-figure tile all bind to it identically.
+    ///
+    /// ```ignore
+    /// let opened = agg.derive_value(&events, "events#count[Event=opened]", "opened",
+    ///                               catalog.build("count", spec)?).await?;
+    /// // → a Dio whose whole content is:  opened
+    /// //                                  ------
+    /// //                                       7
+    /// ```
+    pub async fn derive_value(
+        self: &Arc<Self>,
+        source: &Dio,
+        name: &str,
+        alias: &str,
+        reduction: crate::ScalarAggregation,
+    ) -> Result<DerivedDio> {
+        self.derive(source, name, crate::AsRows::new(alias, reduction))
+            .await
+    }
+
     /// Mount a row-producing aggregation as its own `Dio`.
     ///
     /// The result is an ordinary Dio: open sceneries on it, sort and search it,

--- a/vantage-diorama-aggregate/src/lens.rs
+++ b/vantage-diorama-aggregate/src/lens.rs
@@ -90,6 +90,15 @@ impl AggregateLens {
         }
     }
 
+    /// Close the aggregate cache cleanly, before the process exits.
+    ///
+    /// Derived results are reproducible, so losing this file costs only a warm
+    /// start — but an unclean close costs a full-file repair scan on every
+    /// launch afterwards, which is worse than the thing the cache buys.
+    pub async fn close(&self) {
+        self.backend.close().await;
+    }
+
     /// Drop cached aggregates whose names are no longer in use.
     ///
     /// Names encode what an aggregate *is*; when a definition changes, the old

--- a/vantage-diorama-aggregate/src/lib.rs
+++ b/vantage-diorama-aggregate/src/lib.rs
@@ -65,9 +65,7 @@ pub use builtin::{
     AsRows, Avg, Conditions, Count, CountWhere, Distinct, GroupBy, GroupReducer, Max, Min, Reduce,
     Sum, Where,
 };
-pub use catalog::{
-    AggregationBuilder, AggregationCatalog, AggregationSpec, ScalarAggregation,
-};
+pub use catalog::{AggregationBuilder, AggregationCatalog, AggregationSpec, ScalarAggregation};
 pub use derived::DerivedDio;
 pub use lens::{AggregateLens, AggregateLensBuilder};
 pub use value::AggregateValue;

--- a/vantage-diorama-aggregate/src/lib.rs
+++ b/vantage-diorama-aggregate/src/lib.rs
@@ -62,8 +62,8 @@ mod value;
 
 pub use aggregation::{AggregateOutput, Aggregation, DerivedRows, Rows};
 pub use builtin::{
-    Avg, Conditions, Count, CountWhere, Distinct, GroupBy, GroupReducer, Max, Min, Reduce, Sum,
-    Where,
+    AsRows, Avg, Conditions, Count, CountWhere, Distinct, GroupBy, GroupReducer, Max, Min, Reduce,
+    Sum, Where,
 };
 pub use catalog::{
     AggregationBuilder, AggregationCatalog, AggregationSpec, ScalarAggregation,

--- a/vantage-diorama-aggregate/src/lib.rs
+++ b/vantage-diorama-aggregate/src/lib.rs
@@ -53,6 +53,7 @@
 
 mod aggregation;
 mod builtin;
+mod catalog;
 mod cmp;
 mod derived;
 mod engine;
@@ -60,7 +61,13 @@ mod lens;
 mod value;
 
 pub use aggregation::{AggregateOutput, Aggregation, DerivedRows, Rows};
-pub use builtin::{Avg, Count, CountWhere, Distinct, GroupBy, GroupReducer, Max, Min, Reduce, Sum};
+pub use builtin::{
+    Avg, Conditions, Count, CountWhere, Distinct, GroupBy, GroupReducer, Max, Min, Reduce, Sum,
+    Where,
+};
+pub use catalog::{
+    AggregationBuilder, AggregationCatalog, AggregationSpec, ScalarAggregation,
+};
 pub use derived::DerivedDio;
 pub use lens::{AggregateLens, AggregateLensBuilder};
 pub use value::AggregateValue;

--- a/vantage-diorama-aggregate/tests/paged_source.rs
+++ b/vantage-diorama-aggregate/tests/paged_source.rs
@@ -1,0 +1,133 @@
+//! Aggregates over a source that loads a page at a time.
+//!
+//! An eager source has all its rows before anything is derived from it, so the
+//! first computation is also the right one. A paged source does not: a
+//! dashboard opens against a cold cache, derives three figures over zero rows,
+//! and the rows arrive seconds later.
+//!
+//! Nothing announces those rows per-record. A chunk load writes them straight
+//! into the cache through `ChunkSink::push` and says only `RangeLoaded` — so an
+//! aggregate that ignores that event computes once over the empty set and stays
+//! there, showing a confident zero for as long as the page is open. This is
+//! also what "progressive" means here: every page that lands recomputes over
+//! everything held so far.
+
+mod support;
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use vantage_core::Result;
+use vantage_diorama::{Dio, Lens};
+use vantage_diorama_aggregate::{AggregateLens, Count, CountWhere};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell};
+
+use support::{DEBOUNCE, record, settle, text};
+
+fn lens() -> Arc<AggregateLens> {
+    AggregateLens::in_memory()
+        .debounce(DEBOUNCE)
+        .build()
+        .expect("aggregate lens builds")
+}
+
+fn as_i64(value: Option<CborValue>) -> Option<i64> {
+    match value {
+        Some(CborValue::Integer(i)) => Some(i128::from(i) as i64),
+        _ => None,
+    }
+}
+
+/// Rows the paged source will serve, alternating status so a filtered count has
+/// something to disagree with.
+fn rows(n: usize) -> Vec<(String, Record<CborValue>)> {
+    (0..n)
+        .map(|i| {
+            let status = if i % 2 == 0 { "open" } else { "done" };
+            (format!("id{i}"), record(&[("status", text(status))]))
+        })
+        .collect()
+}
+
+/// A source that holds nothing until a viewport asks for it.
+async fn paged_source(backing: Vec<(String, Record<CborValue>)>) -> Dio {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("status", "String"))
+        .with_id_column("id");
+    let vista =
+        Vista::new(
+            "items",
+            Box::new(MockShell::new().with_metadata(metadata).with_capabilities(
+                VistaCapabilities {
+                    can_order: false,
+                    ..Default::default()
+                },
+            )),
+        );
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_load_chunk(move |_dio, range, _sort, sink| {
+                let backing = backing.clone();
+                async move {
+                    for idx in range {
+                        if let Some((id, r)) = backing.get(idx) {
+                            sink.push(idx, id.clone(), r.clone()).await?;
+                        }
+                    }
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("paged lens builds"),
+    );
+    lens.make_dio(vista).await.expect("paged source dio")
+}
+
+/// The figures track rows as they arrive, page by page — they do not freeze at
+/// whatever the cache held when they were derived.
+#[tokio::test(flavor = "multi_thread")]
+async fn aggregates_follow_a_paged_load() -> Result<()> {
+    let src = paged_source(rows(10)).await;
+    let agg = lens();
+
+    // Derived against an empty cache, exactly as a dashboard opens.
+    let all = agg.value(&src, "all", Count::rows()).await?;
+    let open = agg
+        .value(&src, "open", CountWhere::new().eq("status", text("open")))
+        .await?;
+    settle().await;
+    assert_eq!(as_i64(all.value()), Some(0), "nothing loaded yet");
+
+    // First page lands.
+    let scenery = src.table_scenery().open().await?;
+    scenery.set_viewport(0..4);
+    wait_for(&all, 4).await;
+    assert_eq!(as_i64(all.value()), Some(4), "the first page is counted");
+    assert_eq!(as_i64(open.value()), Some(2), "and so is a filtered count");
+
+    // Scrolling brings more; the figures grow with them.
+    scenery.set_viewport(0..10);
+    wait_for(&all, 10).await;
+    assert_eq!(as_i64(all.value()), Some(10));
+    assert_eq!(as_i64(open.value()), Some(5));
+    Ok(())
+}
+
+/// Wait for a derived value to reach `want`, bounding a hang without asserting
+/// a speed: reaching it takes a chunk load plus the engine's debounce.
+async fn wait_for(value: &Arc<dyn vantage_diorama::ValueScenery>, want: i64) {
+    for _ in 0..60 {
+        if as_i64(value.value()) == Some(want) {
+            return;
+        }
+        settle().await;
+    }
+    panic!(
+        "derived value settled at {:?}, wanted {want} — rows loaded by a chunk \
+         fetch are not reaching the aggregation",
+        as_i64(value.value()),
+    );
+}

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## 0.10.0 — 2026-07-28
+
+**A scenery reads its own shape, not its lens's offers**
+
+One Lens per datasource carries every callback any table under it might need —
+`on_start` to copy a set whole, `on_load_chunk` to window a pageable one. Which
+one applies is a property of the *master*, decided per scenery at open. Several
+places asked the lens instead, and under a shared lens the lens's answer is
+always "both", so they got it wrong.
+
+- **A landed eager seed reaches sceneries again.** `is_chunk_loaded` decided
+  paged-vs-eager from "does this lens register an `on_load_chunk`". Sharing one
+  lens made that always true, so an eager scenery answered a landed dataset by
+  re-fetching a viewport it never fetches through. Its rows sat in the cache and
+  the grid stayed empty for as long as it stayed open — reopening it worked,
+  because the open path seeds from what is by then a warm cache. It now reads
+  the shape recorded at open.
+
+- **`DioEvent::Seeded`** — the eager loader announcing that the whole set is in
+  the cache. Distinct from `DatasetChanged`, which says only "membership moved,
+  re-derive however your shape demands": this says what landed and where, and
+  every scenery whose rows come from the cache answers it the same way. The
+  enum is now `#[non_exhaustive]`, so the next variant will not be a breaking
+  change. **Matches on `DioEvent` need a fallback arm.**
+
+- **A grid no longer paints "no rows" over a load in flight.** Settling is what
+  ends a view's loading state, and two paths did it too early: a paged scenery
+  reseeding from an empty cache (a grid applying its default sort at mount
+  triggers exactly this, milliseconds before the first fetch dispatches), and an
+  eager one reseeding while its background copy was still running. An empty
+  cache and an empty table are indistinguishable from the cache alone;
+  `seed_complete` on the Dio is what tells them apart.
+
+- **`LoadState`** (`Loading` / `Partial` / `Complete`) on `TableScenery`, with
+  `load_state()` and `is_loading()`. Consumers waiting for rows can wait on the
+  state instead of assuming `open()` implies data.
+
+- **A fetch ledger** in `stats`: per table, how many windows were requested, how
+  many were requested more than once, and how many rows came back that the cache
+  already held. Waste is invisible without counting it.
+
+- **`mark_settled` logs its caller.** Which path settled a scenery is the whole
+  question when a grid empties too early, and the flag records only that someone
+  did.
+
+- Chunk loads write once per page rather than once per row — a redb transaction
+  and its durability barrier per row made a hundred-row page cost a hundred of
+  them.
+
+- A source that overstates its total no longer loops: rows it will not serve are
+  asked for a bounded number of times, then the set is capped at what arrived.
+
+- Two-pass hydration prioritises rows by their **displayed** position, so a
+  sorted view hydrates what is on screen rather than what happens to be early in
+  the index.
+
 ## 0.9.0 — 2026-07-27
 
 **Client-side search is gone, and so is the augmentation spec layer**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.6.2", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
 vantage-vista-factory = { version = "0.6", path = "../vantage-vista-factory" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }

--- a/vantage-diorama/src/dio/event_bus.rs
+++ b/vantage-diorama/src/dio/event_bus.rs
@@ -7,7 +7,13 @@ use std::ops::Range;
 /// *upstream* shape (what a SurrealDB LIVE stream or a webhook delivers
 /// about the master backend), while `DioEvent` is the *internal* fanout
 /// shape Sceneries react to.
+/// Marked `#[non_exhaustive]`: the bus gains a variant whenever the layer
+/// learns to say something new about a load, and a consumer that cares about
+/// three of them should not break when a fourth appears. Every match on this
+/// enum needs a fallback arm, which is the right default anyway — an event you
+/// have not heard of is one you have no handling for.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum DioEvent {
     RecordChanged {
         id: String,
@@ -19,6 +25,24 @@ pub enum DioEvent {
         id: String,
     },
     DatasetChanged,
+
+    /// The lens's own eager loader (`on_start`) has finished writing the whole
+    /// set to the cache.
+    ///
+    /// Distinct from [`DatasetChanged`](Self::DatasetChanged), which says only
+    /// "membership moved — re-derive however your shape demands". This says
+    /// what landed and where it is: the full set, in the cache, now. Every
+    /// single-pass scenery answers it the same way — reseed the visible map
+    /// from the cache — whatever its load shape.
+    ///
+    /// That uniformity is the point. Announced as `DatasetChanged`, the seed's
+    /// arrival became a question about shape, and a scenery under a lens that
+    /// also offers `on_load_chunk` answered it wrongly: re-fetch the viewport
+    /// through a pager it never pages through. The rows sat in the cache and
+    /// the grid stayed empty. A scenery cannot get this one wrong by
+    /// misjudging its own shape, because it does not consult it.
+    Seeded,
+
     Refreshing,
     WriteFailed {
         id: Option<String>,

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -202,6 +202,17 @@ pub(crate) struct DioInner {
     /// mask that. The two sets answer different questions and are invalidated
     /// by different events.
     pub(crate) augment_settled: std::sync::Mutex<std::collections::HashSet<String>>,
+
+    /// False only while a detached `on_start` is still copying the set into the
+    /// cache. True once it finishes — success or failure alike, since a failed
+    /// seed means no rows are coming either.
+    ///
+    /// A scenery reads this to tell an empty cache apart from an empty table.
+    /// The two look identical from the cache alone, and calling the first one
+    /// "no rows" is what makes a grid flash its empty state a moment before its
+    /// rows land. Set to true at construction when there is nothing to wait
+    /// for: no `on_start`, or a blocking one that has already run.
+    pub(crate) seed_complete: std::sync::atomic::AtomicBool,
 }
 
 impl Drop for DioInner {
@@ -649,7 +660,10 @@ impl Dio {
         limit: usize,
         sort: Option<(String, crate::SortDir)>,
     ) -> Result<Vec<(String, Record<CborValue>)>> {
-        Ok(self.fetch_window_ordered_counted(offset, limit, sort).await?.0)
+        Ok(self
+            .fetch_window_ordered_counted(offset, limit, sort)
+            .await?
+            .0)
     }
 
     /// [`fetch_window_ordered`](Self::fetch_window_ordered), plus the grand
@@ -716,6 +730,15 @@ impl Dio {
     /// re-deriving their index and re-reading their full state.
     pub fn notify_dataset_changed(&self) {
         let _ = self.inner.event_bus.send(DioEvent::DatasetChanged);
+    }
+
+    /// Publish [`DioEvent::Seeded`] — "the whole set is in the cache now."
+    /// Call this after an eager load that wrote through the cache directly, as
+    /// `on_start` does: cache writes raise no events of their own, so a
+    /// scenery that opened over the cold cache has no other way to learn its
+    /// rows arrived.
+    pub fn notify_seeded(&self) {
+        let _ = self.inner.event_bus.send(DioEvent::Seeded);
     }
 
     /// The Dio's effective write capabilities — master caps, lifted to

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -626,6 +626,22 @@ impl Dio {
         limit: usize,
         sort: Option<(String, crate::SortDir)>,
     ) -> Result<Vec<(String, Record<CborValue>)>> {
+        Ok(self.fetch_window_ordered_counted(offset, limit, sort).await?.0)
+    }
+
+    /// [`fetch_window_ordered`](Self::fetch_window_ordered), plus the grand
+    /// total when the master reported one from the same response.
+    ///
+    /// Hand the total to [`ChunkSink::set_total`](crate::ChunkSink::set_total)
+    /// from an `on_load_chunk` callback and the lens needs no `total_provider`
+    /// — which is what takes a paged open from two round trips to one, and
+    /// leaves nothing for `open()` to await.
+    pub async fn fetch_window_ordered_counted(
+        &self,
+        offset: usize,
+        limit: usize,
+        sort: Option<(String, crate::SortDir)>,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<i64>)> {
         let master = self.master();
         if let Some((col, dir)) = sort
             && master.capabilities().can_order
@@ -637,9 +653,9 @@ impl Dio {
                 crate::SortDir::Desc => vantage_vista::SortDirection::Descending,
             };
             ordered.add_order(&col, vdir)?;
-            return ordered.fetch_window(offset, limit).await;
+            return ordered.fetch_window_counted(offset, limit).await;
         }
-        master.fetch_window(offset, limit).await
+        master.fetch_window_counted(offset, limit).await
     }
 
     // ---- Event bus — user-callable surface ----------------------------------

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -612,6 +612,29 @@ impl Dio {
         Vista::new(name, Box::new(shell))
     }
 
+    /// Ask the **master** to derive an aggregated vista, per
+    /// [`Vista::aggregate`].
+    ///
+    /// `Ok(None)` is the "I can't" answer — unknown reduction, or conditions
+    /// the driver can't express — and it is not an error: a source that cannot
+    /// aggregate is not broken. The caller then derives the same set locally
+    /// from this Dio, which keeps the result reactive because the local
+    /// engine is fed by this Dio's change bus.
+    ///
+    /// ```ignore
+    /// let spec = AggregateSpec::new("count", "failed")
+    ///     .condition("Event", CborValue::Text("failed".into()));
+    /// let derived: Vista = match dio.master_aggregate(&spec)? {
+    ///     // The backend reduces: every matching row, loaded or not.
+    ///     Some(vista) => vista,
+    ///     // We reduce: the rows this Dio actually holds.
+    ///     None => aggregate_lens.derive_vista(dio, &spec)?,
+    /// };
+    /// ```
+    pub fn master_aggregate(&self, spec: &vantage_vista::AggregateSpec) -> Result<Option<Vista>> {
+        self.master().aggregate(spec)
+    }
+
     /// Fetch a `[offset, limit)` window, preferring the master's own ordering.
     ///
     /// When `sort` is set and the master `can_order` and yields an independent

--- a/vantage-diorama/src/lens/cache_backend.rs
+++ b/vantage-diorama/src/lens/cache_backend.rs
@@ -17,6 +17,18 @@ pub trait CacheBackend: Send + Sync + 'static {
     /// memoize so repeat calls for the same name return the same Arc.
     async fn open_table(&self, name: &str) -> Result<Arc<dyn CacheTable>>;
 
+    /// Close the backend cleanly, before the process exits.
+    ///
+    /// Some stores record whether they were shut down properly and, finding
+    /// they weren't, rebuild from a full-file scan on the next open. That scan
+    /// is paid on every subsequent launch and grows with the file, so a store
+    /// that is only ever closed by dropping — at an exit that may never run
+    /// destructors — degrades startup permanently.
+    ///
+    /// Idempotent and safe to call while readers still hold tables: the
+    /// default does nothing, which is right for stores with no such state.
+    async fn close(&self) {}
+
     /// Every table currently present in the backend.
     ///
     /// The counterpart to [`drop_table`](Self::drop_table): a consumer that

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -19,6 +19,10 @@ pub trait SceneryChunkTarget: Send + Sync {
     fn set_chunk_total(&self, total: usize) -> bool;
 }
 
+/// Rows a [`ChunkSink`] has accepted but not yet written — see
+/// [`ChunkSink::buffer`].
+type BufferedRows = Arc<std::sync::Mutex<Vec<(String, Record<CborValue>)>>>;
+
 /// Handle passed to `on_load_chunk` callbacks. Each [`push`](Self::push)
 /// writes one row to the Dio's cache and binds it to a row index in
 /// the calling `TableScenery`'s sparse map. Cheap to clone; the scenery
@@ -31,6 +35,16 @@ pub struct ChunkSink {
     /// Rows with a flash in flight — a chunk refetch is a reconcile, so
     /// its (possibly pre-write) snapshot must not clobber a staged value.
     pub(crate) pending: Arc<PendingFlashes>,
+    /// Rows pushed so far, awaiting one write.
+    ///
+    /// A row per commit is a transaction — and a durability barrier — per row,
+    /// so a hundred-row page costs a hundred of them. The rows are useless
+    /// individually anyway: nothing observes the cache mid-load, and the
+    /// scenery's visible map is bound by [`push`](Self::push) directly. Holding
+    /// them and writing once turns a page load into a single transaction, which
+    /// is also what lets a whole datasource share one store without each
+    /// table's load queueing behind another's.
+    pub(crate) buffer: BufferedRows,
 }
 
 impl std::fmt::Debug for ChunkSink {
@@ -79,9 +93,29 @@ impl ChunkSink {
             target.write_chunk_row(idx, id, staged);
             return Ok(());
         }
-        self.cache.insert_value(&id, &record).await?;
+        if let Ok(mut buffer) = self.buffer.lock() {
+            buffer.push((id.clone(), record.clone()));
+        }
         target.write_chunk_row(idx, id, record);
         Ok(())
+    }
+
+    /// Commit everything pushed so far, in one write.
+    ///
+    /// Called by the loader once `on_load_chunk` returns — and it must run
+    /// before anything reads the cache back (the post-load re-sort rebuilds the
+    /// visible map from it), or the load appears to have fetched nothing.
+    pub(crate) async fn flush(&self) -> Result<()> {
+        let rows: indexmap::IndexMap<String, Record<CborValue>> = {
+            let Ok(mut buffer) = self.buffer.lock() else {
+                return Ok(());
+            };
+            std::mem::take(&mut *buffer).into_iter().collect()
+        };
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.cache.insert_values(rows).await
     }
 }
 

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -13,6 +13,10 @@ use crate::lens::cache_backend::CacheTable;
 /// state type.
 pub trait SceneryChunkTarget: Send + Sync {
     fn write_chunk_row(&self, idx: usize, id: String, record: Record<CborValue>);
+
+    /// Record the grand total a chunk fetch reported. Returns whether the
+    /// value moved, so the loader can decide to repaint.
+    fn set_chunk_total(&self, total: usize) -> bool;
 }
 
 /// Handle passed to `on_load_chunk` callbacks. Each [`push`](Self::push)
@@ -38,6 +42,21 @@ impl std::fmt::Debug for ChunkSink {
 }
 
 impl ChunkSink {
+    /// Report the grand total of matching rows, when the fetch that produced
+    /// this chunk also learned it.
+    ///
+    /// Paged sources carry the total in the same response as the window (see
+    /// [`Vista::fetch_window_counted`](vantage_vista::Vista::fetch_window_counted)),
+    /// so a lens that reads it here needs no separate `total_provider` — and
+    /// therefore no second round trip on open. Calling this is optional; a
+    /// lens that says nothing leaves the total exactly as it was.
+    pub fn set_total(&self, total: usize) {
+        let Some(target) = self.target.upgrade() else {
+            return;
+        };
+        target.set_chunk_total(total);
+    }
+
     /// Insert one row into the cache and bind it to `idx` in the
     /// scenery's sparse map. The row is visible to `row(idx)` as soon
     /// as `push` resolves, but the scenery's generation only bumps

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -62,27 +62,56 @@ impl Lens {
             augment_worker_handles: std::sync::Mutex::new(Vec::new()),
             augment_settled_empty: std::sync::Mutex::new(std::collections::HashSet::new()),
             augment_settled: std::sync::Mutex::new(std::collections::HashSet::new()),
+            // Nothing to wait for unless a detached `on_start` is about to be
+            // spawned below; that branch clears it before spawning.
+            seed_complete: std::sync::atomic::AtomicBool::new(true),
         });
         let dio = Dio { inner };
 
         spawn_write_worker(&dio, write_rx).await;
         spawn_refresh_task(&dio).await;
 
+        // Registered means run. A lens offering both a warm and a pager is a
+        // legitimate hybrid — warm the first rows, page beyond them — and only
+        // the callback knows whether that is what it meant. One that wants to
+        // skip the warm for a windowing master says so from inside `on_start`,
+        // where the Dio (and so the master's capabilities) is in hand.
         if let Some(on_start) = self.callbacks.on_start.as_ref() {
             if self.defaults.on_start_blocking {
                 on_start(&dio).await?;
             } else {
+                // Sceneries opening from here until the copy lands must not
+                // read an empty cache as an empty table.
+                dio.inner
+                    .seed_complete
+                    .store(false, std::sync::atomic::Ordering::SeqCst);
                 let dio_for_task = dio.clone();
                 let lens_for_task = self.clone();
                 self.runtime.spawn(async move {
                     if let Some(cb) = lens_for_task.callbacks.on_start.as_ref() {
-                        match cb(&dio_for_task).await {
+                        let outcome = cb(&dio_for_task).await;
+                        // Set BEFORE the event: `Seeded` is what wakes the
+                        // sceneries, and they consult this flag to decide
+                        // whether an empty cache is an answer. Setting it after
+                        // would leave a genuinely empty table stuck in its
+                        // loading state — the one case with no second event to
+                        // correct it. On the failure path too: a seed that
+                        // errored is still one that is no longer coming.
+                        dio_for_task
+                            .inner
+                            .seed_complete
+                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                        match outcome {
                             // The detached seed writes through the raw cache
                             // (no events), and any scenery that opened over
                             // the still-cold cache rendered zero rows —
-                            // announce the landed dataset or those sceneries
-                            // stay blank until a manual refresh.
-                            Ok(()) => dio_for_task.notify_dataset_changed(),
+                            // announce the landed set or those sceneries stay
+                            // blank until a manual refresh. `Seeded`, not
+                            // `DatasetChanged`: this is the full set arriving
+                            // in the cache, which every scenery shows the same
+                            // way, not an external change each shape answers
+                            // differently.
+                            Ok(()) => dio_for_task.notify_seeded(),
                             Err(e) => {
                                 tracing::error!(error = %e, "on_start callback failed");
                             }

--- a/vantage-diorama/src/lens/redb_cache.rs
+++ b/vantage-diorama/src/lens/redb_cache.rs
@@ -95,6 +95,40 @@ impl RedbCache {
 
 #[async_trait]
 impl CacheBackend for RedbCache {
+    /// Mark the file cleanly closed so the next open skips the repair scan.
+    ///
+    /// redb records this when the `Database` drops — which, in a GUI process
+    /// that exits through the platform's quit path, may never happen: the
+    /// handle is reachable from long-lived state whose destructors don't run.
+    /// The symptom is a full-file scan on **every** launch, growing with the
+    /// cache, and it is invisible except as a slow start.
+    ///
+    /// An empty write transaction is enough: committing it durably records a
+    /// clean state without touching any table, so this is safe to call while
+    /// readers still hold tables.
+    async fn close(&self) {
+        let closed = self
+            .db
+            .begin_write()
+            .map_err(|e| e.to_string())
+            .and_then(|txn| txn.commit().map_err(|e| e.to_string()));
+        match closed {
+            Ok(()) => tracing::debug!(
+                target: "vantage_diorama::cache",
+                path = ?self.path,
+                "cache closed cleanly",
+            ),
+            // Losing the marker costs a repair scan next time, not data —
+            // never worth failing a shutdown over.
+            Err(e) => tracing::warn!(
+                target: "vantage_diorama::cache",
+                path = ?self.path,
+                error = %e,
+                "could not mark the cache cleanly closed — next open will repair",
+            ),
+        }
+    }
+
     async fn open_table(&self, name: &str) -> Result<Arc<dyn CacheTable>> {
         let mut opened = self.opened.lock().expect("RedbCache mutex poisoned");
         if let Some(existing) = opened.get(name) {

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -25,9 +25,9 @@ pub use lens::{
 };
 pub use ops::{ChangeEvent, ChangeFlash, FlashKind, FlashRejection, QueryDescriptor};
 pub use scenery::{
-    Aggregate, CappedScenery, CustomAggregate, EnrichedRecord, OpCondition, RecordScenery,
-    RecordStatus, RowStatus, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder,
-    ValueScenery, ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
+    Aggregate, CappedScenery, CustomAggregate, EnrichedRecord, LoadState, OpCondition,
+    RecordScenery, RecordStatus, RowStatus, RowStatusSummary, SortDir, TableScenery,
+    TableSceneryBuilder, ValueScenery, ValueSceneryBuilder, ValueStatus, boxed_custom_aggregate,
 };
 pub use servo::{IdStrategy, Servo, ServoStatus};
 pub use vantage_vista::VistaCapabilities;

--- a/vantage-diorama/src/scenery/mod.rs
+++ b/vantage-diorama/src/scenery/mod.rs
@@ -6,7 +6,8 @@ pub mod value;
 pub use enriched_record::{EnrichedRecord, RowStatus};
 pub use record::{RecordScenery, RecordStatus};
 pub use table::{
-    CappedScenery, OpCondition, RowStatusSummary, SortDir, TableScenery, TableSceneryBuilder,
+    CappedScenery, LoadState, OpCondition, RowStatusSummary, SortDir, TableScenery,
+    TableSceneryBuilder,
 };
 pub use value::{
     Aggregate, CustomAggregate, ValueScenery, ValueSceneryBuilder, ValueStatus,

--- a/vantage-diorama/src/scenery/record.rs
+++ b/vantage-diorama/src/scenery/record.rs
@@ -149,7 +149,10 @@ async fn reload_loop(state: Arc<RecordSceneryState>, mut bus: broadcast::Receive
                     tracing::error!(error = %e, "RecordScenery reload failed");
                 }
             }
-            Ok(DioEvent::DatasetChanged) => {
+            // `Seeded` alongside `DatasetChanged`: a record scenery opened over
+            // a cold cache found nothing, and the eager seed landing is the one
+            // notice it gets that its record now exists.
+            Ok(DioEvent::DatasetChanged) | Ok(DioEvent::Seeded) => {
                 if let Err(e) = state.reload().await {
                     tracing::error!(error = %e, "RecordScenery reload failed");
                 }

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -328,11 +328,28 @@ impl TableSceneryBuilder {
             // A hybrid lens that DOES warm via `on_start` (cache seeded in the
             // master's list order) still reseeds below, so its cache-aware
             // "skip already-loaded ranges" optimisation is preserved.
+            //
+            // This is the single most expensive decision an open makes, and it
+            // is invisible without saying so: a warm cache sitting unused looks
+            // exactly like a cold one from the outside.
+            tracing::info!(
+                target: "vantage_diorama::cache",
+                table = %dio.master.read().unwrap().name(),
+                cached_rows = dio.cache.count().await.unwrap_or(0),
+                "cache NOT seeded — paged lens; rows come from the master in its \
+                 own order, so the on-open fetch is authoritative",
+            );
             state.bump_generation();
         } else {
             // Eager single-pass (or `on_start`-warmed hybrid): the cache IS the
             // row set; seed (and order) from it directly.
             state.reseed_from_cache().await?;
+            tracing::info!(
+                target: "vantage_diorama::cache",
+                table = %dio.master.read().unwrap().name(),
+                seeded_rows = state.rows.read().unwrap().len(),
+                "cache seeded the visible map",
+            );
             state.bump_generation();
         }
 
@@ -370,6 +387,17 @@ impl TableSceneryBuilder {
             && dio.lens.callbacks.on_load_chunk.is_some()
         {
             let range = initial_range.unwrap_or(0..page_size);
+            // `force_load` means this fetch runs even when the cache already
+            // covers the range — i.e. opening ALWAYS goes to the master. That
+            // is the other half of why a warm cache saves nothing here.
+            tracing::info!(
+                target: "vantage_diorama::cache",
+                table = %dio.master.read().unwrap().name(),
+                ?range,
+                cached_rows = dio.cache.count().await.unwrap_or(0),
+                "on-open fetch scheduled (force_load) — the master is consulted \
+                 regardless of what the cache holds",
+            );
             enqueue_viewport(
                 &state,
                 ViewportRequest {

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use ciborium::Value as CborValue;
 use tokio::sync::{Notify, mpsc, watch};
 use vantage_core::Result;
+use vantage_vista::VistaCapabilities;
 
 use crate::dio::{Dio, DioInner, Generation};
 
@@ -272,6 +273,9 @@ impl TableSceneryBuilder {
             load_in_flight: Mutex::new(None),
             load_dirty: std::sync::atomic::AtomicBool::new(false),
             load_push_count: AtomicUsize::new(0),
+            load_total_reported: std::sync::atomic::AtomicBool::new(false),
+            paged: pages_lazily(&dio, &master_capabilities),
+            settled: std::sync::atomic::AtomicBool::new(false),
             master_capabilities,
             two_pass,
             ui_filters: RwLock::new(Vec::new()),
@@ -284,9 +288,24 @@ impl TableSceneryBuilder {
         });
 
         // 1. total_provider runs once per open, result cached.
+        //
+        // This is the only network round trip an open is allowed to BLOCK on,
+        // and the caller is usually a UI thread waiting to mount a page — so
+        // say how long it took. A grand total from a remote count query has
+        // been the whole of a multi-second open before now, and from the
+        // outside that is indistinguishable from a slow cache.
         if let Some(cb) = dio.lens.callbacks.total_provider.as_ref() {
             let dio_handle = Dio { inner: dio.clone() };
+            let started = std::time::Instant::now();
             let total = cb(&dio_handle).await?;
+            let ms = started.elapsed().as_millis() as u64;
+            tracing::info!(
+                target: "vantage_diorama::cache",
+                table = %dio.master.read().unwrap().name(),
+                total,
+                ms,
+                "total_provider — grand total fetched, blocking the open",
+            );
             *state.total.write().unwrap() = Some(total);
         }
 
@@ -299,21 +318,59 @@ impl TableSceneryBuilder {
             // calls.
             let index_empty = state.index().map(|i| i.is_empty()).unwrap_or(true);
             if index_empty {
-                super::two_pass::run_list_page(state.clone()).await;
+                // The first list page is a query against the datasource, and
+                // awaiting it here put a whole round trip on the open path —
+                // which is a UI thread waiting to mount. On a slow source that
+                // is the entire cost of opening the page: one measured
+                // SurrealDB list of 872 rows took 13.5s, and the window was
+                // frozen for all of it.
+                //
+                // So run it detached. The scenery opens empty and the rows
+                // arrive with a generation bump, exactly as the eager path
+                // already behaves (`on_start_blocking(false)`) — a grid is
+                // reactive, and "empty, filling in" is a state it renders
+                // every day. Nothing downstream may assume rows exist the
+                // moment `open()` returns.
+                // The first list page is a query against the datasource, and
+                // awaiting it here put a whole round trip on the open path —
+                // which is a UI thread waiting to mount. On a slow source that
+                // is the entire cost of opening the page: one measured
+                // SurrealDB list took 13.5s, and the window was frozen for all
+                // of it.
+                //
+                // So run it detached. The scenery opens in
+                // `LoadState::Loading`, the rows arrive with a generation bump,
+                // and consumers that need rows wait for the state to leave
+                // `Loading` rather than assuming `open()` implies data.
+                let seed_state = state.clone();
+                dio.lens.runtime.spawn(async move {
+                    super::two_pass::run_list_page(seed_state.clone()).await;
+                    // Locally-refined views filter/sort the just-seeded rows
+                    // over the cache. With an augmented-column condition this
+                    // yields an empty set until hydration confirms matches.
+                    if seed_state.local_refine() {
+                        super::two_pass::reseed_filtered(&seed_state).await;
+                        seed_state.bump_generation();
+                    }
+                    // A viewport set before the list landed found an empty
+                    // index and enqueued nothing, so hydration would wait for
+                    // the user to scroll. Re-drive it now that there are rows
+                    // to hydrate — the same restart the reorder path does.
+                    seed_state.refresh_loaded_viewport();
+                });
             } else {
+                // A populated shared index costs no query — it is already in
+                // memory, so seeding from it stays inline and the scenery opens
+                // with its rows.
                 super::two_pass::seed_from_index(&state).await;
+                state.mark_settled("open: seeded from shared index");
                 state.bump_generation();
+                if state.local_refine() {
+                    super::two_pass::reseed_filtered(&state).await;
+                    state.bump_generation();
+                }
             }
-            // Locally-refined views filter/sort the just-seeded rows over the
-            // cache. With an augmented-column condition this yields an empty set
-            // until hydration confirms matches.
-            if state.local_refine() {
-                super::two_pass::reseed_filtered(&state).await;
-                state.bump_generation();
-            }
-        } else if dio.lens.callbacks.on_load_chunk.is_some()
-            && dio.lens.callbacks.on_start.is_none()
-        {
+        } else if state.paged && dio.lens.callbacks.on_start.is_none() {
             // Pure paged lens (lazy chunk loading, no eager `on_start` warm): the
             // row ORDER is the master's, fetched a page at a time — NOT the cache's
             // id-keyed iteration order. Seeding densely from the cache here would
@@ -332,10 +389,14 @@ impl TableSceneryBuilder {
             // This is the single most expensive decision an open makes, and it
             // is invisible without saying so: a warm cache sitting unused looks
             // exactly like a cold one from the outside.
-            tracing::info!(
+            // Both read before the macro: the count is awaited, and a lock
+            // taken inside the argument list would be held across that await.
+            let table = dio.master.read().unwrap().name().to_string();
+            let cached_rows = dio.cache.count().await.unwrap_or(0);
+            tracing::debug!(
                 target: "vantage_diorama::cache",
-                table = %dio.master.read().unwrap().name(),
-                cached_rows = dio.cache.count().await.unwrap_or(0),
+                table = %table,
+                cached_rows,
                 "cache NOT seeded — paged lens; rows come from the master in its \
                  own order, so the on-open fetch is authoritative",
             );
@@ -344,12 +405,29 @@ impl TableSceneryBuilder {
             // Eager single-pass (or `on_start`-warmed hybrid): the cache IS the
             // row set; seed (and order) from it directly.
             state.reseed_from_cache().await?;
-            tracing::info!(
+            tracing::debug!(
                 target: "vantage_diorama::cache",
                 table = %dio.master.read().unwrap().name(),
                 seeded_rows = state.rows.read().unwrap().len(),
                 "cache seeded the visible map",
             );
+            // The cache IS the row set for this shape, so a seed that found
+            // rows IS the answer. A seed that found none is not: a cold cache
+            // with a background copy still in flight looks exactly like an
+            // empty table, and calling it settled here is what made the grid
+            // skip its loading state and paint "no rows" over a load that had
+            // not started. Wait for the reactor's reseed in that case.
+            //
+            // Unless nothing more is coming — a blocking `on_start` has already
+            // run by now, so zero rows is a real answer and there will be no
+            // second reseed to wait for.
+            let seeded_any = !state.rows.read().unwrap().is_empty();
+            if seeded_any
+                || dio.lens.defaults.on_start_blocking
+                || dio.lens.callbacks.on_start.is_none()
+            {
+                state.mark_settled("open: seeded from cache");
+            }
             state.bump_generation();
         }
 
@@ -382,19 +460,19 @@ impl TableSceneryBuilder {
         //    server applies the query's ordering, so the on-open fetch must
         //    actually hit the server to replace the seed with ordered rows —
         //    otherwise the grid shows cache order until a manual refresh.
-        if !two_pass
-            && dio.lens.defaults.refresh_on_open
-            && dio.lens.callbacks.on_load_chunk.is_some()
-        {
+        if !two_pass && dio.lens.defaults.refresh_on_open && state.paged {
             let range = initial_range.unwrap_or(0..page_size);
             // `force_load` means this fetch runs even when the cache already
             // covers the range — i.e. opening ALWAYS goes to the master. That
             // is the other half of why a warm cache saves nothing here.
-            tracing::info!(
+            // Read before the macro — see the sibling log above.
+            let table = dio.master.read().unwrap().name().to_string();
+            let cached_rows = dio.cache.count().await.unwrap_or(0);
+            tracing::debug!(
                 target: "vantage_diorama::cache",
-                table = %dio.master.read().unwrap().name(),
+                table = %table,
                 ?range,
-                cached_rows = dio.cache.count().await.unwrap_or(0),
+                cached_rows,
                 "on-open fetch scheduled (force_load) — the master is consulted \
                  regardless of what the cache holds",
             );
@@ -419,4 +497,24 @@ impl TableSceneryBuilder {
         // `scenery` drops here — its guard aborts the redundant tasks.
         Ok(dio.register_table_scenery(key, scenery))
     }
+}
+
+/// Whether this view pages rows in lazily rather than warming from the cache.
+///
+/// Both behaviours are *offers*: `on_load_chunk` says the lens can fetch a
+/// window, `on_start` says it can copy the whole set up front. Which offer
+/// applies is a property of the **master**, not of the lens — a source that can
+/// serve `[offset, limit)` should be paged, and one that cannot must be warmed
+/// whole. Reading it off the lens instead (the older rule: "chunked, and no
+/// `on_start`") forced a separate Lens per table shape, because a lens carrying
+/// both offers was silently treated as eager for every table under it.
+///
+/// A lens making only one offer keeps that offer regardless of capability:
+/// there is no alternative to fall back to, and a paged lens over a master that
+/// does not advertise `can_fetch_window` is a legitimate arrangement — the
+/// callback may know how to window a source the Vista can't describe.
+fn pages_lazily(dio: &Arc<DioInner>, master: &VistaCapabilities) -> bool {
+    let can_page = dio.lens.callbacks.on_load_chunk.is_some();
+    let can_warm = dio.lens.callbacks.on_start.is_some();
+    can_page && (!can_warm || master.can_fetch_window)
 }

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -38,12 +38,22 @@ pub(crate) async fn viewport_loop(
         let mut absorbed = 0usize;
 
         // Keep absorbing requests until the channel is quiet for `debounce`.
+        //
+        // Absorbing takes the newest RANGE — an older viewport is not worth
+        // fetching — but `force_load` is not a property of the range, it is an
+        // instruction to consult the master rather than the cache. Dropping it
+        // with the request that carried it lost the on-open refresh on every
+        // mount, because the grid always pushes its first real viewport inside
+        // the debounce window: the table then sat on cached rows and never
+        // contacted the source at all.
         loop {
             match tokio::time::timeout(debounce, rx.recv()).await {
                 Ok(Some(next)) => {
                     state.viewport_queue_depth.fetch_sub(1, Ordering::SeqCst);
                     absorbed += 1;
+                    let force = latest.force_load || next.force_load;
                     latest = next;
+                    latest.force_load = force;
                 }
                 Ok(None) => {
                     tracing::warn!(target: "vantage_diorama::viewport", "viewport_loop: channel closed mid-debounce, exiting");
@@ -196,11 +206,11 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             Some(r) => r,
             None => {
                 tracing::debug!(
-                    target: "vantage_diorama::viewport",
-                    visible = ?visible,
-                    visible_len,
-                    visible_cached,
-                    "fire_chunk_load: SKIP (visible fully cached)",
+                    target: "vantage_diorama::source",
+                    table = %dio_inner.master.read().unwrap().name(),
+                    range = ?visible,
+                    rows = visible_cached,
+                    "CACHE — served locally, no master fetch",
                 );
                 return;
             }
@@ -213,13 +223,24 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     // anything that re-drives the viewport on a timer (a relation list's
     // periodic re-pull, `refresh_loaded_viewport`) would otherwise emit a
     // warning per tick, forever.
-    let cb = match dio_inner.lens.callbacks.on_load_chunk.as_ref() {
+    // Only a paged view fetches windows. An eager one holds every row already
+    // — its viewport moving is its steady state, not a reason to fetch — and
+    // its master may not be able to serve a window at all, which is an error
+    // raised to the user rather than a quiet no-op.
+    let cb = match dio_inner
+        .lens
+        .callbacks
+        .on_load_chunk
+        .as_ref()
+        .filter(|_| state.paged)
+    {
         Some(cb) => cb,
         None => {
             tracing::debug!(
                 target: "vantage_diorama::viewport",
                 visible = ?visible,
-                "fire_chunk_load: SKIP (no on_load_chunk callback)",
+                paged = state.paged,
+                "fire_chunk_load: SKIP (this view does not page)",
             );
             return;
         }
@@ -253,12 +274,14 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     // Recompute overlap on the effective range so the log shows the
     // shift working.
     let effective_len = effective_range.end - effective_range.start;
-    let effective_cached = {
+    let (effective_cached, first_hole) = {
         let rows = state.rows.read().unwrap();
-        effective_range
+        let present = effective_range
             .clone()
             .filter(|i| rows.contains_key(i))
-            .count()
+            .count();
+        let first_hole = effective_range.clone().find(|i| !rows.contains_key(i));
+        (present, first_hole)
     };
     let effective_to_fetch = effective_len - effective_cached;
 
@@ -266,7 +289,11 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         target: Arc::downgrade(&state) as std::sync::Weak<dyn crate::lens::SceneryChunkTarget>,
         cache: dio_inner.cache.clone(),
         pending: dio_inner.pending_flashes.clone(),
+        buffer: Default::default(),
     };
+    // The sink is moved into the callback; keep a clone so the buffered rows
+    // can be committed once it returns.
+    let writer = sink.clone();
 
     let dio = Dio {
         inner: dio_inner.clone(),
@@ -289,24 +316,79 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         force_load,
         "fire_chunk_load: dispatching on_load_chunk",
     );
+    // The counterpart of the CACHE line above: this is the moment a range
+    // costs a round trip. `already_cached` says how much of what we are about
+    // to fetch the cache ALREADY holds — non-zero means the fetch is
+    // re-reading rows we have, which on a `force_load` is by design and
+    // otherwise is worth explaining.
+    tracing::debug!(
+        target: "vantage_diorama::source",
+        table = %dio_inner.master.read().unwrap().name(),
+        range = ?effective_range,
+        rows = effective_to_fetch,
+        already_cached = effective_cached,
+        force_load,
+        "MASTER — fetching from the datasource",
+    );
     // Clear the dirty flag so it reflects only the rows this load writes;
     // `write_chunk_row` sets it when a row's content actually changes.
     state.reset_load_dirty();
+    let total_before = *state.total.read().unwrap();
     let sort = state.sort.read().unwrap().clone();
-    let result = cb(&dio, effective_range.clone(), sort, sink).await;
+    let mut result = cb(&dio, effective_range.clone(), sort, sink).await;
+    // Commit the page in one write, before anything reads the cache back. A
+    // failed commit fails the load: the rows are bound in the visible map but
+    // absent from the cache, and the next re-sort would rebuild the map without
+    // them — better to report the load failed than to silently lose the page.
+    if result.is_ok() {
+        result = writer.flush().await;
+    }
 
     *state.load_in_flight.lock().unwrap() = None;
 
     let cached_after = state.rows.read().unwrap().len();
     match result {
         Ok(()) => {
-            // A short page — fewer rows than the requested window — is the end
-            // of the set, so the grand total is `start + received`. This keeps
-            // `total` self-correcting from the fetch we already did (no separate
-            // count request), and fixes a list opened before its rows existed:
-            // its `total` was counted once at 0 and would otherwise never grow.
+            // The window came back — whatever it contained, this view now has
+            // an answer rather than a not-yet.
+            state.mark_settled("chunk load succeeded");
             let pushed = state.load_push_count();
-            let total_changed = if pushed < effective_len {
+            let ms = t.elapsed().as_millis() as u64;
+            // One line per fetch is for reading a session; the ledger is for
+            // counting one. `already_cached` rows are the waste signal — rows
+            // paid for that the cache already held.
+            crate::stats::record_fetch(
+                dio_inner.master.read().unwrap().name(),
+                &effective_range,
+                pushed,
+                effective_cached,
+                ms,
+            );
+            tracing::debug!(
+                target: "vantage_diorama::source",
+                table = %dio_inner.master.read().unwrap().name(),
+                range = ?effective_range,
+                received = pushed,
+                ms,
+                "MASTER — fetch returned",
+            );
+            // Where the grand total came from. A total the source stated in the
+            // same response as the rows (`ChunkSink::set_total`) outranks
+            // anything inferred here: a short page can equally mean "the source
+            // capped the window", and reading that as the end of the set would
+            // cut the grid off at its first screen. With nothing stated, a
+            // short page IS the end of the set, which keeps `total`
+            // self-correcting from a fetch already made — including for a list
+            // opened before its rows existed, counted once at 0.
+            let mut total_changed = if state.take_load_total_reported() {
+                tracing::debug!(
+                    target: "vantage_diorama::source",
+                    table = %dio_inner.master.read().unwrap().name(),
+                    total = ?*state.total.read().unwrap(),
+                    "total stated by the fetch itself — no count request needed",
+                );
+                *state.total.read().unwrap() != total_before
+            } else if pushed < effective_len {
                 state.set_total(Some(effective_range.start + pushed))
             } else {
                 false
@@ -333,6 +415,50 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 } else {
                     false
                 };
+
+            // Rows nobody can deliver.
+            //
+            // A source may claim more rows than it will actually serve — a
+            // stated total counting records its own paging never returns, or an
+            // offset it quietly ignores so every page past a point repeats ids
+            // already held. The grid then advertises slots that no fetch can
+            // fill, and since a hole is exactly what triggers a fetch, it asks
+            // again, and again, for as long as the page is open: one request
+            // per few seconds, forever, against the slowest thing in reach.
+            //
+            // The proof is right here and needs no cooperation from the source:
+            // this load was asked for a range with holes in it and filled NONE
+            // of them. Whatever the total claims, the addressable set ends at
+            // the first of those holes — so say so, and the range stops being
+            // requested. Measured after the resort because a client-side sort
+            // rebuilds the visible map from the cache once the load lands.
+            if let Some(hole) = first_hole {
+                let present_after = {
+                    let rows = state.rows.read().unwrap();
+                    effective_range
+                        .clone()
+                        .filter(|i| rows.contains_key(i))
+                        .count()
+                };
+                if present_after == effective_cached {
+                    let stated = *state.total.read().unwrap();
+                    if stated.map(|t| t > hole).unwrap_or(true) {
+                        tracing::warn!(
+                            target: "vantage_diorama::source",
+                            table = %dio_inner.master.read().unwrap().name(),
+                            range = ?effective_range,
+                            received = pushed,
+                            stated_total = ?stated,
+                            reachable = hole,
+                            "source served none of the requested rows — its total \
+                             promises more than it delivers; capping the set at what \
+                             is reachable so the fetch is not repeated forever",
+                        );
+                        total_changed |= state.set_total(Some(hole));
+                    }
+                }
+            }
+
             // Drain the dirty flag regardless (so it doesn't leak into the next
             // load). Bump when this was a forced refetch (a refresh or load-more —
             // it carries the single repaint for the whole refresh, including a

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -91,6 +91,24 @@ pub(crate) struct ViewportRequest {
     pub(crate) force_load: bool,
 }
 
+/// How much of a scenery's data has arrived.
+///
+/// Distinguishes the three situations a consumer has to act on differently. A
+/// grid renders a skeleton for [`Loading`](Self::Loading) and its empty-set
+/// placeholder only for a [`Complete`](Self::Complete) view with no rows — the
+/// same picture, opposite meanings. A test or a profiler waits for `Loading` to
+/// end before asserting, and for `Complete` before claiming a total.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoadState {
+    /// No load has finished. The view has no answer yet — not even "empty".
+    Loading,
+    /// Rows are present and more are known to exist: the ordinary state of a
+    /// paged grid that has loaded its first window of a larger set.
+    Partial,
+    /// Every row this query yields is in the view.
+    Complete,
+}
+
 /// Breakdown of the row statuses currently materialized in a scenery's sparse
 /// map. Cheap to compute (iterates only loaded rows, not the full row count) —
 /// the per-scenery slice of the diagnostics surface.
@@ -109,6 +127,21 @@ pub struct RowStatusSummary {
 /// Reactive view onto a Dio that exposes an ordered, paginated row set.
 pub trait TableScenery: Send + Sync {
     fn row_count(&self) -> usize;
+
+    /// How much of this view's data has arrived.
+    ///
+    /// Three states, because two are not enough to act on: a consumer needs to
+    /// tell "no rows" from "no rows *yet*" (they render identically and mean
+    /// opposite things), and a test or a profiler needs to tell "showing
+    /// something" from "showing everything" before it measures.
+    fn load_state(&self) -> LoadState {
+        LoadState::Complete
+    }
+
+    /// Shorthand for [`LoadState::Loading`] — the view has no answer yet.
+    fn is_loading(&self) -> bool {
+        self.load_state() == LoadState::Loading
+    }
 
     /// Status breakdown over the rows currently in the sparse map. Used by the
     /// diagnostics surface to report how much of a scenery is hydrated.
@@ -173,6 +206,21 @@ impl Drop for SceneryGuard {
 }
 
 impl TableScenery for TableSceneryImpl {
+    fn load_state(&self) -> LoadState {
+        if !self.inner.settled.load(std::sync::atomic::Ordering::SeqCst) {
+            return LoadState::Loading;
+        }
+        // A known total the visible map has not reached means rows are still
+        // coming — the ordinary state of a paged grid before it is scrolled.
+        // With no total there is nothing to be short of, so what is loaded is
+        // all there is.
+        let loaded = self.inner.rows.read().unwrap().len();
+        match *self.inner.total.read().unwrap() {
+            Some(total) if loaded < total => LoadState::Partial,
+            _ => LoadState::Complete,
+        }
+    }
+
     fn row_count(&self) -> usize {
         // A locally-refined view's visible map is authoritative — the index may
         // hold more ids than match the filter.

--- a/vantage-diorama/src/scenery/table/reactor.rs
+++ b/vantage-diorama/src/scenery/table/reactor.rs
@@ -62,6 +62,26 @@ pub(crate) async fn reload_loop(
                     | DioEvent::DatasetChanged) => {
                         refresh(&state).await;
                     }
+                    // The eager seed landed in the cache — which matters only
+                    // to a scenery whose rows come *from* the cache. A two-pass
+                    // scenery's spine is its own ordered index, and a paged
+                    // one's is the master's window order, so for them a full
+                    // cache is not an answer and must not be treated as one:
+                    // reseeding a paged scenery here would paint the cache's
+                    // id-keyed order and mark it settled over a set it never
+                    // fetched.
+                    //
+                    // A shared lens makes this reachable for all three shapes.
+                    // The scenery reads its own recorded shape rather than the
+                    // lens's offers, which is the distinction that was wrong
+                    // when the seed went unseen.
+                    Ok(DioEvent::Seeded) => {
+                        if state.two_pass {
+                            super::two_pass::refresh_index(&state).await;
+                        } else if !state.paged {
+                            reseed(&state).await;
+                        }
+                    }
                     // A scheduled detail fetch for one of our rows failed —
                     // stamp the slot so the grid shows the failure (single-pass
                     // rows load through their own chunk pipeline, not the
@@ -137,6 +157,33 @@ async fn reseed(state: &Arc<TableSceneryState>) {
     if let Err(e) = state.reseed_from_cache().await {
         tracing::error!(error = %e, "TableScenery reseed failed");
     } else {
+        // An eager lens loads in the background; this is where its rows reach
+        // the view, so this is where "still loading" ends.
+        //
+        // A reseed that found rows is an answer. One that found none is only an
+        // answer if nothing further is coming, and both shapes have a way to
+        // still be waiting:
+        //
+        // - **paged** — the cache is not the row source at all; rows arrive
+        //   from the master a window at a time. A grid applying its default
+        //   sort at mount pings this loop, and that reseed landed milliseconds
+        //   before the first fetch even dispatched. The loader settles it when
+        //   the window arrives.
+        // - **eager** — the cache IS the row source, but a detached `on_start`
+        //   may still be filling it. An empty cache and an empty table are
+        //   indistinguishable from here; `seed_complete` is what tells them
+        //   apart. Without it a grid flashed "no rows" and then filled in.
+        //
+        // Same rule the open path uses (see `builder`).
+        let has_rows = !state.rows.read().unwrap().is_empty();
+        let seeded = state
+            .dio_weak
+            .upgrade()
+            .map(|d| d.seed_complete.load(std::sync::atomic::Ordering::SeqCst))
+            .unwrap_or(true);
+        if has_rows || (!state.paged && seeded) {
+            state.mark_settled("reactor reseed");
+        }
         state.bump_generation();
     }
 }

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -71,6 +71,39 @@ pub(crate) struct TableSceneryState {
     /// derives the grand `total` from it (no separate count request).
     pub(crate) load_push_count: AtomicUsize,
 
+    /// Whether the in-flight chunk load reported a grand total of its own (via
+    /// [`ChunkSink::set_total`](crate::ChunkSink::set_total)).
+    ///
+    /// It settles which of two answers wins. A short page is only *evidence* of
+    /// the end of the set; a total the source stated in the same response is
+    /// the fact. They disagree whenever a source caps its page below what we
+    /// asked for — 25 rows back from a request for 100 means "here is a page",
+    /// not "there are 25 rows" — and inferring from the page there would cut
+    /// the grid off at its first screen.
+    pub(crate) load_total_reported: std::sync::atomic::AtomicBool,
+
+    /// Whether this view has finished its first load.
+    ///
+    /// "No rows" and "no rows *yet*" are the same picture and opposite
+    /// meanings: a grid that paints its empty state while the first fetch is
+    /// still in flight tells the user the table is empty, and they believe it.
+    /// Set once, by whichever path first puts rows in front of the user —
+    /// a seed from cache, a chunk load, or the two-pass list — and never
+    /// cleared, because a later refresh returning nothing is a real answer.
+    pub(crate) settled: std::sync::atomic::AtomicBool,
+
+    /// Whether this view loads a window at a time (rather than over a cache the
+    /// lens filled whole). Decided once at open from the lens's offers and the
+    /// master's capabilities — see `builder::pages_lazily`.
+    ///
+    /// Recorded rather than re-derived because the two consumers must not be
+    /// able to disagree. The loader used to infer it from "is an `on_load_chunk`
+    /// registered", which was the same answer only while every table had its own
+    /// lens. Sharing one lens across a datasource made that callback always
+    /// present, and an eager table's viewport then asked a source for a window
+    /// it had never claimed to serve.
+    pub(crate) paged: bool,
+
     /// Snapshot of the master Vista's capability flags taken at open
     /// time. Sceneries hand this back through
     /// `TableScenery::master_capabilities` so UI delegates can route
@@ -143,6 +176,36 @@ impl TableSceneryState {
             || self.sort.read().unwrap().is_some()
     }
 
+    /// Mark the first load complete — the view now shows an answer, even if
+    /// that answer is "no rows".
+    ///
+    /// Logged because settling is the moment a grid stops showing its skeleton
+    /// and commits to what it has. Settling early with nothing paints "no rows"
+    /// over a load still in flight, and from the outside that is indis-
+    /// tinguishable from an empty table — the row count alone never says which.
+    /// `reason` names the call site. Which of them settles a given scenery is
+    /// the whole question when a grid shows "no rows" too early, and it is not
+    /// recoverable from the state afterwards — the flag records that someone
+    /// settled it, never who.
+    pub(crate) fn mark_settled(&self, reason: &'static str) {
+        if !self.settled.swap(true, Ordering::SeqCst) {
+            tracing::debug!(
+                target: "vantage_diorama::cache",
+                reason,
+                table = self
+                    .dio_weak
+                    .upgrade()
+                    .map(|d| d.cache_table_name.clone())
+                    .unwrap_or_default(),
+                rows = self.rows.read().unwrap().len(),
+                total = ?*self.total.read().unwrap(),
+                paged = self.paged,
+                two_pass = self.two_pass,
+                "scenery settled — the grid now shows this as the answer",
+            );
+        }
+    }
+
     pub(crate) fn bump_generation(&self) {
         let next = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
         let _ = self.generation_tx.send_replace(Generation(next));
@@ -157,6 +220,12 @@ impl TableSceneryState {
     pub(crate) fn reset_load_dirty(&self) {
         self.load_dirty.store(false, Ordering::SeqCst);
         self.load_push_count.store(0, Ordering::SeqCst);
+        self.load_total_reported.store(false, Ordering::SeqCst);
+    }
+
+    /// Whether the just-finished load stated a grand total, clearing the flag.
+    pub(crate) fn take_load_total_reported(&self) -> bool {
+        self.load_total_reported.swap(false, Ordering::SeqCst)
     }
 
     /// Read and clear the chunk-load dirty flag. `true` means the load changed
@@ -333,14 +402,15 @@ impl TableSceneryState {
     /// visible window in place instead of reseeding from cache — reseeding
     /// would only re-show whatever happens to be cached (and shows nothing
     /// if the cache was just cleared).
+    ///
+    /// Reads the decision [`paged`](Self::paged) recorded at open, for the
+    /// reason given there. Asking the lens instead makes every scenery under a
+    /// shared lens claim to be paged, and an eager one then answers a landed
+    /// dataset by re-fetching a viewport it never fetches through — so the rows
+    /// its `on_start` just wrote to the cache never reach the visible map, and
+    /// the grid stays empty until something reopens it over the warm cache.
     pub(crate) fn is_chunk_loaded(&self) -> bool {
-        if self.two_pass {
-            return false;
-        }
-        self.dio_weak
-            .upgrade()
-            .map(|d| d.lens.callbacks.on_load_chunk.is_some())
-            .unwrap_or(false)
+        !self.two_pass && self.paged
     }
 
     /// Re-fetch the loaded rows in place so a refresh updates them without
@@ -408,6 +478,7 @@ impl SceneryChunkTarget for TableSceneryState {
     /// sizes the scrollbar without a `total_provider` — i.e. without a second
     /// request on open, which is the one network call `open()` used to await.
     fn set_chunk_total(&self, total: usize) -> bool {
+        self.load_total_reported.store(true, Ordering::SeqCst);
         self.set_total(Some(total))
     }
 

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -404,6 +404,13 @@ impl TableSceneryState {
 }
 
 impl SceneryChunkTarget for TableSceneryState {
+    /// A total learned from the chunk fetch itself. This is how a paged lens
+    /// sizes the scrollbar without a `total_provider` — i.e. without a second
+    /// request on open, which is the one network call `open()` used to await.
+    fn set_chunk_total(&self, total: usize) -> bool {
+        self.set_total(Some(total))
+    }
+
     fn write_chunk_row(&self, idx: usize, id: String, record: Record<CborValue>) {
         // Count every received row (before the skips below), so the loader can
         // tell a short page (end of set) from a full one.

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -242,6 +242,11 @@ pub(crate) async fn run_list_page(state: Arc<TableSceneryState>) {
     match result {
         Ok((base, new_ids)) => {
             seed_rows(&state, &dio_inner, base, &new_ids).await;
+            // The list pass is what puts rows on screen for a two-pass view;
+            // the detail pass only enriches them, so waiting for hydration
+            // before dropping the loading state would hold it for the whole
+            // table.
+            state.mark_settled("two-pass list page");
             state.bump_generation();
             let _ = dio_inner.event_bus.send(DioEvent::RangeLoaded {
                 range: base..index.len(),
@@ -581,6 +586,9 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     // column). A condition/sort on a *native* (list-pass) column needs no extra
     // hydration — `reseed_filtered` already orders/filters the cheap cache rows —
     // so it keeps normal viewport-driven hydration.
+    // What the user is actually looking at. Kept even when the sweep widens
+    // below, because it decides the ORDER work is queued in.
+    let visible = range.clone();
     let range = if state.local_refine() && references_augmented_column(&state, &dio_inner) {
         0..index.len()
     } else {
@@ -596,7 +604,9 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     let augmented = dio_inner.augmented_columns.read().unwrap().clone();
     let gap_aware = dio_inner.has_dio_augment() && !augmented.is_empty();
 
-    let mut pending = Vec::new();
+    // `(idx, id)` rather than bare ids, so the queue can be ordered by where a
+    // row sits relative to the viewport.
+    let mut pending: Vec<(usize, String)> = Vec::new();
     let mut seeded = false;
     // Sweep census, for the log line below. A detail pass that keeps enqueueing
     // the same rows every time it runs is the signature of a hydration loop,
@@ -685,11 +695,38 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
                 continue;
             }
         }
-        pending.push(id);
+        pending.push((idx, id));
     }
     if seeded {
         state.bump_generation();
     }
+    // On-screen rows first.
+    //
+    // A view whose filter or sort touches an augmented column has to hydrate
+    // the whole table before it can decide what belongs on screen at all — but
+    // that is an argument about *how many* rows, not about which order to fetch
+    // them in. Queued as swept, a table of 872 rows hydrates whatever sits
+    // first in the list-pass order and reaches the visible window whenever it
+    // gets there, so the rows under the cursor fill in last. The cost is
+    // identical either way; only the wait the user sees changes.
+    //
+    // "On screen" is a position in the DISPLAYED map, not in the shared index.
+    // The two are the same order only for an unrefined view: a locally sorted
+    // or filtered one rebuilds `rows` in its own order (`reseed_filtered`),
+    // while the sweep above walks the index. Ranking by the index position
+    // would prioritise whichever rows happen to occupy those slots in the
+    // unsorted order — a different set, near enough at random.
+    //
+    // Stable within each group, so the visible window hydrates top-down and the
+    // remainder keeps the sweep's order.
+    {
+        let displayed = state.id_to_idx.read().unwrap();
+        pending.sort_by_key(|(idx, id)| {
+            let position = displayed.get(id).copied().unwrap_or(*idx);
+            !visible.contains(&position)
+        });
+    }
+    let pending: Vec<String> = pending.into_iter().map(|(_, id)| id).collect();
     tracing::debug!(
         target: "vantage_diorama::augment",
         requested,

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -516,7 +516,9 @@ async fn track_loop(
             {
                 absorb_from_cache(&state, &dio_weak).await;
             }
-            DioEvent::DatasetChanged => {
+            // `Seeded` alongside `DatasetChanged`: a servo bound before the
+            // eager load finished has nothing to absorb until it lands.
+            DioEvent::DatasetChanged | DioEvent::Seeded => {
                 absorb_from_cache(&state, &dio_weak).await;
             }
             DioEvent::WritePending { id, kind } if bound(&id) => {

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -65,3 +65,155 @@ pub fn live_counts() -> LiveCounts {
         servos: SERVOS.load(Ordering::Relaxed),
     }
 }
+
+// ---- Fetch ledger ----------------------------------------------------------
+
+/// Every window a table pulled from its master, and what it cost.
+///
+/// A remote fetch is the most expensive thing a grid does and the easiest to do
+/// by accident: a range re-requested because the rows never landed, a viewport
+/// that re-fires on every repaint, a refresh overlapping a scroll. None of it
+/// shows up as an error, and in a log it reads as ordinary activity — the give
+/// away is only ever a *count*, which no single log line can carry.
+///
+/// So the counts are kept. `repeats` and `rows_redundant` are the two numbers
+/// worth reading: the first says a range was asked for more than once, the
+/// second says rows arrived that the cache already held. Both should be near
+/// zero on a healthy table.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FetchStats {
+    pub table: String,
+    /// Windows requested from the master.
+    pub fetches: usize,
+    /// Distinct ranges among them.
+    pub distinct_ranges: usize,
+    /// Fetches for a range already fetched before — `fetches - distinct_ranges`.
+    pub repeats: usize,
+    /// The most re-requested range, and how many times. A range fetched over
+    /// and over is a source that will not serve it.
+    pub worst_range: Option<(String, usize)>,
+    /// Rows the master handed back, across every fetch.
+    pub rows_received: usize,
+    /// Of the rows requested, how many the cache already held — work paid for
+    /// twice. A forced refresh counts here legitimately; a scroll should not.
+    pub rows_redundant: usize,
+    pub ms_total: u64,
+    pub ms_max: u64,
+}
+
+#[derive(Default)]
+struct TableLedger {
+    fetches: usize,
+    ranges: std::collections::HashMap<String, usize>,
+    rows_received: usize,
+    rows_redundant: usize,
+    ms_total: u64,
+    ms_max: u64,
+}
+
+/// Cap on distinct ranges remembered per table. A grid scrolled through a large
+/// set would otherwise grow this map without bound; past the cap the counts
+/// stay exact and only the per-range breakdown stops taking new entries — which
+/// is the right trade, since a repeat loop repeats a range it already recorded.
+const MAX_TRACKED_RANGES: usize = 256;
+
+static LEDGER: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<String, TableLedger>>,
+> = std::sync::LazyLock::new(Default::default);
+
+/// Record one completed master fetch. Called by the chunk loader.
+pub(crate) fn record_fetch(
+    table: &str,
+    range: &std::ops::Range<usize>,
+    rows_received: usize,
+    rows_redundant: usize,
+    ms: u64,
+) {
+    let Ok(mut ledger) = LEDGER.lock() else {
+        return;
+    };
+    let entry = ledger.entry(table.to_string()).or_default();
+    entry.fetches += 1;
+    entry.rows_received += rows_received;
+    entry.rows_redundant += rows_redundant;
+    entry.ms_total += ms;
+    entry.ms_max = entry.ms_max.max(ms);
+    let key = format!("{}..{}", range.start, range.end);
+    let tracked = entry.ranges.len();
+    match entry.ranges.get_mut(&key) {
+        Some(count) => *count += 1,
+        None if tracked < MAX_TRACKED_RANGES => {
+            entry.ranges.insert(key, 1);
+        }
+        None => {}
+    }
+}
+
+/// Snapshot the fetch ledger, busiest table first.
+pub fn fetch_stats() -> Vec<FetchStats> {
+    let Ok(ledger) = LEDGER.lock() else {
+        return Vec::new();
+    };
+    let mut out: Vec<FetchStats> = ledger
+        .iter()
+        .map(|(table, e)| FetchStats {
+            table: table.clone(),
+            fetches: e.fetches,
+            distinct_ranges: e.ranges.len(),
+            repeats: e.fetches.saturating_sub(e.ranges.len()),
+            worst_range: e
+                .ranges
+                .iter()
+                .max_by_key(|(_, count)| **count)
+                .filter(|(_, count)| **count > 1)
+                .map(|(range, count)| (range.clone(), *count)),
+            rows_received: e.rows_received,
+            rows_redundant: e.rows_redundant,
+            ms_total: e.ms_total,
+            ms_max: e.ms_max,
+        })
+        .collect();
+    out.sort_by(|a, b| b.fetches.cmp(&a.fetches).then(a.table.cmp(&b.table)));
+    out
+}
+
+/// Forget every recorded fetch — so a measurement can be scoped to one
+/// interaction ("open the page, then scroll") instead of the whole session.
+pub fn reset_fetch_stats() {
+    if let Ok(mut ledger) = LEDGER.lock() {
+        ledger.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeats_and_waste_are_counted_per_range() {
+        reset_fetch_stats();
+        record_fetch("events", &(0..100), 35, 0, 3000);
+        record_fetch("events", &(35..42), 7, 7, 2000);
+        record_fetch("events", &(35..42), 7, 7, 2500);
+        record_fetch("tags", &(0..50), 50, 0, 10);
+
+        let stats = fetch_stats();
+        assert_eq!(stats[0].table, "events", "busiest table first");
+        assert_eq!(stats[0].fetches, 3);
+        assert_eq!(stats[0].distinct_ranges, 2);
+        assert_eq!(stats[0].repeats, 1);
+        assert_eq!(
+            stats[0].worst_range,
+            Some(("35..42".to_string(), 2)),
+            "the range that keeps being asked for",
+        );
+        assert_eq!(stats[0].rows_redundant, 14);
+        assert_eq!(stats[0].ms_max, 3000);
+
+        assert_eq!(stats[1].table, "tags");
+        assert_eq!(
+            stats[1].worst_range, None,
+            "fetched once, nothing to report"
+        );
+    }
+}

--- a/vantage-diorama/tests/augment.rs
+++ b/vantage-diorama/tests/augment.rs
@@ -8,6 +8,8 @@
 //! same path serves a REST master + cmd detail, since the catalog is
 //! persistence-agnostic).
 
+mod support;
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -132,7 +134,7 @@ async fn eventually(label: &str, f: impl Fn() -> bool) {
 async fn id_source_augments_from_a_separate_vista() {
     let tmp = TempDir::new().unwrap();
     let dio = open(&tmp, vec![aug("runs-detail", Source::Id, &["detail"])]).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
 
     // List pass ran: cheap columns present, Incomplete, no augmented column yet.
     assert!(matches!(
@@ -167,7 +169,7 @@ async fn column_source_keyed_by_field() {
         to: None,
     };
     let dio = open(&tmp, vec![aug("runs-detail", source, &["detail"])]).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("hydrated", || {
@@ -189,7 +191,7 @@ async fn multiple_augmentations_merge_independently() {
         ],
     )
     .await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("hydrated", || {
@@ -212,7 +214,7 @@ async fn missing_key_field_marks_row_failed() {
         to: None,
     };
     let dio = open(&tmp, vec![aug("runs-detail", source, &["detail"])]).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("row failed", || {
@@ -229,7 +231,7 @@ async fn missing_key_field_marks_row_failed() {
 async fn refresh_keeps_hydrated_detail_when_master_unchanged() {
     let tmp = TempDir::new().unwrap();
     let dio = open(&tmp, vec![aug("runs-detail", Source::Id, &["detail"])]).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
     eventually("hydrated", || {
         matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
@@ -262,7 +264,7 @@ async fn custom_fetch_closure_reads_narrowed_detail() {
         },
     };
     let dio = open(&tmp, vec![augmentation]).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("hydrated", || {
@@ -326,7 +328,7 @@ async fn fixed_detail_vista_hydrates_without_a_catalog() {
                 },
             }],
         );
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("rows hydrated", || {
@@ -383,7 +385,7 @@ async fn changed_master_row_refetches_its_augment() {
                 },
             }],
         );
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..1);
     eventually("hydrated with the first size", || {
         col_of(&scenery, 0, "size").as_deref() == Some("100")
@@ -789,7 +791,7 @@ async fn augment_fetches_only_while_a_view_demands_augment_columns() {
 async fn ui_filter_narrows_on_an_augmented_column() {
     let tmp = TempDir::new().unwrap();
     let dio = open(&tmp, vec![aug("runs-detail", Source::Id, &["detail"])]).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
 
     scenery.set_viewport(0..2);
     eventually("rows hydrated", || {

--- a/vantage-diorama/tests/bdd_support/backend.rs
+++ b/vantage-diorama/tests/bdd_support/backend.rs
@@ -142,6 +142,12 @@ impl MasterRows {
             can_search: true,
             can_set_page_size: true,
             can_fetch_page: true,
+            // The row-indexed sibling of `can_fetch_page`, and the one chunk
+            // loading actually maps onto: a scenery pages a master that
+            // advertises this. Omitting it left the mock claiming random access
+            // by page but not by row, so a lens offering both a warm and a
+            // pager was read as warm-only.
+            can_fetch_window: true,
             ..Default::default()
         };
         let mut shell = MockShell::new().with_metadata(meta).with_capabilities(caps);

--- a/vantage-diorama/tests/chunk_overstated_total.rs
+++ b/vantage-diorama/tests/chunk_overstated_total.rs
@@ -1,0 +1,235 @@
+//! A paged source that promises more rows than it will serve.
+//!
+//! Real APIs do this. SendLayer's events endpoint reports `TotalRecords: 42`
+//! while only ever yielding 35 distinct rows: ask for the tail and it returns
+//! ids already held, because it ignores the offset once past what it will hand
+//! out. The grid sizes itself to the stated total, so rows 35..41 are holes; a
+//! hole is what triggers a fetch; the fetch returns nothing new. Left alone
+//! that is an unbounded loop — one request every few seconds, forever, against
+//! the slowest dependency in the system — and the user sees a scrollbar that
+//! never fills.
+//!
+//! The scenery has no way to know in advance which sources lie. It finds out
+//! the only way anyone could: it asks for a range with holes in it and none of
+//! them come back filled.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Lens, SortDir};
+use vantage_types::Record;
+
+mod support;
+use support::chunk::{master as master_cols, settle};
+
+/// Comfortably past the 50ms viewport debounce — long enough that a fetch this
+/// test claims does not happen would have been dispatched by now.
+const DEBOUNCE_MARGIN: std::time::Duration = std::time::Duration::from_millis(120);
+
+/// Rows the source will actually hand out, however many it claims to have.
+const SERVED: usize = 5;
+/// What it claims.
+const STATED: usize = 8;
+
+fn rec(v: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(v.to_string()));
+    r
+}
+
+fn backend() -> Vec<(String, Record<CborValue>)> {
+    (0..SERVED)
+        .map(|i| (format!("id{i}"), rec(&format!("v{i}"))))
+        .collect()
+}
+
+/// A lens over a source that overstates its total.
+///
+/// Within `SERVED` it pages honestly. Past that it ignores the offset and
+/// replies with rows it has already given out — under their original ids, which
+/// is what makes them invisible: they overwrite cache entries that exist rather
+/// than filling the slots that were asked for. Every response states `STATED`.
+fn lying_lens(
+    cache: std::path::PathBuf,
+    calls: Arc<Mutex<Vec<std::ops::Range<usize>>>>,
+) -> Arc<Lens> {
+    let rows = backend();
+    Lens::new()
+        .cache_at(cache)
+        .on_load_chunk(move |_dio, range, _sort, sink| {
+            let rows = rows.clone();
+            let calls = calls.clone();
+            async move {
+                calls.lock().unwrap().push(range.clone());
+                sink.set_total(STATED);
+                for idx in range {
+                    // Past what it serves, the offset is ignored: the source
+                    // repeats a row it already sent, id and all.
+                    let (id, record) = &rows[idx.min(SERVED - 1)];
+                    sink.push(idx, id.clone(), record.clone()).await?;
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .map(Arc::new)
+        .expect("build lens")
+}
+
+/// The set is capped at what the source will actually deliver, and the
+/// unreachable tail is asked for a bounded number of times — not forever.
+#[tokio::test(flavor = "multi_thread")]
+async fn overstated_total_does_not_loop() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let calls: Arc<Mutex<Vec<std::ops::Range<usize>>>> = Arc::new(Mutex::new(Vec::new()));
+    let lens = lying_lens(tmp.path().join("c.redb"), calls.clone());
+    let dio = lens.make_dio(master_cols(&[("v", "String")])).await?;
+    let scenery = dio.table_scenery().open().await?;
+
+    // A client-side sort makes the visible map a projection of the cache — the
+    // shape this bites in, because duplicate ids collapse there and the slots
+    // stay empty however many rows come back.
+    scenery.set_sort(Some("v".to_string()), SortDir::Asc);
+    settle().await;
+
+    // Look at the whole set the source claims exists.
+    scenery.set_viewport(0..STATED);
+
+    // Wait for the outcome, not for a duration. A fixed sleep here is a speed
+    // assertion — and the opening fetch writes a row per redb transaction, so
+    // "long enough" is not a constant, least of all on a loaded machine running
+    // the rest of the suite alongside this.
+    wait_for_row_count(&scenery, SERVED).await;
+    let settled = calls.lock().unwrap().len();
+
+    // And re-asking for the same viewport must not restart it. Proving an
+    // absence does need real time, but only enough to cover the viewport
+    // debounce plus a fetch — not the quarter-second `settle` uses to be safe
+    // about arrivals, which is the wrong budget for observing nothing.
+    for _ in 0..4 {
+        scenery.set_viewport(0..STATED);
+        tokio::time::sleep(DEBOUNCE_MARGIN).await;
+    }
+    let after = calls.lock().unwrap().clone();
+    assert_eq!(
+        after.len(),
+        settled,
+        "the unreachable tail is being re-fetched: {after:?}",
+    );
+
+    Ok(())
+}
+
+/// Block until row `idx` is materialised.
+async fn wait_for_row(scenery: &Arc<dyn vantage_diorama::TableScenery>, idx: usize) {
+    let mut generations = scenery.subscribe();
+    let arrived = async {
+        while scenery.row(idx).is_none() {
+            generations
+                .changed()
+                .await
+                .expect("generation watch closed");
+        }
+    };
+    if tokio::time::timeout(std::time::Duration::from_secs(3), arrived)
+        .await
+        .is_err()
+    {
+        panic!("row {idx} never loaded");
+    }
+}
+
+/// Block until the scenery reports `want` rows.
+///
+/// Driven by the generation watch, not a poll: every change to the visible set
+/// bumps it, so sleeping between checks only adds latency to a signal that
+/// already exists. Polling here cost this test two seconds of sleep to observe
+/// something that happens in milliseconds.
+///
+/// The timeout bounds a hang; it does not assert a speed.
+async fn wait_for_row_count(scenery: &Arc<dyn vantage_diorama::TableScenery>, want: usize) {
+    let mut generations = scenery.subscribe();
+    let reached = async {
+        while scenery.row_count() != want {
+            generations
+                .changed()
+                .await
+                .expect("generation watch closed");
+        }
+    };
+    if tokio::time::timeout(std::time::Duration::from_secs(3), reached)
+        .await
+        .is_err()
+    {
+        panic!(
+            "row_count settled at {} (wanted {want}) — the set was never capped \
+             at what the source will serve",
+            scenery.row_count(),
+        );
+    }
+}
+
+/// The clamp keys on holes going unfilled, NOT on a page being shorter than
+/// requested — a source that caps its window size still pages correctly, and
+/// treating its first short page as the end of the set would strand the user on
+/// one screen.
+#[tokio::test(flavor = "multi_thread")]
+async fn page_capped_source_still_pages() -> Result<()> {
+    const CAP: usize = 3;
+    const TOTAL: usize = 9;
+
+    let tmp = TempDir::new().unwrap();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let seen = hits.clone();
+    let lens = Lens::new()
+        .cache_at(tmp.path().join("c.redb"))
+        .on_load_chunk(move |_dio, range, _sort, sink| {
+            let seen = seen.clone();
+            async move {
+                seen.fetch_add(1, Ordering::SeqCst);
+                sink.set_total(TOTAL);
+                // Honest paging, capped window: never more than CAP rows back,
+                // however wide the request.
+                for idx in range.clone().take(CAP) {
+                    if idx < TOTAL {
+                        sink.push(idx, format!("id{idx}"), rec(&format!("v{idx}")))
+                            .await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .map(Arc::new)
+        .expect("build lens");
+
+    let dio = lens.make_dio(master_cols(&[("v", "String")])).await?;
+    let scenery = dio.table_scenery().open().await?;
+
+    scenery.set_viewport(0..CAP);
+    settle().await;
+    assert_eq!(
+        scenery.row_count(),
+        TOTAL,
+        "a capped page is not the end of the set",
+    );
+
+    // Walk down it a window at a time; every row must eventually arrive. Each
+    // step waits for its last row rather than for a fixed time — the rows are
+    // the thing being asserted, and they announce themselves.
+    for start in (0..TOTAL).step_by(CAP) {
+        let end = (start + CAP).min(TOTAL);
+        scenery.set_viewport(start..end);
+        wait_for_row(&scenery, end - 1).await;
+    }
+    assert_eq!(scenery.row_count(), TOTAL, "the set did not shrink");
+    assert!(
+        scenery.row(TOTAL - 1).is_some(),
+        "the last row never loaded — the clamp fired on an honest short page",
+    );
+
+    Ok(())
+}

--- a/vantage-diorama/tests/shared_lens_eager_seed.rs
+++ b/vantage-diorama/tests/shared_lens_eager_seed.rs
@@ -1,0 +1,137 @@
+//! One lens serving both shapes: the eager seed must still reach open sceneries.
+//!
+//! vantage-ui builds one Lens per datasource, so that lens carries every
+//! callback any table under it might need — `on_start` to copy a whole set,
+//! `on_load_chunk` to window a pageable one. Which applies is a property of the
+//! master, decided per scenery at open (`builder::pages_lazily`) and recorded
+//! as `TableSceneryState::paged`.
+//!
+//! The shape that broke: an eager scenery opens over a cold cache, shows
+//! nothing (correctly — there is nothing yet), and the detached `on_start`
+//! lands its rows a moment later and announces `DatasetChanged`. The reactor
+//! answers a whole-set event one of two ways, and it was choosing between them
+//! by asking the *lens* whether an `on_load_chunk` existed. Under a shared lens
+//! one always does, so an eager scenery took the paged branch: re-count, then
+//! re-fetch the current viewport — through a callback the loader will not
+//! dispatch for it. Nothing reseeded the visible map from the cache, so the
+//! grid stayed empty for as long as it stayed open. Reopening it fixed it,
+//! because `open()` seeds from what is by then a warm cache — which is exactly
+//! how this presented: blank on first visit, instant on the second.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_dataset::prelude::ReadableValueSet;
+use vantage_diorama::{Lens, TableScenery};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+/// Bounds a hang; not an assertion about speed.
+const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+fn named(name: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("name".to_string(), CborValue::Text(name.to_string()));
+    r
+}
+
+/// An eager master: it holds rows and, crucially, does **not** advertise
+/// `can_fetch_window` — so a lens offering both shapes is warmed whole.
+fn master(rows: &[(&str, &str)]) -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String"))
+        .with_id_column("id");
+    let mut shell = MockShell::new().with_metadata(metadata);
+    for (id, name) in rows {
+        shell = shell.with_record(*id, named(name));
+    }
+    Vista::new("items", Box::new(shell))
+}
+
+/// Block until the scenery reports `want` rows, driven by the generation watch.
+async fn wait_for_rows(scenery: &Arc<dyn TableScenery>, want: usize) {
+    let mut generations = scenery.subscribe();
+    let reached = async {
+        while scenery.row_count() != want {
+            generations
+                .changed()
+                .await
+                .expect("generation watch closed");
+        }
+    };
+    if tokio::time::timeout(TIMEOUT, reached).await.is_err() {
+        panic!(
+            "scenery settled at {} rows (wanted {want}) — the eager seed never \
+             reached the visible map",
+            scenery.row_count(),
+        );
+    }
+}
+
+/// The detached seed reaches a scenery that opened before it landed, and the
+/// paged callback the shared lens also carries is never dispatched for it.
+#[tokio::test(flavor = "multi_thread")]
+async fn eager_seed_reaches_a_scenery_opened_over_a_cold_cache() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    // Held shut until the scenery is open, so the seed is guaranteed to land
+    // *after* it — the ordering the bug needs, which a race would otherwise
+    // only sometimes produce.
+    let gate = Arc::new(tokio::sync::Notify::new());
+    let chunk_calls = Arc::new(AtomicUsize::new(0));
+
+    let opener = gate.clone();
+    let counted = chunk_calls.clone();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_at(tmp.path().join("c.redb"))
+            .on_start_blocking(false)
+            .on_start(move |dio| {
+                let dio = dio.clone();
+                let opener = opener.clone();
+                async move {
+                    opener.notified().await;
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await
+                }
+            })
+            // The other shape the shared lens carries. An eager scenery must
+            // never route through it: this master was never asked whether it
+            // can serve a window, and in the app that mis-dispatch surfaced as
+            // a "get_windowed not supported" toast.
+            .on_load_chunk(move |_dio, _range, _sort, _sink| {
+                let counted = counted.clone();
+                async move {
+                    counted.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+
+    let dio = lens
+        .make_dio(master(&[("a", "Ann"), ("b", "Bob"), ("c", "Cid")]))
+        .await?;
+    let scenery = dio.table_scenery().open().await?;
+    assert_eq!(
+        scenery.row_count(),
+        0,
+        "nothing is cached yet — the seed is still gated",
+    );
+
+    // Release the seed. Its `DatasetChanged` is the only thing that can put
+    // these rows on screen.
+    gate.notify_one();
+    wait_for_rows(&scenery, 3).await;
+
+    assert_eq!(
+        chunk_calls.load(Ordering::SeqCst),
+        0,
+        "an eager scenery fetched a window through the shared lens's pager",
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/support/mod.rs
+++ b/vantage-diorama/tests/support/mod.rs
@@ -136,6 +136,48 @@ pub async fn eager_dio(master: Vista) -> Dio {
     lens.make_dio(master).await.expect("make_dio")
 }
 
+/// Open a two-pass scenery and wait until its first rows have landed.
+///
+/// `open()` no longer implies data: a two-pass view runs its list page detached
+/// so a slow source cannot freeze the caller (a UI thread, in the app). Waiting
+/// on [`LoadState`] is the supported way to say "once it has something" —
+/// a fixed sleep would be a speed assertion, and asserting straight after
+/// `open()` is a race the test would sometimes win.
+pub async fn open_listed(dio: &Dio, page_size: usize) -> Arc<dyn TableScenery> {
+    let scenery = dio
+        .table_scenery()
+        .page_size(page_size)
+        .open()
+        .await
+        .expect("scenery opens");
+    wait_listed(&scenery).await;
+    scenery
+}
+
+/// Wait for a scenery to leave [`LoadState::Loading`].
+///
+/// Driven by the generation watch rather than a poll: every path that settles a
+/// scenery bumps the generation immediately afterwards, so the signal already
+/// exists and sleeping between checks would only add latency to it. Subscribe
+/// before the first check, or a load that finishes in between is a bump nobody
+/// is listening for.
+///
+/// The timeout bounds a hang; it is not an assertion about speed.
+pub async fn wait_listed(scenery: &Arc<dyn TableScenery>) {
+    let mut generations = scenery.subscribe();
+    let settled = async {
+        while scenery.load_state() == vantage_diorama::LoadState::Loading {
+            generations
+                .changed()
+                .await
+                .expect("generation watch closed");
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(3), settled)
+        .await
+        .expect("scenery never left LoadState::Loading");
+}
+
 // ---- MockView ------------------------------------------------------------
 
 /// A scenery consumer for tests. Wraps a `TableScenery` and exposes the
@@ -145,7 +187,10 @@ pub struct MockView {
 }
 
 impl MockView {
-    /// Open a grid-style view over a Dio with the given page size.
+    /// Open a grid-style view over a Dio with the given page size, and wait for
+    /// its first rows — a real grid renders a loading state until then, so a
+    /// test that asserts straight after `open()` is asserting about a frame the
+    /// user never sees.
     pub async fn open(dio: &Dio, page_size: usize) -> Self {
         let scenery = dio
             .table_scenery()
@@ -153,6 +198,7 @@ impl MockView {
             .open()
             .await
             .expect("scenery opens");
+        wait_listed(&scenery).await;
         Self { scenery }
     }
 
@@ -167,6 +213,7 @@ impl MockView {
     ) -> Self {
         let builder = dio.table_scenery().page_size(page_size);
         let scenery = customize(builder).open().await.expect("scenery opens");
+        wait_listed(&scenery).await;
         Self { scenery }
     }
 

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -11,6 +11,8 @@
 //! `$RUNS_LOG`, so a test reads that file back to assert the exact sequence of
 //! `list`/`detail` calls the machinery issued.
 
+mod support;
+
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -172,7 +174,7 @@ async fn list_pass_creates_incomplete_rows_and_no_detail_calls() {
     let lens = two_pass_lens(tmp.path(), &log);
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
 
     // First list page already ran (open awaits it): r0, r1 as Incomplete.
     assert_eq!(scenery.estimated_total(), Some(2));
@@ -206,7 +208,7 @@ async fn detail_pass_hydrates_visible_rows_once_in_order() {
     let lens = two_pass_lens(tmp.path(), &log);
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("rows hydrated", || {
@@ -249,7 +251,7 @@ async fn sort_change_restarts_augmentation_without_scrolling() {
     let lens = two_pass_lens(tmp.path(), &log);
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
     eventually("initial hydration", || {
         matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
@@ -338,6 +340,7 @@ async fn titles_only_picker_skips_detail_hydration() {
         .open()
         .await
         .unwrap();
+    support::wait_listed(&picker).await;
     picker.set_viewport(0..2);
     // Let the viewport debounce + (suppressed) detail path run.
     tokio::time::sleep(Duration::from_millis(30)).await;
@@ -363,7 +366,7 @@ async fn titles_only_picker_skips_detail_hydration() {
 
     // A full grid over the same query is a DISTINCT scenery (it hydrates), so
     // the Dio now holds two live sceneries.
-    let grid = dio.table_scenery().page_size(2).open().await.unwrap();
+    let grid = support::open_listed(&dio, 2).await;
     assert!(
         !std::sync::Arc::ptr_eq(&picker, &grid),
         "titles_only keys distinctly from a full grid"
@@ -422,7 +425,7 @@ async fn diagnostics_report_sceneries_refcount_and_hydration() {
     assert_eq!(dio.diagnostics().await.sceneries[0].refcount, 2);
 
     // A full grid is a distinct scenery that hydrates → Fresh rows.
-    let grid = dio.table_scenery().page_size(2).open().await.unwrap();
+    let grid = support::open_listed(&dio, 2).await;
     grid.set_viewport(0..2);
     eventually("grid hydrates both rows", || {
         matches!(status_of(&grid, 0), Some(RowStatus::Fresh))
@@ -452,7 +455,7 @@ async fn sequential_paging_stops_on_short_page() {
     let lens = two_pass_lens(tmp.path(), &log);
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     assert_eq!(scenery.estimated_total(), Some(2));
     assert!(scenery.has_more());
 
@@ -494,7 +497,7 @@ async fn shared_detail_across_filter_variants() {
     let dio = open_dio(&lens, &make_cmd(&log)).await;
 
     // Unfiltered: page through all 5 and hydrate them.
-    let all = dio.table_scenery().page_size(2).open().await.unwrap();
+    let all = support::open_listed(&dio, 2).await;
     all.request_load_more();
     eventually("page2", || all.estimated_total() == Some(4)).await;
     all.request_load_more();
@@ -570,7 +573,7 @@ async fn reopen_resumes_without_refetching_complete_rows() {
         let log = cache_dir.join("run1.log");
         let lens = two_pass_lens(&cache_dir, &log);
         let dio = open_dio(&lens, &make_cmd(&log)).await;
-        let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+        let scenery = support::open_listed(&dio, 2).await;
         scenery.set_viewport(0..2);
         eventually("run1 hydrated", || {
             matches!(status_of(&scenery, 0), Some(RowStatus::Fresh))
@@ -649,7 +652,7 @@ async fn detail_failure_marks_only_that_row() {
     );
 
     let dio = open_dio(&lens, &make_cmd(&log)).await;
-    let scenery = dio.table_scenery().page_size(2).open().await.unwrap();
+    let scenery = support::open_listed(&dio, 2).await;
     scenery.set_viewport(0..2);
 
     eventually("r0 fresh, r1 failed", || {

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.12 — 2026-07-28
+
+- `fetch_window` serves a row-indexed window as `LIMIT n START m`. The
+  capability is implemented but **not yet advertised**: `can_fetch_window`
+  switches every SurrealDB table to lazy paging, and a paged grid cannot yet
+  bootstrap from a cold cache — with no rows it renders its loading view rather
+  than a row list, so nothing reports a visible range and no window is ever
+  asked for. It goes on once the first window is driven by the open rather than
+  by the viewport.
+
 ## 0.6.11 — 2026-07-23
 
 - `add_op_condition` pushes non-equality filters into the SurrealDB query: `!=`,

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.11"
+version = "0.6.12"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -86,6 +86,15 @@ impl SurrealVistaFactory {
                 can_filter_operators: true,
                 can_set_page_size: true,
                 can_fetch_page: true,
+                // NOT advertised yet, though `fetch_window` below implements it
+                // (`LIMIT n START m`). Turning it on flips every SurrealDB
+                // table to lazy paging, and a paged grid currently cannot
+                // bootstrap from a cold cache: with no rows the table renders
+                // its empty/loading view instead of the row list, so nothing
+                // reports a visible range, so no window is ever requested. The
+                // capability goes on once the first window is driven by the
+                // open rather than by the viewport.
+                // can_fetch_window: true,
                 can_fetch_next: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -448,6 +448,28 @@ where
             .collect())
     }
 
+    /// `LIMIT limit START offset` — a row-indexed window.
+    ///
+    /// Unlike [`fetch_page`](Self::fetch_page) the offset is arbitrary, so it
+    /// needs no `set_page_size` beforehand and does not have to align to a page
+    /// boundary. This is the primitive a lazily-paged grid drives on scroll: its
+    /// ranges are edge-anchored to whatever is already cached (`35..42`), which
+    /// no page index expresses.
+    async fn fetch_window(
+        &self,
+        _vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        let mut window_table = self.table.clone();
+        window_table.set_pagination(Some(Pagination::window(offset as i64, limit as i64)));
+        let raw = window_table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(thing, record)| (thing.to_string(), to_cbor_record(record)))
+            .collect())
+    }
+
     async fn fetch_next(
         &self,
         _vista: &Vista,

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.18 — 2026-07-28
+
+- **`AggregateSpec` and `Vista::aggregate`** — an aggregation derives a *new
+  vista*, not a value. `count(*)` yields one row and `GROUP BY` yields one per
+  group, and either can then be conditioned, ordered or counted like any other
+  set, so every consumer keeps the one shape it already handles instead of
+  growing a scalar special case. `TableShell::aggregate_vista` returns
+  `Ok(None)` for "this driver cannot answer that" — distinct from an empty
+  result, because the caller's fallback is to reduce over the rows it holds,
+  which is a different question with a different answer. "Can't" must never
+  collapse into a number.
+
+- **`fetch_window_counted`** returns a window together with the grand total,
+  when the driver learned it from the same response. Paginated APIs generally
+  state their total in the envelope; asking for it separately is a second round
+  trip for something already in hand. `None` means this response carried no
+  total, and `get_count` is still there when one is required.
+
 ## 0.6.17 — 2026-07-26
 
 - The live-subscription contract is now written down on `TableShell::watch_vista`:

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/aggregate.rs
+++ b/vantage-vista/src/aggregate.rs
@@ -7,15 +7,14 @@
 //! returns a [`Vista`](crate::Vista), not a number, and every consumer keeps
 //! the one shape it already knows.
 
-use ciborium::Value as CborValue;
-
 /// What to reduce, how, and what to call the result.
 ///
-/// Conditions live here rather than being applied to the source vista
-/// beforehand so a driver can accept or refuse the request **as a unit**. A
-/// driver that can sum but cannot express one of the terms must not quietly
-/// sum the unfiltered set; given the whole question it can answer `None` and
-/// let the caller reduce locally instead.
+/// **Conditions are not here.** Narrow the source vista first, then aggregate
+/// it — the order SQL uses, where the filter belongs to the inner query and
+/// the aggregate selects from the result. Narrowing already reports its own
+/// failure (`add_condition_eq` returns `Err` on a driver that can't express a
+/// term), so a caller knows to fall back *before* it asks for a reduction, and
+/// no driver is ever handed a filter it will silently ignore.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AggregateSpec {
     /// The reduction: `count`, `sum`, `avg`, `min`, `max`, `distinct`, or
@@ -27,8 +26,6 @@ pub struct AggregateSpec {
     /// Column name the result is published under — the single column of a
     /// scalar aggregate's single row.
     pub alias: String,
-    /// Equality terms, ANDed, restricting the rows reduced.
-    pub conditions: Vec<(String, CborValue)>,
     /// Group keys. Empty means one row out; otherwise one row per distinct
     /// combination, carrying the key columns alongside `alias`.
     pub group_by: Vec<String>,
@@ -41,7 +38,6 @@ impl AggregateSpec {
             op: op.into(),
             column: None,
             alias: alias.into(),
-            conditions: Vec::new(),
             group_by: Vec::new(),
         }
     }
@@ -52,53 +48,41 @@ impl AggregateSpec {
         self
     }
 
-    /// Restrict to rows where `field == value`.
-    pub fn condition(mut self, field: impl Into<String>, value: CborValue) -> Self {
-        self.conditions.push((field.into(), value));
-        self
-    }
-
     /// Emit one row per distinct value of `column`.
     pub fn group_by(mut self, column: impl Into<String>) -> Self {
         self.group_by.push(column.into());
         self
     }
 
-    /// A stable, unique name for the set this spec derives from `table`.
+    /// A stable, unique name for the set this spec derives from a source.
     ///
-    /// Two things depend on it. A derived Dio caches under this name, so it
-    /// must not collide with the source table or with a differently-shaped
-    /// aggregate over the same source. And two identical aggregates must
-    /// produce the *same* key, so a page showing one number twice shares one
+    /// `source_key` identifies the source **as narrowed** — pass
+    /// [`Vista::index_key`](crate::Vista::index_key), which already renders a
+    /// vista's conditions and sort in a canonical, order-independent form.
+    /// That is what keeps two differently-filtered aggregates apart without
+    /// this type knowing anything about conditions.
+    ///
+    /// Two things depend on the result. A derived Dio caches under it, so it
+    /// must not collide with the source or with a differently-shaped aggregate
+    /// over the same source. And the same question asked twice must produce
+    /// the *same* key, so a page showing one number in two places shares one
     /// engine instead of computing it twice.
     ///
-    /// `#` separates the source from its derivation: it has no other meaning
-    /// in this vocabulary (dots are column paths, `/` already separates
-    /// datasource from table), and it sorts each derived table next to the
-    /// one it came from in a cache directory.
+    /// `#` separates a source from its derivation: it has no other meaning
+    /// here (dots are column paths, `/` already separates datasource from
+    /// table), and it sorts each derived table next to its origin in a cache
+    /// directory.
     ///
     /// ```
     /// # use vantage_vista::AggregateSpec;
-    /// # use ciborium::Value as CborValue;
-    /// let spec = AggregateSpec::new("count", "opened")
-    ///     .condition("Event", CborValue::Text("opened".into()));
-    /// assert_eq!(spec.cache_key("email_events"), "email_events#count[Event=opened]");
+    /// let spec = AggregateSpec::new("sum", "bytes").column("Size");
+    /// assert_eq!(spec.cache_key("events|c:Event=opened|s:"),
+    ///            "events|c:Event=opened|s:#sum(Size)");
     /// ```
-    pub fn cache_key(&self, table: &str) -> String {
-        let mut key = format!("{table}#{}", self.op);
+    pub fn cache_key(&self, source_key: &str) -> String {
+        let mut key = format!("{source_key}#{}", self.op);
         if let Some(column) = &self.column {
             key.push_str(&format!("({column})"));
-        }
-        if !self.conditions.is_empty() {
-            // Sorted, so two specs that differ only in the order the terms
-            // were added still share a cache table and an engine.
-            let mut terms: Vec<String> = self
-                .conditions
-                .iter()
-                .map(|(field, value)| format!("{field}={}", scalar(value)))
-                .collect();
-            terms.sort();
-            key.push_str(&format!("[{}]", terms.join(",")));
         }
         if !self.group_by.is_empty() {
             // NOT sorted: grouping by (a, b) is a different table from
@@ -109,93 +93,95 @@ impl AggregateSpec {
     }
 }
 
-/// Render a condition value for the cache key. Non-scalars get a shape-stable
-/// debug form — they're rare in an equality term, and a key only has to be
-/// stable and unique, not readable.
-fn scalar(value: &CborValue) -> String {
-    match value {
-        CborValue::Text(s) => s.clone(),
-        CborValue::Integer(i) => i128::from(*i).to_string(),
-        CborValue::Float(f) => f.to_string(),
-        CborValue::Bool(b) => b.to_string(),
-        CborValue::Null => "null".to_string(),
-        other => format!("{other:?}"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mocks::MockShell;
+    use crate::vista::Vista;
+    use ciborium::Value as CborValue;
 
     fn text(s: &str) -> CborValue {
         CborValue::Text(s.to_string())
     }
 
+    /// A narrowed source, keyed the way a caller is expected to key it.
+    fn source_key(conditions: &[(String, CborValue)]) -> String {
+        let vista = Vista::new("email_events", Box::new(MockShell::new()));
+        vista.index_key(conditions, None)
+    }
+
     #[test]
     fn a_bare_reduction_keys_on_its_op() {
-        assert_eq!(
-            AggregateSpec::new("count", "total").cache_key("email_events"),
-            "email_events#count"
-        );
+        let key = AggregateSpec::new("count", "total").cache_key(&source_key(&[]));
+        assert!(key.ends_with("#count"), "got {key}");
     }
 
     #[test]
     fn the_reduced_column_is_part_of_the_key() {
-        assert_eq!(
-            AggregateSpec::new("sum", "bytes")
-                .column("Size")
-                .cache_key("email_events"),
-            "email_events#sum(Size)"
-        );
+        let key = AggregateSpec::new("sum", "bytes")
+            .column("Size")
+            .cache_key(&source_key(&[]));
+        assert!(key.ends_with("#sum(Size)"), "got {key}");
     }
 
-    /// The point of the key: two differently-conditioned aggregates over one
-    /// source must not share a cache table, or one would serve the other's
-    /// number.
+    /// The point of keying off the narrowed source: two aggregates that differ
+    /// ONLY in their source's conditions must not share a cache table, or one
+    /// would serve the other's number.
     #[test]
-    fn conditions_separate_two_aggregates_over_one_source() {
-        let opened = AggregateSpec::new("count", "opened").condition("Event", text("opened"));
-        let failed = AggregateSpec::new("count", "failed").condition("Event", text("failed"));
-        assert_ne!(
-            opened.cache_key("email_events"),
-            failed.cache_key("email_events")
-        );
+    fn conditions_on_the_source_separate_two_aggregates() {
+        let spec = AggregateSpec::new("count", "n");
+        let opened = spec.cache_key(&source_key(&[("Event".into(), text("opened"))]));
+        let failed = spec.cache_key(&source_key(&[("Event".into(), text("failed"))]));
+        assert_ne!(opened, failed);
     }
 
-    /// And the converse: the same question asked twice must land on ONE
-    /// engine, however the terms were ordered.
+    /// And the converse: the same question asked twice lands on ONE engine,
+    /// however the source's terms were ordered — `index_key` sorts them.
     #[test]
-    fn term_order_does_not_change_the_key() {
-        let a = AggregateSpec::new("count", "x")
-            .condition("Event", text("opened"))
-            .condition("Ip", text("1.2.3.4"));
-        let b = AggregateSpec::new("count", "x")
-            .condition("Ip", text("1.2.3.4"))
-            .condition("Event", text("opened"));
-        assert_eq!(a.cache_key("t"), b.cache_key("t"));
+    fn source_term_order_does_not_change_the_key() {
+        let spec = AggregateSpec::new("count", "n");
+        let a = spec.cache_key(&source_key(&[
+            ("Event".into(), text("opened")),
+            ("Ip".into(), text("1.2.3.4")),
+        ]));
+        let b = spec.cache_key(&source_key(&[
+            ("Ip".into(), text("1.2.3.4")),
+            ("Event".into(), text("opened")),
+        ]));
+        assert_eq!(a, b);
     }
 
     /// Grouping order IS significant — it decides the output column order.
     #[test]
     fn group_order_does_change_the_key() {
-        let a = AggregateSpec::new("count", "n").group_by("a").group_by("b");
-        let b = AggregateSpec::new("count", "n").group_by("b").group_by("a");
-        assert_ne!(a.cache_key("t"), b.cache_key("t"));
+        let key = source_key(&[]);
+        let a = AggregateSpec::new("count", "n")
+            .group_by("a")
+            .group_by("b")
+            .cache_key(&key);
+        let b = AggregateSpec::new("count", "n")
+            .group_by("b")
+            .group_by("a")
+            .cache_key(&key);
+        assert_ne!(a, b);
     }
 
     /// The alias names the output column, not the question — two aliases for
     /// the same reduction are the same computation and should share it.
     #[test]
     fn the_alias_does_not_affect_the_key() {
-        let a = AggregateSpec::new("count", "total");
-        let b = AggregateSpec::new("count", "observed");
-        assert_eq!(a.cache_key("t"), b.cache_key("t"));
+        let key = source_key(&[]);
+        assert_eq!(
+            AggregateSpec::new("count", "total").cache_key(&key),
+            AggregateSpec::new("count", "observed").cache_key(&key),
+        );
     }
 
     #[test]
-    fn a_derived_key_cannot_collide_with_a_plain_table() {
-        let key = AggregateSpec::new("count", "total").cache_key("email_events");
-        assert!(key.starts_with("email_events#"));
-        assert_ne!(key, "email_events");
+    fn a_derived_key_cannot_collide_with_its_source() {
+        let key = source_key(&[]);
+        let derived = AggregateSpec::new("count", "total").cache_key(&key);
+        assert!(derived.starts_with(&key));
+        assert_ne!(derived, key);
     }
 }

--- a/vantage-vista/src/aggregate.rs
+++ b/vantage-vista/src/aggregate.rs
@@ -1,0 +1,201 @@
+//! Describing a reduction, so a driver can decide whether it can perform one.
+//!
+//! An aggregation is not a value — it is a **new set**. `SELECT count(*) …`
+//! yields a one-row table, `GROUP BY` yields one row per group, and both are
+//! ordinary sets you can then condition, order or count again. So the verb
+//! this spec feeds ([`TableShell::aggregate_vista`](crate::TableShell::aggregate_vista))
+//! returns a [`Vista`](crate::Vista), not a number, and every consumer keeps
+//! the one shape it already knows.
+
+use ciborium::Value as CborValue;
+
+/// What to reduce, how, and what to call the result.
+///
+/// Conditions live here rather than being applied to the source vista
+/// beforehand so a driver can accept or refuse the request **as a unit**. A
+/// driver that can sum but cannot express one of the terms must not quietly
+/// sum the unfiltered set; given the whole question it can answer `None` and
+/// let the caller reduce locally instead.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AggregateSpec {
+    /// The reduction: `count`, `sum`, `avg`, `min`, `max`, `distinct`, or
+    /// whatever else a driver understands. A driver that doesn't recognise
+    /// the name answers `None`.
+    pub op: String,
+    /// Column being reduced. `None` for reductions over whole rows (`count`).
+    pub column: Option<String>,
+    /// Column name the result is published under — the single column of a
+    /// scalar aggregate's single row.
+    pub alias: String,
+    /// Equality terms, ANDed, restricting the rows reduced.
+    pub conditions: Vec<(String, CborValue)>,
+    /// Group keys. Empty means one row out; otherwise one row per distinct
+    /// combination, carrying the key columns alongside `alias`.
+    pub group_by: Vec<String>,
+}
+
+impl AggregateSpec {
+    /// A scalar reduction over whole rows, e.g. `count`.
+    pub fn new(op: impl Into<String>, alias: impl Into<String>) -> Self {
+        Self {
+            op: op.into(),
+            column: None,
+            alias: alias.into(),
+            conditions: Vec::new(),
+            group_by: Vec::new(),
+        }
+    }
+
+    /// Reduce `column` rather than whole rows.
+    pub fn column(mut self, column: impl Into<String>) -> Self {
+        self.column = Some(column.into());
+        self
+    }
+
+    /// Restrict to rows where `field == value`.
+    pub fn condition(mut self, field: impl Into<String>, value: CborValue) -> Self {
+        self.conditions.push((field.into(), value));
+        self
+    }
+
+    /// Emit one row per distinct value of `column`.
+    pub fn group_by(mut self, column: impl Into<String>) -> Self {
+        self.group_by.push(column.into());
+        self
+    }
+
+    /// A stable, unique name for the set this spec derives from `table`.
+    ///
+    /// Two things depend on it. A derived Dio caches under this name, so it
+    /// must not collide with the source table or with a differently-shaped
+    /// aggregate over the same source. And two identical aggregates must
+    /// produce the *same* key, so a page showing one number twice shares one
+    /// engine instead of computing it twice.
+    ///
+    /// `#` separates the source from its derivation: it has no other meaning
+    /// in this vocabulary (dots are column paths, `/` already separates
+    /// datasource from table), and it sorts each derived table next to the
+    /// one it came from in a cache directory.
+    ///
+    /// ```
+    /// # use vantage_vista::AggregateSpec;
+    /// # use ciborium::Value as CborValue;
+    /// let spec = AggregateSpec::new("count", "opened")
+    ///     .condition("Event", CborValue::Text("opened".into()));
+    /// assert_eq!(spec.cache_key("email_events"), "email_events#count[Event=opened]");
+    /// ```
+    pub fn cache_key(&self, table: &str) -> String {
+        let mut key = format!("{table}#{}", self.op);
+        if let Some(column) = &self.column {
+            key.push_str(&format!("({column})"));
+        }
+        if !self.conditions.is_empty() {
+            // Sorted, so two specs that differ only in the order the terms
+            // were added still share a cache table and an engine.
+            let mut terms: Vec<String> = self
+                .conditions
+                .iter()
+                .map(|(field, value)| format!("{field}={}", scalar(value)))
+                .collect();
+            terms.sort();
+            key.push_str(&format!("[{}]", terms.join(",")));
+        }
+        if !self.group_by.is_empty() {
+            // NOT sorted: grouping by (a, b) is a different table from
+            // (b, a) — the key columns come out in this order.
+            key.push_str(&format!("/by:{}", self.group_by.join(",")));
+        }
+        key
+    }
+}
+
+/// Render a condition value for the cache key. Non-scalars get a shape-stable
+/// debug form — they're rare in an equality term, and a key only has to be
+/// stable and unique, not readable.
+fn scalar(value: &CborValue) -> String {
+    match value {
+        CborValue::Text(s) => s.clone(),
+        CborValue::Integer(i) => i128::from(*i).to_string(),
+        CborValue::Float(f) => f.to_string(),
+        CborValue::Bool(b) => b.to_string(),
+        CborValue::Null => "null".to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text(s: &str) -> CborValue {
+        CborValue::Text(s.to_string())
+    }
+
+    #[test]
+    fn a_bare_reduction_keys_on_its_op() {
+        assert_eq!(
+            AggregateSpec::new("count", "total").cache_key("email_events"),
+            "email_events#count"
+        );
+    }
+
+    #[test]
+    fn the_reduced_column_is_part_of_the_key() {
+        assert_eq!(
+            AggregateSpec::new("sum", "bytes")
+                .column("Size")
+                .cache_key("email_events"),
+            "email_events#sum(Size)"
+        );
+    }
+
+    /// The point of the key: two differently-conditioned aggregates over one
+    /// source must not share a cache table, or one would serve the other's
+    /// number.
+    #[test]
+    fn conditions_separate_two_aggregates_over_one_source() {
+        let opened = AggregateSpec::new("count", "opened").condition("Event", text("opened"));
+        let failed = AggregateSpec::new("count", "failed").condition("Event", text("failed"));
+        assert_ne!(
+            opened.cache_key("email_events"),
+            failed.cache_key("email_events")
+        );
+    }
+
+    /// And the converse: the same question asked twice must land on ONE
+    /// engine, however the terms were ordered.
+    #[test]
+    fn term_order_does_not_change_the_key() {
+        let a = AggregateSpec::new("count", "x")
+            .condition("Event", text("opened"))
+            .condition("Ip", text("1.2.3.4"));
+        let b = AggregateSpec::new("count", "x")
+            .condition("Ip", text("1.2.3.4"))
+            .condition("Event", text("opened"));
+        assert_eq!(a.cache_key("t"), b.cache_key("t"));
+    }
+
+    /// Grouping order IS significant — it decides the output column order.
+    #[test]
+    fn group_order_does_change_the_key() {
+        let a = AggregateSpec::new("count", "n").group_by("a").group_by("b");
+        let b = AggregateSpec::new("count", "n").group_by("b").group_by("a");
+        assert_ne!(a.cache_key("t"), b.cache_key("t"));
+    }
+
+    /// The alias names the output column, not the question — two aliases for
+    /// the same reduction are the same computation and should share it.
+    #[test]
+    fn the_alias_does_not_affect_the_key() {
+        let a = AggregateSpec::new("count", "total");
+        let b = AggregateSpec::new("count", "observed");
+        assert_eq!(a.cache_key("t"), b.cache_key("t"));
+    }
+
+    #[test]
+    fn a_derived_key_cannot_collide_with_a_plain_table() {
+        let key = AggregateSpec::new("count", "total").cache_key("email_events");
+        assert!(key.starts_with("email_events#"));
+        assert_ne!(key, "email_events");
+    }
+}

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+pub mod aggregate;
 pub mod any_expression;
 pub mod capabilities;
 pub mod column;
@@ -19,6 +20,7 @@ pub mod source;
 pub mod spec;
 pub mod vista;
 
+pub use aggregate::AggregateSpec;
 pub use any_expression::{AnyExpression, ExpressionLike};
 pub use capabilities::VistaCapabilities;
 pub use column::Column;

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -217,12 +217,23 @@ pub trait TableShell: Send + Sync + 'static {
     /// handles instead of growing a scalar special case.
     ///
     /// `Ok(None)` means *this driver cannot answer this request* — not that
-    /// the result is empty. The whole [`AggregateSpec`] is offered at once so
-    /// the refusal can be whole: a driver that can sum but cannot express one
-    /// of the conditions must answer `None` rather than sum the unfiltered
-    /// set. The caller then reduces locally, which is a different question
-    /// (the rows it holds, not every row that matches) with a different
-    /// answer, so "can't" must never collapse into a number.
+    /// the result is empty. The caller then reduces locally, which is a
+    /// different question (the rows it holds, not every row that matches) with
+    /// a different answer, so "can't" must never collapse into a number.
+    ///
+    /// **Narrow before aggregating.** Conditions belong to the source, applied
+    /// with `add_eq_condition` before this call — the order SQL uses, where the
+    /// filter is the inner query and the aggregate selects from its result.
+    /// Narrowing reports its own failure, so a driver is never handed a filter
+    /// it would silently ignore.
+    ///
+    /// **The returned vista's capabilities describe the DERIVED set, not the
+    /// source.** In particular it must not advertise condition support unless
+    /// the driver really implements it: adding a condition to an aggregate is
+    /// `HAVING`, a different operation over different values, and inheriting
+    /// the source's flag would promise a filter that silently does nothing.
+    /// An aggregator holding its entire output in memory is the exception —
+    /// it can filter what it produced, and may say so.
     ///
     /// This is construction, not a query — nothing is fetched until someone
     /// lists the returned vista.

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -8,6 +8,7 @@ use vantage_core::{Result, VantageError, error};
 use vantage_types::Record;
 
 use crate::{
+    aggregate::AggregateSpec,
     capabilities::VistaCapabilities,
     column::Column,
     reference::{ContainedSpec, Reference},
@@ -204,6 +205,29 @@ pub trait TableShell: Send + Sync + 'static {
     /// count (`SELECT COUNT(*)`, etc.) override.
     async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
         Ok(self.list_vista_values(vista).await?.len() as i64)
+    }
+
+    /// Derive a **new vista** that reduces this one — the driver's equivalent
+    /// of selecting from a subquery.
+    ///
+    /// An aggregation is not a value, it is a different set: `count(*)` yields
+    /// one row, `GROUP BY` yields one per group, and either can then be
+    /// conditioned, ordered or counted like any other set. Returning a
+    /// [`Vista`] is what lets every consumer keep the single shape it already
+    /// handles instead of growing a scalar special case.
+    ///
+    /// `Ok(None)` means *this driver cannot answer this request* — not that
+    /// the result is empty. The whole [`AggregateSpec`] is offered at once so
+    /// the refusal can be whole: a driver that can sum but cannot express one
+    /// of the conditions must answer `None` rather than sum the unfiltered
+    /// set. The caller then reduces locally, which is a different question
+    /// (the rows it holds, not every row that matches) with a different
+    /// answer, so "can't" must never collapse into a number.
+    ///
+    /// This is construction, not a query — nothing is fetched until someone
+    /// lists the returned vista.
+    fn aggregate_vista(&self, _vista: &Vista, _spec: &AggregateSpec) -> Result<Option<Vista>> {
+        Ok(None)
     }
 
     // ---- Conditions --------------------------------------------------------

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -342,6 +342,27 @@ pub trait TableShell: Send + Sync + 'static {
         Err(self.default_error("fetch_window", "can_fetch_window"))
     }
 
+    /// [`fetch_window`](Self::fetch_window), plus the grand total of matching
+    /// rows when this fetch already learned it.
+    ///
+    /// Paged sources typically report the total in every response envelope,
+    /// alongside the window's rows. A caller needing both — a lazily-loaded
+    /// grid sizing its scrollbar — would otherwise pay a second round trip for
+    /// a number the first reply already carried.
+    ///
+    /// Drivers that can answer override this. The default delegates and
+    /// reports `None`, so no existing driver changes and no caller is told a
+    /// total exists when it doesn't. `None` means "this fetch didn't say",
+    /// never "zero".
+    async fn fetch_window_counted(
+        &self,
+        vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<i64>)> {
+        Ok((self.fetch_window(vista, offset, limit).await?, None))
+    }
+
     // ---- Quicksearch -------------------------------------------------------
 
     /// Apply a quicksearch filter — a single string the driver fans out across

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -257,6 +257,18 @@ impl Vista {
         self.source.fetch_window(self, offset, limit).await
     }
 
+    /// [`fetch_window`](Self::fetch_window), plus the grand total when the
+    /// driver learned it from the same response. `None` means this fetch
+    /// carried no total — ask [`get_count`](Self::get_count) when one is
+    /// required.
+    pub async fn fetch_window_counted(
+        &self,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<i64>)> {
+        self.source.fetch_window_counted(self, offset, limit).await
+    }
+
     // ---- quicksearch -------------------------------------------------------
 
     /// Apply a quicksearch filter. The driver decides which columns participate;

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -3,6 +3,7 @@ use vantage_core::{Result, error};
 use vantage_types::Record;
 
 use crate::{
+    aggregate::AggregateSpec,
     capabilities::VistaCapabilities,
     column::Column,
     flags,
@@ -183,6 +184,16 @@ impl Vista {
 
     pub async fn get_count(&self) -> Result<i64> {
         self.source.get_vista_count(self).await
+    }
+
+    /// Derive a new vista that reduces this one, or `None` when the driver
+    /// can't answer the request.
+    ///
+    /// `None` is the signal to reduce locally instead — see
+    /// [`TableShell::aggregate_vista`](crate::TableShell::aggregate_vista) for
+    /// why a partial answer is never returned.
+    pub fn aggregate(&self, spec: &AggregateSpec) -> Result<Option<Vista>> {
+        self.source.aggregate_vista(self, spec)
     }
 
     /// Fetch one record by id, passing the caller's existing record down to the


### PR DESCRIPTION
Eight commits spanning three related threads: carrying a paginated response's own total through the stack, deriving aggregates in memory over a Dio, and fixing what a scenery decides about its own load shape when one Lens serves a whole datasource.

## Window totals

`fetch_window_counted` returns the grand total the window response already states, so a paged table sizes its scrollbar without a second request. Previously a `total_provider` issued a separate `limit=1` call and the open path awaited it — one measured startup spent **8.5s** there, all of it on the main thread.

## Aggregates

`AggregateSpec` derives a new vista rather than a value, with a collision-free cache key; conditions narrow the source before aggregating; a scalar reduction mounts as a one-row table so no consumer needs a value path; `group_by` builds its per-group reduction through the same catalog as an ungrouped one, so the two cannot disagree.

Aggregates over a **paged** source used to sit at zero on a cold cache — the engine ignored `RangeLoaded` and a chunk load emits no per-row event. They now recompute as each window lands.

## Load shape under a shared lens

One Lens per datasource carries every callback any table under it might need. Which one applies is a property of the *master*, decided per scenery at open — but several places asked the lens, whose answer is always "both".

- **An eager scenery's landed seed reaches it again.** `is_chunk_loaded` read the lens; under a shared lens every scenery claimed to be paged, so a landed dataset was answered by re-fetching a viewport it never fetches through. Rows sat in the cache and the grid stayed empty until something reopened it over a warm cache.
- **`DioEvent::Seeded`** — the eager loader saying the whole set is in the cache, distinct from `DatasetChanged`'s "membership moved, re-derive per your shape".
- **A grid no longer paints "no rows" over a load in flight.** Two paths settled too early: a paged scenery reseeding from an empty cache (a default sort at mount triggers exactly this, milliseconds before the first fetch), and an eager one reseeding while its copy was still running.
- **`LoadState`** (`Loading`/`Partial`/`Complete`) so consumers wait on state rather than assuming `open()` implies data.

## Breaking

`DioEvent` gains `Seeded` and is now `#[non_exhaustive]` — **matches on it need a fallback arm**. `vantage-diorama` 0.9.0 → **0.10.0**; dependents' requirements updated.

## Other

- Chunk loads write once per page, not once per row (a redb transaction and durability barrier per row made a 100-row page cost 100 of them).
- A source that overstates its total no longer loops forever asking for rows it will not serve.
- Two-pass hydration prioritises rows by **displayed** position, so a sorted view hydrates what is on screen.
- A fetch ledger in `stats` counting windows requested, re-requested, and rows returned that the cache already held.
- Every REST round trip is timed; over 1s it logs `slow REST GET` with the URL.
- `vantage-surrealdb` implements `fetch_window`, deliberately not yet advertised — see its changelog for why.

## Versions

`vantage-diorama` 0.10.0 · `vantage-diorama-aggregate` 0.6.3 · `vantage-api-client` 0.6.9 · `vantage-surrealdb` 0.6.12

## Testing

Workspace clippy clean on 1.97.0; `cargo fmt` clean. 186 diorama tests, 45 aggregate, 87 api-client, 90 surrealdb — all passing. The only failures in the workspace are `surreal-client` and `vantage-surrealdb` tests that require a live SurrealDB server, which fail the same way on this branch's base.

New regression coverage: `shared_lens_eager_seed` (fails without the shape fix with `settled at 0 rows`), `chunk_overstated_total`, and `paged_source` for aggregates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable aggregations including count, sum, average, min, max, distinct, filtering, and grouping.
  * Added support for presenting scalar aggregation results as compact one-row tables.
  * Added table loading states: Loading, Partial, and Complete.
  * Added counted window fetching so row pages can include total matching rows.
  * Added driver-backed aggregation support and fetch diagnostics.
  * Added cache shutdown handling and seeded-data notifications.

* **Bug Fixes**
  * Aggregates now update progressively as paged data loads.
  * Improved paging behavior prevents repeated requests for unreachable rows.
  * Improved eager and two-pass loading reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->