### PR TITLE
Fix fallout from the diorama 0.10 bump: doc links and vantage-faker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama-aggregate"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.4 — 2026-07-28
+
+- Doc fixes: three intra-doc links that rustdoc could not resolve under
+  `--document-private-items` — one to a crate that isn't a dependency here, one
+  missing its crate path, one restating a target its label already resolved to.
+  No code change.
+
 ## 0.6.3 — 2026-07-28
 
 - Track vantage-diorama 0.10.

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama-aggregate"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Reactive client-side aggregation over a Vantage Diorama"

--- a/vantage-diorama-aggregate/src/builtin/filter.rs
+++ b/vantage-diorama-aggregate/src/builtin/filter.rs
@@ -3,7 +3,7 @@
 //! Every reduction in this crate answers over "the rows it was given", so
 //! restricting *which* rows is a separate, orthogonal concern — not something
 //! each reduction should re-implement. [`Where`] wraps any
-//! [`Aggregation`](crate::Aggregation) and hands it a narrowed set, so `sum of
+//! [`crate::Aggregation`] and hands it a narrowed set, so `sum of
 //! Size where Event = opened` composes out of the two pieces already here
 //! instead of needing a `SumWhere`.
 

--- a/vantage-diorama-aggregate/src/catalog.rs
+++ b/vantage-diorama-aggregate/src/catalog.rs
@@ -7,9 +7,9 @@
 //! grows the same six-arm match, and none of them can be extended with an
 //! aggregation the crate doesn't ship.
 //!
-//! [`AggregationCatalog`] is that lookup — the same shape as
-//! [`VistaCatalog`](vantage_vista_factory::VistaCatalog), which resolves a
-//! vista by name for exactly the same reason.
+//! [`AggregationCatalog`] is that lookup — the same shape as vista-factory's
+//! `VistaCatalog`, which resolves a vista by name for exactly the same reason.
+//! (Named, not linked: that crate is not a dependency here.)
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -151,7 +151,8 @@ enum Wake {
 /// missed by ignoring them.
 ///
 /// `RangeLoaded` is NOT among them, though it reads like one. A single-pass
-/// chunk load writes its rows through [`ChunkSink::push`], straight into the
+/// chunk load writes its rows through [`vantage_diorama::ChunkSink::push`],
+/// straight into the
 /// cache — it emits no per-row event, and `RangeLoaded` is the only thing it
 /// announces. Ignoring it meant a paged source could load its whole first page
 /// and every aggregate over it would still be reporting the empty set it was

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.10 — 2026-07-28
+
+- Track vantage-diorama 0.10. The requirement stayed at `0.9` when diorama
+  released 0.10, which left this crate unresolvable and — more to the point —
+  put a second diorama into the graph of anything depending on both. `Dio` and
+  `ChangeEvent` from two versions are different types, so that surfaces far from
+  its cause.
+
 ## 0.6.9 — 2026-07-27
 
 - Track vantage-diorama 0.9 (client-side search and the augmentation spec layer

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.8"
+version = "0.6.10"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.5"
+version = "0.6.7"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.16"
+version = "0.6.19"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.9", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"

--- a/vantage-ui-adapters/Cargo.lock
+++ b/vantage-ui-adapters/Cargo.lock
@@ -10829,7 +10829,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "atty",
  "indexmap 2.14.0",
@@ -10860,7 +10860,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.6.18"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -10871,6 +10871,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "vantage-core",
  "vantage-dataset",
  "vantage-table",
@@ -10894,7 +10895,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.10"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -10918,8 +10919,9 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.3"
+version = "0.6.7"
 dependencies = [
+ "chrono",
  "ciborium",
  "indexmap 2.14.0",
  "paste",
@@ -10940,7 +10942,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.11"
+version = "0.6.19"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.19 — 2026-07-28
+
+- Doc fix: an intra-doc link on `Vista::aggregate` spelled out a target the
+  label already resolved to, which `-D warnings` rejects. No code change.
+
 ## 0.6.18 — 2026-07-28
 
 - **`AggregateSpec` and `Vista::aggregate`** — an aggregation derives a *new

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -190,8 +190,8 @@ impl Vista {
     /// can't answer the request.
     ///
     /// `None` is the signal to reduce locally instead — see
-    /// [`TableShell::aggregate_vista`](crate::TableShell::aggregate_vista) for
-    /// why a partial answer is never returned.
+    /// [`crate::TableShell::aggregate_vista`] for why a partial answer is
+    /// never returned.
     pub fn aggregate(&self, spec: &AggregateSpec) -> Result<Option<Vista>> {
         self.source.aggregate_vista(self, spec)
     }


### PR DESCRIPTION
Two things #372 broke, neither caught by CI.

## Intra-doc links

The `Check documentation` job runs rustdoc with `-D warnings` **and `--document-private-items`**, which resolves links a plain `cargo doc` never reaches — which is why these got through locally.

- `vantage-diorama-aggregate/src/catalog.rs` — linked to `vantage_vista_factory::VistaCatalog`, not a dependency of this crate. Named in prose instead, with a note saying why it isn't a link.
- `vantage-diorama-aggregate/src/engine.rs` — `ChunkSink::push` needed its crate path; it resolves as `vantage_diorama::ChunkSink::push`.
- `vantage-diorama-aggregate/src/builtin/filter.rs` and `vantage-vista/src/vista.rs` — explicit link targets restating what the label already resolves to, which `rustdoc::redundant_explicit_links` rejects.

## vantage-faker

`vantage-faker` still required `vantage-diorama = "^0.9"`, so after diorama went to 0.10 the crate no longer resolves at all:

```
error: failed to select a version for the requirement `vantage-diorama = "^0.9"`
candidate versions found which didn't match: 0.10.0
```

Nothing caught this: `vantage-faker` is in the workspace `exclude` list, so `cargo check --workspace` skips it, and it has no workflow of its own. The consequence is worse than a failed build — anything depending on both faker and diorama would resolve **two** diorama versions, and `Dio`/`ChangeEvent` from two versions are distinct types, so the error lands far from its cause. This is what would have blocked the matching vantage-ui release.

I checked the other excluded crates for the same stale pin: `vantage-aws`, `vantage-cmd`, `vantage-kubernetes` and `vantage-spacetimedb` don't depend on diorama; `vantage-ui-adapters` uses a path dep with no version requirement and builds clean with `--features ratatui`.

## Versions

`vantage-vista` 0.6.19 · `vantage-diorama-aggregate` 0.6.4 · `vantage-faker` 0.6.10. Patch bumps because `pr-version-check` requires one for any change to a publishable crate.

## Testing

The exact CI doc invocation passes:

```
RUSTDOCFLAGS="-D warnings" cargo doc --workspace \
  --exclude surreal-client --exclude vantage-surrealdb --exclude vantage-sql \
  --exclude bakery_model3 --exclude vantage-mongodb \
  --no-deps --document-private-items
```

`cargo check` passes standalone in `vantage-faker` and in `vantage-ui-adapters --features ratatui`.

Worth considering separately: `vantage-faker` builds in no CI job at all, which is how a dependency bump broke it silently.