### PR TITLE
diorama: official per-datasource debug stream (DebugTap, census, exit summary)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5693,6 +5693,7 @@ dependencies = [
  "indexmap",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "vantage-core",
  "vantage-dataset",
  "vantage-diorama",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5662,6 +5662,7 @@ dependencies = [
  "futures",
  "indexmap",
  "insta",
+ "libc",
  "redb",
  "rstest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama-aggregate"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.11", path = "../vantage-diorama" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.5 — 2026-07-30
+
+- Track vantage-diorama 0.11.
+- **`"aggregate recompute"` joins the debug stream.** An aggregate has no
+  datasource of its own to opt in — its debug lines are inherited from
+  whatever the source Dio was built with, and fire under the same
+  `vantage_diorama::debug` target with the same `ds=` the source uses.
+  Reports the trigger (`initial`, `debounce-trailing`, `nudge`, `lagged`, or
+  the `DioEvent` variant that woke the loop), rows in and out, timing, and
+  whether the output changed enough to publish. A `derive()`'s first load
+  reports two `initial` lines — the eager compute that seeds the derived
+  Vista's schema, then the engine's own seed pass reading that output back —
+  which is the intended reading, not a duplicate line.
+
 ## 0.6.4 — 2026-07-28
 
 - Doc fixes: three intra-doc links that rustdoc could not resolve under

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama-aggregate"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Reactive client-side aggregation over a Vantage Diorama"
@@ -14,7 +14,7 @@ vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
-vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.11", path = "../vantage-diorama" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -31,3 +31,4 @@ tokio = { version = "1", features = [
     "sync",
     "time",
 ] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/vantage-diorama-aggregate/src/aggregation.rs
+++ b/vantage-diorama-aggregate/src/aggregation.rs
@@ -53,6 +53,11 @@ pub trait Aggregation: Send + Sync + 'static {
 pub trait AggregateOutput: PartialEq + Clone + Send + Sync + 'static {
     #[doc(hidden)]
     fn seal() -> Sealed;
+
+    /// Row count for the debug stream's `rows_out` field: 1 for a scalar,
+    /// the row count for a derived set.
+    #[doc(hidden)]
+    fn debug_row_count(&self) -> usize;
 }
 
 #[doc(hidden)]
@@ -62,6 +67,10 @@ pub struct Sealed;
 impl AggregateOutput for CborValue {
     fn seal() -> Sealed {
         Sealed
+    }
+
+    fn debug_row_count(&self) -> usize {
+        1
     }
 }
 
@@ -110,5 +119,9 @@ impl PartialEq for DerivedRows {
 impl AggregateOutput for DerivedRows {
     fn seal() -> Sealed {
         Sealed
+    }
+
+    fn debug_row_count(&self) -> usize {
+        self.len()
     }
 }

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -13,9 +13,9 @@ use ciborium::Value as CborValue;
 use tokio::sync::{Notify, broadcast};
 use tokio::task::JoinHandle;
 use vantage_dataset::traits::ReadableValueSet;
-use vantage_diorama::{Dio, DioEvent};
+use vantage_diorama::{DebugTap, Dio, DioEvent};
 
-use crate::aggregation::Aggregation;
+use crate::aggregation::{Aggregation, AggregateOutput};
 
 /// Where a recomputed output goes. Implemented by the two surfaces.
 #[async_trait]
@@ -45,6 +45,7 @@ pub(crate) struct Source<R> {
 /// before it can build its Vista) — so the loop's own first pass recognises
 /// that output as current and stays quiet.
 pub(crate) fn spawn<A, R, P>(
+    name: &str,
     source: Source<R>,
     aggregation: Arc<A>,
     publisher: &Arc<P>,
@@ -60,6 +61,7 @@ where
     let publisher = Arc::downgrade(publisher);
     let runtime = tokio::runtime::Handle::current();
     runtime.spawn(run(
+        name.to_string(),
         source,
         aggregation,
         publisher,
@@ -70,6 +72,7 @@ where
 }
 
 async fn run<A, R, P>(
+    name: String,
     source: Source<R>,
     aggregation: Arc<A>,
     publisher: Weak<P>,
@@ -81,12 +84,16 @@ async fn run<A, R, P>(
     R: ReadableValueSet<Id = String, Value = CborValue> + Send + Sync + 'static,
     P: Publish<A::Output>,
 {
+    // The tap is the source dio's, not this layer's own — an aggregate has
+    // no datasource of its own to opt in, so its debug lines are inherited
+    // from whatever the source was built with.
+    let tap = source.dio.debug_tap();
     let mut bus = source.dio.subscribe_events();
     let mut last: Option<A::Output> = already_published;
 
     // Seed: whatever the source already holds. A warm cache means the layer
     // has a value before any fetch completes.
-    if recompute(&source, &aggregation, &publisher, &mut last)
+    if recompute(&name, &tap, "initial", &source, &aggregation, &publisher, &mut last)
         .await
         .is_break()
     {
@@ -95,15 +102,23 @@ async fn run<A, R, P>(
 
     loop {
         // Idle until something happens.
-        match wait(&mut bus, &nudge).await {
-            Wake::Changed => {}
+        let trigger = match wait(&mut bus, &nudge, &tap).await {
+            Wake::Changed(trigger) => trigger,
             Wake::SourceGone => return,
-        }
+        };
 
         // Leading edge: react at once, so a single change feels immediate.
-        if recompute(&source, &aggregation, &publisher, &mut last)
-            .await
-            .is_break()
+        if recompute(
+            &name,
+            &tap,
+            trigger.as_deref().unwrap_or(""),
+            &source,
+            &aggregation,
+            &publisher,
+            &mut last,
+        )
+        .await
+        .is_break()
         {
             return;
         }
@@ -114,16 +129,24 @@ async fn run<A, R, P>(
         let deadline = tokio::time::Instant::now() + debounce;
         let mut dirty = false;
         loop {
-            match tokio::time::timeout_at(deadline, wait(&mut bus, &nudge)).await {
-                Ok(Wake::Changed) => dirty = true,
+            match tokio::time::timeout_at(deadline, wait(&mut bus, &nudge, &tap)).await {
+                Ok(Wake::Changed(_)) => dirty = true,
                 Ok(Wake::SourceGone) => return,
                 Err(_) => break,
             }
         }
         if dirty
-            && recompute(&source, &aggregation, &publisher, &mut last)
-                .await
-                .is_break()
+            && recompute(
+                &name,
+                &tap,
+                "debounce-trailing",
+                &source,
+                &aggregation,
+                &publisher,
+                &mut last,
+            )
+            .await
+            .is_break()
         {
             return;
         }
@@ -131,8 +154,29 @@ async fn run<A, R, P>(
 }
 
 enum Wake {
-    Changed,
+    /// The trigger label for the recompute this wake causes — `Some` only
+    /// when the tap is enabled, since it exists purely for the debug line.
+    ///
+    /// Two spellings meet in this label: a real `DioEvent` variant comes
+    /// through Debug-formatted and PascalCase (`"RecordChanged"`); a wake
+    /// with no event behind it — the local write-through nudge, or a lagged
+    /// bus counted as "something changed" — is spelled lowercase
+    /// (`"nudge"`, `"lagged"`), the same register as `"initial"` and
+    /// `"debounce-trailing"` at the call sites in `run`.
+    Changed(Option<String>),
     SourceGone,
+}
+
+/// The event's variant name, Debug-formatted and trimmed of its fields —
+/// `RecordChanged { id: "5" }` becomes `"RecordChanged"`. Cheap enough to
+/// build only where it is: on the wake path, gated behind `tap.enabled()`.
+fn event_trigger(event: &DioEvent) -> String {
+    let debug = format!("{event:?}");
+    debug
+        .split([' ', '('])
+        .next()
+        .unwrap_or(&debug)
+        .to_string()
 }
 
 /// Block until the source's rows may have changed.
@@ -168,23 +212,27 @@ enum Wake {
 /// refresh from flickering every derived value through empty. If the refresh
 /// fails there is no `DatasetChanged` and the layer keeps its last good output,
 /// which is the same stale-over-blank choice made everywhere else here.
-async fn wait(bus: &mut broadcast::Receiver<DioEvent>, nudge: &Notify) -> Wake {
+async fn wait(bus: &mut broadcast::Receiver<DioEvent>, nudge: &Notify, tap: &DebugTap) -> Wake {
     loop {
         tokio::select! {
-            _ = nudge.notified() => return Wake::Changed,
+            _ = nudge.notified() => {
+                return Wake::Changed(tap.enabled().then(|| "nudge".to_string()));
+            }
             received = bus.recv() => match received {
                 Ok(DioEvent::ViewportChanged { .. })
                 | Ok(DioEvent::LoadFailed { .. })
                 | Ok(DioEvent::Hydrating { .. })
                 | Ok(DioEvent::Refreshing) => continue,
-                Ok(_) => return Wake::Changed,
+                Ok(event) => {
+                    return Wake::Changed(tap.enabled().then(|| event_trigger(&event)));
+                }
                 Err(broadcast::error::RecvError::Lagged(dropped)) => {
                     tracing::debug!(
                         target: "vantage_diorama_aggregate",
                         dropped,
                         "source event bus lagged — recomputing from the current rows",
                     );
-                    return Wake::Changed;
+                    return Wake::Changed(tap.enabled().then(|| "lagged".to_string()));
                 }
                 Err(broadcast::error::RecvError::Closed) => return Wake::SourceGone,
             },
@@ -197,6 +245,9 @@ async fn wait(bus: &mut broadcast::Receiver<DioEvent>, nudge: &Notify) -> Wake {
 /// Returns `Break` when the publisher has been dropped, which is how the task
 /// learns to stop.
 async fn recompute<A, R, P>(
+    name: &str,
+    tap: &DebugTap,
+    trigger: &str,
     source: &Source<R>,
     aggregation: &Arc<A>,
     publisher: &Weak<P>,
@@ -211,6 +262,11 @@ where
         return std::ops::ControlFlow::Break(());
     };
 
+    // Timing is the only thing worth gating here — rows_in/rows_out are
+    // plain lengths off values `recompute` already has to produce, so
+    // computing them costs nothing extra whether or not the tap is on.
+    let start = tap.enabled().then(std::time::Instant::now);
+
     let rows = match source.reader.list_values().await {
         Ok(rows) => rows,
         Err(e) => {
@@ -218,12 +274,31 @@ where
             return std::ops::ControlFlow::Continue(());
         }
     };
+    let rows_in = rows.len();
 
     let output = aggregation.compute(&rows);
+    let rows_out = output.debug_row_count();
 
     // The comparison is what makes unconditional recomputation affordable:
     // recomputing often is fine as long as it does not repaint often.
-    if last.as_ref() == Some(&output) {
+    let unchanged = last.as_ref() == Some(&output);
+
+    if tap.enabled() {
+        let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
+        tracing::info!(
+            target: "vantage_diorama::debug",
+            ds = %tap.ds(),
+            aggregate = name,
+            trigger,
+            rows_in,
+            rows_out,
+            ms,
+            unchanged,
+            "aggregate recompute",
+        );
+    }
+
+    if unchanged {
         return std::ops::ControlFlow::Continue(());
     }
 

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -15,7 +15,7 @@ use tokio::task::JoinHandle;
 use vantage_dataset::traits::ReadableValueSet;
 use vantage_diorama::{DebugTap, Dio, DioEvent};
 
-use crate::aggregation::{Aggregation, AggregateOutput};
+use crate::aggregation::{AggregateOutput, Aggregation};
 
 /// Where a recomputed output goes. Implemented by the two surfaces.
 #[async_trait]
@@ -93,9 +93,17 @@ async fn run<A, R, P>(
 
     // Seed: whatever the source already holds. A warm cache means the layer
     // has a value before any fetch completes.
-    if recompute(&name, &tap, "initial", &source, &aggregation, &publisher, &mut last)
-        .await
-        .is_break()
+    if recompute(
+        &name,
+        &tap,
+        "initial",
+        &source,
+        &aggregation,
+        &publisher,
+        &mut last,
+    )
+    .await
+    .is_break()
     {
         return;
     }
@@ -172,11 +180,7 @@ enum Wake {
 /// build only where it is: on the wake path, gated behind `tap.enabled()`.
 fn event_trigger(event: &DioEvent) -> String {
     let debug = format!("{event:?}");
-    debug
-        .split([' ', '('])
-        .next()
-        .unwrap_or(&debug)
-        .to_string()
+    debug.split([' ', '(']).next().unwrap_or(&debug).to_string()
 }
 
 /// Block until the source's rows may have changed.

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -232,6 +232,12 @@ async fn wait(bus: &mut broadcast::Receiver<DioEvent>, nudge: &Notify, tap: &Deb
                         dropped,
                         "source event bus lagged — recomputing from the current rows",
                     );
+                    // "lagged" is intentionally untested: forcing a broadcast
+                    // receiver to fall behind deterministically (fill its
+                    // ring buffer faster than this task drains it) isn't
+                    // worth the test complexity for one trigger label. The
+                    // label exists so a real lag shows up in the stream
+                    // rather than masquerading as some other trigger.
                     return Wake::Changed(tap.enabled().then(|| "lagged".to_string()));
                 }
                 Err(broadcast::error::RecvError::Closed) => return Wake::SourceGone,
@@ -262,9 +268,6 @@ where
         return std::ops::ControlFlow::Break(());
     };
 
-    // Timing is the only thing worth gating here — rows_in/rows_out are
-    // plain lengths off values `recompute` already has to produce, so
-    // computing them costs nothing extra whether or not the tap is on.
     let start = tap.enabled().then(std::time::Instant::now);
 
     let rows = match source.reader.list_values().await {
@@ -274,17 +277,21 @@ where
             return std::ops::ControlFlow::Continue(());
         }
     };
-    let rows_in = rows.len();
 
     let output = aggregation.compute(&rows);
-    let rows_out = output.debug_row_count();
 
     // The comparison is what makes unconditional recomputation affordable:
     // recomputing often is fine as long as it does not repaint often.
     let unchanged = last.as_ref() == Some(&output);
 
+    // rows_in/rows_out are cheap today (a length, a stored count) but the
+    // gate stays structural rather than relying on that: nothing here
+    // should cost anything when the tap is off, including a future
+    // `debug_row_count` that isn't.
     if tap.enabled() {
         let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
+        let rows_in = rows.len();
+        let rows_out = output.debug_row_count();
         tracing::info!(
             target: "vantage_diorama::debug",
             ds = %tap.ds(),

--- a/vantage-diorama-aggregate/src/lens.rs
+++ b/vantage-diorama-aggregate/src/lens.rs
@@ -17,7 +17,7 @@ use vantage_dataset::traits::ReadableValueSet;
 use vantage_diorama::{CacheBackend, Dio, Lens, MemoryCache, RedbCache, ValueScenery};
 use vantage_vista::Vista;
 
-use crate::aggregation::{Aggregation, DerivedRows};
+use crate::aggregation::{AggregateOutput, Aggregation, DerivedRows};
 use crate::derived::{AggregateShell, DerivedDio, DerivedState, shared};
 use crate::engine::{self, Publish, Source};
 use crate::value::{AggregateValue, TaskGuard, ValueState};
@@ -139,6 +139,7 @@ impl AggregateLens {
         state.seed_from_cache().await;
 
         let handle = engine::spawn(
+            name,
             Source {
                 reader: source.vista(),
                 dio: source.clone(),
@@ -201,8 +202,32 @@ impl AggregateLens {
         // Compute once up front: the schema of the derived table is whatever
         // the aggregation declares, and the Vista needs it before it exists.
         let aggregation = Arc::new(aggregation);
+        let tap = source.debug_tap();
+        let start = tap.enabled().then(std::time::Instant::now);
         let rows = source.vista().list_values().await?;
+        let rows_in = rows.len();
         let initial = aggregation.compute(&rows);
+
+        // This eager pass never goes through the engine's own `recompute` —
+        // it runs before `engine::spawn` even exists to seed the Vista's
+        // schema — so it carries its own debug line. The engine's Seed pass
+        // that follows will report the same output as `unchanged` (it is
+        // seeded with `already_published` below), which is the intended
+        // "publish skipped" reading for that second line.
+        if tap.enabled() {
+            let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
+            tracing::info!(
+                target: "vantage_diorama::debug",
+                ds = %tap.ds(),
+                aggregate = name,
+                trigger = "initial",
+                rows_in,
+                rows_out = initial.debug_row_count(),
+                ms,
+                unchanged = false,
+                "aggregate recompute",
+            );
+        }
 
         let shared_rows = shared(initial.clone());
         let shell = AggregateShell::new(shared_rows.clone(), &initial.columns);
@@ -215,6 +240,7 @@ impl AggregateLens {
         state.publish(initial.clone()).await;
 
         let handle = engine::spawn(
+            name,
             Source {
                 reader: source.vista(),
                 dio: source.clone(),

--- a/vantage-diorama-aggregate/src/lens.rs
+++ b/vantage-diorama-aggregate/src/lens.rs
@@ -205,7 +205,6 @@ impl AggregateLens {
         let tap = source.debug_tap();
         let start = tap.enabled().then(std::time::Instant::now);
         let rows = source.vista().list_values().await?;
-        let rows_in = rows.len();
         let initial = aggregation.compute(&rows);
 
         // This eager pass never goes through the engine's own `recompute` —
@@ -214,6 +213,9 @@ impl AggregateLens {
         // that follows will report the same output as `unchanged` (it is
         // seeded with `already_published` below), which is the intended
         // "publish skipped" reading for that second line.
+        //
+        // rows_in/rows_out stay inside this gate, not hoisted above it, so
+        // nothing here costs anything when the tap is off.
         if tap.enabled() {
             let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
             tracing::info!(
@@ -221,7 +223,7 @@ impl AggregateLens {
                 ds = %tap.ds(),
                 aggregate = name,
                 trigger = "initial",
-                rows_in,
+                rows_in = rows.len(),
                 rows_out = initial.debug_row_count(),
                 ms,
                 unchanged = false,

--- a/vantage-diorama-aggregate/tests/debug_tap.rs
+++ b/vantage-diorama-aggregate/tests/debug_tap.rs
@@ -1,0 +1,171 @@
+//! The aggregate engine has no datasource of its own — its debug lines are
+//! inherited from whatever tap the *source* Dio was built with.
+
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+
+mod support;
+use ciborium::Value as CborValue;
+use support::{DEBOUNCE, int, master, record, settle, source, source_with_debug, text};
+use vantage_core::Result;
+use vantage_diorama_aggregate::{AggregateLens, GroupBy, Reduce};
+use vantage_types::Record;
+use vantage_vista::Column;
+
+/// Collects every `vantage_diorama::debug` event as one flat string:
+/// `"<message> ds=<..> <field>=<..> ..."` — order of fields as emitted.
+///
+/// Copied from `vantage-diorama/tests/debug_tap.rs` — crates don't share
+/// test helpers.
+struct CaptureLayer(Arc<Mutex<Vec<String>>>);
+
+struct FlatVisitor {
+    message: String,
+    fields: String,
+}
+
+impl Visit for FlatVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            let _ = write!(self.fields, " {}={value:?}", field.name());
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        if event.metadata().target() != "vantage_diorama::debug" {
+            return;
+        }
+        let mut v = FlatVisitor {
+            message: String::new(),
+            fields: String::new(),
+        };
+        event.record(&mut v);
+        self.0
+            .lock()
+            .unwrap()
+            .push(format!("{}{}", v.message, v.fields));
+    }
+}
+
+/// Install a thread-local subscriber that captures every
+/// `vantage_diorama::debug` event as a flat string. Returns the guard
+/// (drop it to uninstall) and the shared log the events land in.
+fn capture() -> (tracing::subscriber::DefaultGuard, Arc<Mutex<Vec<String>>>) {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer(log.clone()));
+    (tracing::subscriber::set_default(subscriber), log)
+}
+
+/// Captured lines whose flattened text contains `needle`.
+fn lines_containing(log: &Arc<Mutex<Vec<String>>>, needle: &str) -> Vec<String> {
+    log.lock()
+        .unwrap()
+        .iter()
+        .filter(|l| l.contains(needle))
+        .cloned()
+        .collect()
+}
+
+/// The revenue-per-status reducer used by the grouping tests in
+/// `aggregate.rs` — copied here rather than shared, same reasoning as the
+/// capture harness.
+fn revenue() -> Reduce<impl Fn(&CborValue, &[&Record<CborValue>]) -> Record<CborValue>> {
+    Reduce::new(
+        vec![Column::new("orders", "i64"), Column::new("revenue", "i64")],
+        |_key, rows| {
+            let total: i64 = rows
+                .iter()
+                .filter_map(|r| r.get("amount"))
+                .filter_map(|v| match v {
+                    CborValue::Integer(i) => Some(i128::from(*i) as i64),
+                    _ => None,
+                })
+                .sum();
+            let mut out = Record::new();
+            out.insert("orders".to_string(), int(rows.len() as i64));
+            out.insert("revenue".to_string(), int(total));
+            out
+        },
+    )
+}
+
+#[tokio::test]
+async fn aggregate_recompute_line_is_inherited_from_the_source_tap() -> Result<()> {
+    let (_guard, log) = capture();
+
+    let shell = master(&[("status", "String"), ("amount", "i64")]);
+    shell.set_record(
+        "a",
+        record(&[("status", text("open")), ("amount", int(10))]),
+    );
+    shell.set_record("b", record(&[("status", text("done")), ("amount", int(5))]));
+
+    let src = source_with_debug(shell.clone(), "agg-ds").await;
+    let derived = AggregateLens::in_memory()
+        .debounce(DEBOUNCE)
+        .build()?
+        .derive(&src, "by_status", GroupBy::column("status", revenue()))
+        .await?;
+    settle().await;
+
+    let lines = lines_containing(&log, "aggregate recompute");
+    assert!(!lines.is_empty(), "expected at least one recompute line");
+    assert!(
+        lines
+            .iter()
+            .any(|l| l.contains("rows_out=") && l.contains("unchanged=false")),
+        "{lines:?}"
+    );
+    assert!(
+        lines.iter().all(|l| l.contains("ds=agg-ds")),
+        "every inherited line must carry the source's ds: {lines:?}"
+    );
+    assert!(
+        lines.iter().all(|l| l.contains("aggregate=\"by_status\"")),
+        "{lines:?}"
+    );
+
+    drop(derived);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_non_debug_source_emits_no_aggregate_recompute_lines() -> Result<()> {
+    let (_guard, log) = capture();
+
+    let shell = master(&[("status", "String"), ("amount", "i64")]);
+    shell.set_record(
+        "a",
+        record(&[("status", text("open")), ("amount", int(10))]),
+    );
+
+    let src = source(shell.clone()).await;
+    let derived = AggregateLens::in_memory()
+        .debounce(DEBOUNCE)
+        .build()?
+        .derive(&src, "by_status", GroupBy::column("status", revenue()))
+        .await?;
+    settle().await;
+
+    // A source refresh too — recompute definitely runs at least once more.
+    shell.set_record("c", record(&[("status", text("open")), ("amount", int(3))]));
+    src.refresh().await?;
+    settle().await;
+
+    assert!(
+        lines_containing(&log, "aggregate recompute").is_empty(),
+        "a non-debug source must produce zero lines: {:?}",
+        log.lock().unwrap()
+    );
+
+    drop(derived);
+    Ok(())
+}

--- a/vantage-diorama-aggregate/tests/debug_tap.rs
+++ b/vantage-diorama-aggregate/tests/debug_tap.rs
@@ -10,9 +10,12 @@ use tracing_subscriber::layer::{Context, SubscriberExt};
 
 mod support;
 use ciborium::Value as CborValue;
-use support::{DEBOUNCE, int, master, record, settle, source, source_with_debug, text};
+use support::{
+    DEBOUNCE, int, master, record, settle, source, source_with_debug,
+    source_with_debug_and_failing_refresh, text,
+};
 use vantage_core::Result;
-use vantage_diorama_aggregate::{AggregateLens, GroupBy, Reduce};
+use vantage_diorama_aggregate::{AggregateLens, GroupBy, Reduce, Sum};
 use vantage_types::Record;
 use vantage_vista::Column;
 
@@ -167,5 +170,58 @@ async fn a_non_debug_source_emits_no_aggregate_recompute_lines() -> Result<()> {
     );
 
     drop(derived);
+    Ok(())
+}
+
+/// `AggregateValue::request_refresh` covers a source with no refresh route
+/// by nudging the engine loop directly, in addition to asking the source to
+/// refresh. A working refresh would also emit `DatasetChanged`, racing the
+/// nudge for which one the engine loop's `wait()` observes first — so this
+/// test's source fails its `on_refresh` (see
+/// `support::source_with_debug_and_failing_refresh`), which suppresses that
+/// `DatasetChanged` and leaves the nudge as the only thing that wakes the
+/// loop, deterministically.
+#[tokio::test]
+async fn nudge_trigger_is_emitted_by_a_values_local_write_through() -> Result<()> {
+    let (_guard, log) = capture();
+
+    let shell = master(&[("amount", "i64")]);
+    shell.set_record("a", record(&[("amount", int(10))]));
+
+    let src = source_with_debug_and_failing_refresh(shell.clone(), "agg-ds").await;
+    let total = AggregateLens::in_memory()
+        .debounce(DEBOUNCE)
+        .build()?
+        .value(&src, "total", Sum::new("amount"))
+        .await?;
+    settle().await;
+    // Only interested in what request_refresh triggers below.
+    log.lock().unwrap().clear();
+
+    total.request_refresh();
+    settle().await;
+
+    let nudge_lines = lines_containing(&log, "trigger=\"nudge\"");
+    assert!(
+        !nudge_lines.is_empty(),
+        "expected a recompute line triggered by the local nudge: {:?}",
+        log.lock().unwrap()
+    );
+    assert!(
+        nudge_lines
+            .iter()
+            .all(|l| l.starts_with("aggregate recompute") && l.contains("aggregate=\"total\"")),
+        "{nudge_lines:?}"
+    );
+    // The failing refresh must not have smuggled in a DatasetChanged-
+    // triggered line alongside the nudge — the whole point of the failing
+    // source is to isolate the one trigger.
+    assert!(
+        lines_containing(&log, "trigger=\"DatasetChanged\"").is_empty(),
+        "the refresh was made to fail precisely so it wouldn't race the nudge: {:?}",
+        log.lock().unwrap()
+    );
+
+    drop(total);
     Ok(())
 }

--- a/vantage-diorama-aggregate/tests/support/mod.rs
+++ b/vantage-diorama-aggregate/tests/support/mod.rs
@@ -59,6 +59,43 @@ pub async fn source_with_debug(shell: MockShell, ds_name: &str) -> Dio {
     build_source(shell, Some(ds_name)).await
 }
 
+/// A debug-tapped source whose `on_refresh` always fails.
+///
+/// `AggregateValue::request_refresh` always calls the source's `refresh()`
+/// *and then* nudges the engine loop directly — the nudge is there for a
+/// source with no refresh route, so the value doesn't just sit inert. A
+/// working `on_refresh` makes those two signals arrive together (the
+/// refresh's own `DatasetChanged` and the nudge, both ready before the
+/// engine loop gets a chance to poll), which makes the wake a genuine race:
+/// `trigger` could land as either. Failing the refresh suppresses
+/// `DatasetChanged` (`Dio::refresh` only emits it on `Ok`) while the nudge
+/// still fires unconditionally, so a test wanting the `"nudge"` trigger on
+/// its own, deterministically, needs a source like this one.
+pub async fn source_with_debug_and_failing_refresh(shell: MockShell, ds_name: &str) -> Dio {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .debug_datasource(ds_name)
+            .on_start(|dio| {
+                let dio = dio.clone();
+                async move {
+                    let rows = dio.master().list_values().await?;
+                    dio.cache().insert_values(rows).await?;
+                    Ok(())
+                }
+            })
+            .on_refresh(|_dio| async move {
+                Err(vantage_core::error!(
+                    "test: refresh always fails to isolate the nudge trigger"
+                ))
+            })
+            .build()
+            .expect("source lens builds"),
+    );
+    let vista = Vista::new("items", Box::new(shell));
+    lens.make_dio(vista).await.expect("source dio")
+}
+
 async fn build_source(shell: MockShell, debug: Option<&str>) -> Dio {
     let mut builder = Lens::new().cache_in_memory();
     if let Some(name) = debug {

--- a/vantage-diorama-aggregate/tests/support/mod.rs
+++ b/vantage-diorama-aggregate/tests/support/mod.rs
@@ -50,9 +50,22 @@ pub fn master(columns: &[(&str, &str)]) -> MockShell {
 /// `on_refresh` replaces it. Mutating the shell then calling
 /// [`Dio::refresh`] is how a test simulates the datasource changing.
 pub async fn source(shell: MockShell) -> Dio {
+    build_source(shell, None).await
+}
+
+/// Same as [`source`], but with the official debug stream turned on for
+/// this datasource — the tap an aggregate spawned over this Dio inherits.
+pub async fn source_with_debug(shell: MockShell, ds_name: &str) -> Dio {
+    build_source(shell, Some(ds_name)).await
+}
+
+async fn build_source(shell: MockShell, debug: Option<&str>) -> Dio {
+    let mut builder = Lens::new().cache_in_memory();
+    if let Some(name) = debug {
+        builder = builder.debug_datasource(name);
+    }
     let lens = Arc::new(
-        Lens::new()
-            .cache_in_memory()
+        builder
             .on_start(|dio| {
                 let dio = dio.clone();
                 async move {

--- a/vantage-diorama/ARCHITECTURE.md
+++ b/vantage-diorama/ARCHITECTURE.md
@@ -570,6 +570,88 @@ Diorama errors fall into three categories:
 No callback failure ever poisons the Dio. The user's strategy decides whether
 a failed refresh marks data stale or hides it; Diorama just reports.
 
+## Debug stream
+
+Every `Lens` carries a `DebugTap` — a cheap-to-clone, cheap-to-check switch
+threaded through `Dio`, every `Scenery`, and every task either spawns. It is
+off by default. `LensBuilder::debug_datasource(name)` turns it on for every
+`Dio` that Lens produces; `name` is stamped as `ds=<name>` on every line the
+tap emits. Off means nothing is emitted and nothing is paid for: every call
+site checks `tap.enabled()` before doing any work a line needs — building a
+query descriptor, counting a column set, snapshotting process stats — not
+just before formatting the line itself.
+
+### The tap and the target
+
+Enabled lines emit at `info` under the single target `vantage_diorama::debug`
+— visible in a default log with no `RUST_LOG` required. Every line carries
+`ds=<datasource>`; every line about a specific Dio also carries
+`dio=<master table name>`, so a multi-table session's stream can be grepped
+per table. A monotonic per-Dio counter (`req=N`) ties a dispatch line to its
+matching return or failed line — the correlator for a load whose response
+lands after other lines have interleaved.
+
+### The frozen message strings
+
+These strings and their field sets are a contract: a downstream BDD harness
+greps them. Changing one is a breaking change to that harness, not just a
+log-message rewording.
+
+| Message | Fields | Fires when |
+|---|---|---|
+| `"load dispatch"` | `req, dio, visible, effective, rows_to_fetch, already_cached, sort, search, force_load` | a viewport fetch is about to run |
+| `"load return"` | `req, dio, received, ms, cached_after` | that fetch returned `Ok` |
+| `"load failed"` | `req, dio, ms, error` | that fetch returned `Err` |
+| `"cache hit — viewport served locally"` | `dio, range, rows` | a viewport is fully cached; no fetch fires |
+| `"total"` | `dio, total, provenance` | the grand total changed; `provenance` ∈ `stated` \| `short-page` \| `horizon-extended` \| `hole-clamped` |
+| `"state"` | `dio, from, to, reason` | a `LoadState` transition (`Loading` / `Partial` / `Complete`) |
+| `"cache write"` | `dio, written, new, updated, cached_rows, known_total, cached_pct` | a load committed rows to the cache; only emitted when `written > 0` |
+| `"cache seed"` | `dio, mode, rows` | a scenery seeded its rows from the cache at open; `mode` ∈ `warm` \| `cold` |
+| `"columns"` | `dio, demanded, received_count, received_sample, undemanded_count, payload_bytes, rows` | the wide-data detector — what a chunk actually carried against what was demanded |
+| `"census: <kind> <verb>"` | `dio, table_sceneries, record_sceneries, servos, uptime_ms, cpu_ms, peak_rss_mb` | a consumer opened or closed; `kind` ∈ `table scenery` \| `record scenery` \| `servo`, `verb` ∈ `opened` \| `closed` |
+| `"list page dispatch"` | `req, dio, offset, limit, conditions, sort` | a two-pass list page is about to be fetched |
+| `"list page return"` | `req, rows, ms, index_len, complete` | that list page returned |
+| `"detail pass"` | `dio, requested, pending, already_complete` | a two-pass detail (augment) sweep queued its pending ids |
+| `"aggregate recompute"` | `aggregate, trigger, rows_in, rows_out, ms, unchanged` | a `vantage-diorama-aggregate` layer recomputed |
+
+`aggregate recompute`'s `trigger` is `initial`, `debounce-trailing`, `nudge`,
+`lagged`, or a `DioEvent` variant name (`RecordChanged`, `DatasetChanged`,
+…) Debug-formatted and trimmed to its variant name. A `derive()`'s first
+load emits two `initial` lines: an eager compute that seeds the derived
+Vista's schema before the engine loop even exists (`unchanged = false`),
+immediately followed by the engine's own seed pass reading that same output
+back (`unchanged = true`). Both are genuine recomputations — the second is
+what proves the engine's own loop agrees with the eager pass before anything
+has changed, not a duplicated log call.
+
+### Census
+
+`emit_census(kind, verb)` on `DioInner` fires on every table-scenery,
+record-scenery, and servo open/close (when the tap is enabled) with a
+`"census: <kind> <verb>"` message, the live counts of each consumer kind on
+that Dio, and a process snapshot (`uptime_ms`, `cpu_ms`, `peak_rss_mb`) via
+`process_stats()`. This is the resource-accounting evidence: how many
+consumers a Dio is carrying and what the process is paying, sampled at every
+boundary a consumer's lifetime crosses.
+
+### Exit summary
+
+`stats::debug_summary_lines()` renders the session's cache evidence as plain
+strings, in order:
+
+1. Header: `"— diorama session summary —"`.
+2. One ledger line per table that had a fetch, busiest first: fetch count,
+   repeat count, rows received, redundant rows, total and max fetch time.
+3. A `"live:"` line: dios, table sceneries, record sceneries, servos still
+   open.
+4. A `"process:"` line: uptime, CPU time, peak RSS.
+
+`stats::emit_debug_summary()` logs each line at `info` under
+`vantage_diorama::debug`, unconditionally — it does not check the tap,
+since the caller (typically a shutdown hook) decides when a summary is
+warranted regardless of whether per-line tracing was ever turned on for
+this session.
+
 ## File layout
 
 ```

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.11.0 — 2026-07-30
+
+**The official per-datasource debug stream.**
+
+`LensBuilder::debug_datasource(name)` turns on a curated, greppable log
+stream for one datasource at a time, under the single `vantage_diorama::debug`
+target at `info` — every line carries `ds=<name>`, every per-dio line also
+`dio=<master table name>`. Off is the default and off means nothing is
+emitted and nothing is paid for: every call site checks the tap before doing
+any work a line needs, not just before formatting it.
+
+- **Load lifecycle.** `"load dispatch"` / `"load return"` / `"load failed"`,
+  correlated by a per-dio `req=N`, report the requested and effective ranges,
+  what was already cached, and the sort/search in play. `"cache hit —
+  viewport served locally"` marks a viewport a fetch never touched.
+- **Cache evidence.** `"cache write"` reports new vs. updated rows and the
+  running cached percentage of the known total; `"cache seed"` reports
+  whether a scenery opened warm or cold. `"total"` reports the grand total
+  and where it came from — stated by the source, inferred from a short page,
+  extended past an inferred horizon, or clamped at a hole a source promised
+  but never delivered.
+- **`"state"`** reports every `LoadState` transition (`Loading` / `Partial` /
+  `Complete`) with the reason that drove it.
+- **`"columns"`** is the wide-data detector: what a chunk actually carried
+  against what was demanded, with a sample of the received field names and
+  the payload's encoded size.
+- **Census.** `"census: <kind> <verb>"` fires on every table-scenery,
+  record-scenery, and servo open/close, with the live counts of each on that
+  Dio and a process snapshot (uptime, CPU time, peak RSS).
+- **Two-pass.** `"list page dispatch"` / `"list page return"` cover the list
+  pass; `"detail pass"` reports what a detail sweep queued against what was
+  already complete.
+- **Exit summary.** `stats::debug_summary_lines()` / `emit_debug_summary()`
+  render the session's fetch ledger, live consumer counts, and process stats
+  as a final block — unconditional, independent of whether the tap was ever
+  turned on.
+
 ## 0.10.0 — 2026-07-28
 
 **A scenery reads its own shape, not its lens's offers**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -28,6 +28,9 @@ tokio = { version = "1", features = ["sync", "rt", "time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v7"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"
 # Diagnostic output in loader tests (`with_test_writer` + env filter).

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/debug.rs
+++ b/vantage-diorama/src/debug.rs
@@ -1,15 +1,57 @@
 //! The official per-datasource debug stream.
 //!
 //! A [`DebugTap`] is carried by every [`Lens`](crate::Lens) and reached from
-//! every task the lens spawns. When enabled (one datasource opted in via
-//! `debug: true`), curated events emit at `info` level under the single
-//! target `vantage_diorama::debug` — visible in a default log with no
-//! `RUST_LOG` required. When off, nothing is emitted and nothing is paid.
+//! every task the lens spawns. Enabled per datasource via
+//! [`LensBuilder::debug_datasource`](crate::lens::LensBuilder::debug_datasource),
+//! it emits at `info` level under the single target `vantage_diorama::debug`
+//! — visible in a default log with no `RUST_LOG` required. Every line carries
+//! `ds=<datasource>`; every per-dio line also carries `dio=<master table
+//! name>`. Off — the default — nothing is emitted and nothing is paid: every
+//! call site checks [`DebugTap::enabled`] before doing any work the line
+//! itself needs, not just before formatting it.
 //!
 //! This stream is the mechanism for demonstrating the cache's efficiency
 //! and its resilience to backend faults: every master round trip, every
 //! cache mutation, every consumer open/close (the *census*), every status
 //! transition — attributable, correlated (`req=N`), and greppable.
+//!
+//! # Frozen message strings
+//!
+//! These strings are a contract: downstream test harnesses grep them.
+//! Changing one is a breaking change to whatever greps it, on par with
+//! changing a public function's signature.
+//!
+//! | Message | Fields | Where |
+//! |---|---|---|
+//! | `"load dispatch"` | `req, dio, visible, effective, rows_to_fetch, already_cached, sort, search, force_load` | a viewport fetch is about to run |
+//! | `"load return"` | `req, dio, received, ms, cached_after` | that fetch came back `Ok` |
+//! | `"load failed"` | `req, dio, ms, error` | that fetch came back `Err` |
+//! | `"cache hit — viewport served locally"` | `dio, range, rows` | a viewport is fully cached; no fetch fires |
+//! | `"total"` | `dio, total, provenance` | the grand total changed; `provenance` ∈ `stated` / `short-page` / `horizon-extended` / `hole-clamped` |
+//! | `"state"` | `dio, from, to, reason` | a [`LoadState`](crate::scenery::LoadState) transition |
+//! | `"cache write"` | `dio, written, new, updated, cached_rows, known_total, cached_pct` | a load committed rows to the cache; only emitted when `written > 0` |
+//! | `"cache seed"` | `dio, mode, rows` | a scenery seeded its rows from the cache at open; `mode` ∈ `warm` / `cold` |
+//! | `"columns"` | `dio, demanded, received_count, received_sample, undemanded_count, payload_bytes, rows` | the wide-data detector — what a chunk actually carried against what was asked for |
+//! | `"census: {kind} {verb}"` | `dio, table_sceneries, record_sceneries, servos, uptime_ms, cpu_ms, peak_rss_mb` | a consumer opened or closed; `kind` ∈ `table scenery` / `record scenery` / `servo`, `verb` ∈ `opened` / `closed` |
+//! | `"list page dispatch"` | `req, dio, offset, limit, conditions, sort` | a two-pass list page is about to be fetched |
+//! | `"list page return"` | `req, rows, ms, index_len, complete` | that list page came back |
+//! | `"detail pass"` | `dio, requested, pending, already_complete` | a two-pass detail (augment) sweep queued its pending ids |
+//! | `"aggregate recompute"` | `aggregate, trigger, rows_in, rows_out, ms, unchanged` | a `vantage-diorama-aggregate` layer recomputed; `trigger` ∈ `initial` / `debounce-trailing` / `nudge` / `lagged` / a `DioEvent` variant name |
+//! | `"— diorama session summary —"` | (header, no fields) | first line of [`stats::debug_summary_lines`](crate::stats::debug_summary_lines) / [`stats::emit_debug_summary`](crate::stats::emit_debug_summary) |
+//!
+//! A `derive()`'s first load emits two `"aggregate recompute"` lines with
+//! `trigger = "initial"`: an eager compute that seeds the derived Vista's
+//! schema (`unchanged = false`, since there is no prior output to compare
+//! against), immediately followed by the engine's own seed pass over the
+//! same rows (`unchanged = true`, since it reads the value the eager pass
+//! just published). Both are real recomputations, not a duplicate log call —
+//! the second is what proves the engine's own loop agrees with the eager
+//! pass before anything has changed.
+//!
+//! `req=N` is a per-dio, monotonically increasing counter
+//! ([`DioInner::next_req`](crate::dio::DioInner::next_req)) that ties a
+//! dispatch line to its matching return/failed line — only allocated when
+//! the tap is enabled.
 
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -128,7 +170,10 @@ mod tests {
         let s = process_stats();
         #[cfg(unix)]
         {
-            assert!(s.peak_rss_bytes > 0, "peak RSS should be measurable on unix");
+            assert!(
+                s.peak_rss_bytes > 0,
+                "peak RSS should be measurable on unix"
+            );
             assert!(s.cpu_ms > 0, "cpu time should be nonzero after busy loop");
         }
         let _ = s.uptime_ms; // monotonic, may be 0 in a fast test — presence is enough

--- a/vantage-diorama/src/debug.rs
+++ b/vantage-diorama/src/debug.rs
@@ -49,9 +49,8 @@
 //! pass before anything has changed.
 //!
 //! `req=N` is a per-dio, monotonically increasing counter
-//! ([`DioInner::next_req`](crate::dio::DioInner::next_req)) that ties a
-//! dispatch line to its matching return/failed line — only allocated when
-//! the tap is enabled.
+//! (`DioInner::next_req`) that ties a dispatch line to its matching
+//! return/failed line — only allocated when the tap is enabled.
 
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -93,7 +92,6 @@ impl DebugTap {
 ///
 /// `tapline!(tap, field = value, ..., "message")` — the target and the
 /// `ds` field are supplied here so call sites can't drift.
-#[allow(unused_macros)]
 macro_rules! tapline {
     ($tap:expr, $($rest:tt)*) => {
         if $tap.enabled() {
@@ -101,7 +99,6 @@ macro_rules! tapline {
         }
     };
 }
-#[allow(unused_imports)]
 pub(crate) use tapline;
 
 /// Wall/CPU/memory snapshot for census lines and the exit summary.

--- a/vantage-diorama/src/debug.rs
+++ b/vantage-diorama/src/debug.rs
@@ -1,0 +1,136 @@
+//! The official per-datasource debug stream.
+//!
+//! A [`DebugTap`] is carried by every [`Lens`](crate::Lens) and reached from
+//! every task the lens spawns. When enabled (one datasource opted in via
+//! `debug: true`), curated events emit at `info` level under the single
+//! target `vantage_diorama::debug` — visible in a default log with no
+//! `RUST_LOG` required. When off, nothing is emitted and nothing is paid.
+//!
+//! This stream is the mechanism for demonstrating the cache's efficiency
+//! and its resilience to backend faults: every master round trip, every
+//! cache mutation, every consumer open/close (the *census*), every status
+//! transition — attributable, correlated (`req=N`), and greppable.
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::time::Instant;
+
+/// Per-datasource debug switch. Cheap to clone, cheap to check.
+#[derive(Debug, Clone, Default)]
+pub struct DebugTap {
+    /// `Some(name)` = enabled for that datasource; `None` = off.
+    ds: Option<Arc<str>>,
+}
+
+impl DebugTap {
+    /// The disabled tap — the default for every Lens.
+    pub fn off() -> Self {
+        Self { ds: None }
+    }
+
+    /// An enabled tap tagged with the datasource's name; every emitted
+    /// line carries it as `ds=<name>`.
+    pub fn for_datasource(name: impl Into<String>) -> Self {
+        Self {
+            ds: Some(Arc::from(name.into())),
+        }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.ds.is_some()
+    }
+
+    /// The datasource name, or `""` when the tap is off. Only meaningful
+    /// inside a `tapline!` (which never fires when off).
+    pub fn ds(&self) -> &str {
+        self.ds.as_deref().unwrap_or("")
+    }
+}
+
+/// Emit one debug-stream line, only when the tap is enabled.
+///
+/// `tapline!(tap, field = value, ..., "message")` — the target and the
+/// `ds` field are supplied here so call sites can't drift.
+#[allow(unused_macros)]
+macro_rules! tapline {
+    ($tap:expr, $($rest:tt)*) => {
+        if $tap.enabled() {
+            tracing::info!(target: "vantage_diorama::debug", ds = %$tap.ds(), $($rest)*);
+        }
+    };
+}
+#[allow(unused_imports)]
+pub(crate) use tapline;
+
+/// Wall/CPU/memory snapshot for census lines and the exit summary.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProcessStats {
+    /// Milliseconds since the first `process_stats()` call in this process.
+    pub uptime_ms: u64,
+    /// User + system CPU time consumed by the process, in milliseconds.
+    pub cpu_ms: u64,
+    /// Peak resident set size, in bytes. 0 where unsupported.
+    pub peak_rss_bytes: u64,
+}
+
+static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// Snapshot process wall-clock, CPU time, and peak RSS.
+///
+/// Unix only (`getrusage`); other platforms report uptime and zeros.
+pub fn process_stats() -> ProcessStats {
+    let uptime_ms = PROCESS_START.elapsed().as_millis() as u64;
+    #[cfg(unix)]
+    {
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        if unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) } == 0 {
+            let tv_ms = |tv: libc::timeval| tv.tv_sec as u64 * 1000 + tv.tv_usec as u64 / 1000;
+            // ru_maxrss is bytes on macOS, kilobytes on Linux.
+            #[cfg(target_os = "macos")]
+            let peak = usage.ru_maxrss as u64;
+            #[cfg(not(target_os = "macos"))]
+            let peak = usage.ru_maxrss as u64 * 1024;
+            return ProcessStats {
+                uptime_ms,
+                cpu_ms: tv_ms(usage.ru_utime) + tv_ms(usage.ru_stime),
+                peak_rss_bytes: peak,
+            };
+        }
+    }
+    ProcessStats {
+        uptime_ms,
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tap_is_off_by_default_and_carries_the_datasource_name() {
+        let off = DebugTap::default();
+        assert!(!off.enabled());
+        assert_eq!(off.ds(), "");
+        let on = DebugTap::for_datasource("librarian");
+        assert!(on.enabled());
+        assert_eq!(on.ds(), "librarian");
+    }
+
+    #[test]
+    fn process_stats_reports_nonzero_cpu_and_rss() {
+        // Burn a little CPU so utime is measurable.
+        let mut x = 0u64;
+        for i in 0..5_000_000u64 {
+            x = x.wrapping_add(i);
+        }
+        std::hint::black_box(x);
+        let s = process_stats();
+        #[cfg(unix)]
+        {
+            assert!(s.peak_rss_bytes > 0, "peak RSS should be measurable on unix");
+            assert!(s.cpu_ms > 0, "cpu time should be nonzero after busy loop");
+        }
+        let _ = s.uptime_ms; // monotonic, may be 0 in a fast test — presence is enough
+    }
+}

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -244,6 +244,42 @@ impl DioInner {
         self.req_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Prune dead entries from the table-scenery dedup registry and return
+    /// how many are left. Shared by [`Dio::live_table_scenery_count`] (the
+    /// public diagnostics window) and [`Self::emit_census`] (the debug
+    /// stream), so there is exactly one pruning pass to keep in sync.
+    pub(crate) fn live_table_scenery_count(&self) -> usize {
+        let mut guard = self.table_sceneries.lock().unwrap();
+        guard.retain(|_, weak| weak.strong_count() > 0);
+        guard.len()
+    }
+
+    /// One census line: who is consuming this Dio right now, and what the
+    /// process costs. Emitted on every consumer open/close when the tap is
+    /// enabled. Returns before any work when it isn't — the off-path must
+    /// stay byte-identical to a build without this stream.
+    pub(crate) fn emit_census(&self, kind: &'static str, verb: &'static str) {
+        let tap = self.tap();
+        if !tap.enabled() {
+            return;
+        }
+        let table_sceneries = self.live_table_scenery_count();
+        let record_sceneries = self.record_census.load(std::sync::atomic::Ordering::Relaxed);
+        let servos = self.servo_census.load(std::sync::atomic::Ordering::Relaxed);
+        let p = crate::debug::process_stats();
+        crate::debug::tapline!(
+            tap,
+            dio = self.master.read().unwrap().name(),
+            table_sceneries,
+            record_sceneries,
+            servos,
+            uptime_ms = p.uptime_ms,
+            cpu_ms = p.cpu_ms,
+            peak_rss_mb = p.peak_rss_bytes / (1024 * 1024),
+            "census: {kind} {verb}",
+        );
+    }
+
     /// See [`Dio::write_capabilities`]. Lives on the inner so
     /// [`DioShell`] can share the one definition of capability lifting.
     pub(crate) fn write_capabilities(&self) -> WriteCapabilities {
@@ -565,9 +601,7 @@ impl Dio {
     /// handle is released the count drops back, proving no leak. A read-only
     /// window onto the dedup registry — the seed for the diagnostics surface.
     pub fn live_table_scenery_count(&self) -> usize {
-        let mut guard = self.inner.table_sceneries.lock().unwrap();
-        guard.retain(|_, weak| weak.strong_count() > 0);
-        guard.len()
+        self.inner.live_table_scenery_count()
     }
 
     /// Open a reactive view onto a single record by id. Reads the

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -213,6 +213,14 @@ pub(crate) struct DioInner {
     /// rows land. Set to true at construction when there is nothing to wait
     /// for: no `on_start`, or a blocking one that has already run.
     pub(crate) seed_complete: std::sync::atomic::AtomicBool,
+
+    /// Monotonic per-dio request id for correlating debug-stream
+    /// dispatch/return lines (`req=N`).
+    pub(crate) req_seq: std::sync::atomic::AtomicU64,
+    /// Live servos opened on this Dio — census bookkeeping only.
+    pub(crate) servo_census: std::sync::atomic::AtomicUsize,
+    /// Live record sceneries opened on this Dio — census bookkeeping only.
+    pub(crate) record_census: std::sync::atomic::AtomicUsize,
 }
 
 impl Drop for DioInner {
@@ -224,6 +232,18 @@ impl Drop for DioInner {
 }
 
 impl DioInner {
+    /// The debug tap this Dio's Lens carries — the source of truth every
+    /// `tapline!` call site reaches through.
+    pub(crate) fn tap(&self) -> &crate::debug::DebugTap {
+        &self.lens.debug
+    }
+
+    /// Next value in this Dio's request sequence — stamped as `req=N` to
+    /// correlate a dispatch line with its return line in the debug stream.
+    pub(crate) fn next_req(&self) -> u64 {
+        self.req_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// See [`Dio::write_capabilities`]. Lives on the inner so
     /// [`DioShell`] can share the one definition of capability lifting.
     pub(crate) fn write_capabilities(&self) -> WriteCapabilities {
@@ -359,6 +379,12 @@ impl Dio {
     /// awaits even while a concurrent [`reload`](Self::reload) swaps it.
     pub fn master(&self) -> Arc<Vista> {
         self.inner.master.read().unwrap().clone()
+    }
+
+    /// The debug tap this Dio inherited from its Lens. Enabled when the
+    /// datasource opted into the `vantage_diorama::debug` stream.
+    pub fn debug_tap(&self) -> crate::debug::DebugTap {
+        self.inner.lens.debug.clone()
     }
 
     /// Traverse a reference and return a NEW [`Dio`] bound to the traversed

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -241,7 +241,8 @@ impl DioInner {
     /// Next value in this Dio's request sequence — stamped as `req=N` to
     /// correlate a dispatch line with its return line in the debug stream.
     pub(crate) fn next_req(&self) -> u64 {
-        self.req_seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        self.req_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Prune dead entries from the table-scenery dedup registry and return
@@ -264,7 +265,9 @@ impl DioInner {
             return;
         }
         let table_sceneries = self.live_table_scenery_count();
-        let record_sceneries = self.record_census.load(std::sync::atomic::Ordering::Relaxed);
+        let record_sceneries = self
+            .record_census
+            .load(std::sync::atomic::Ordering::Relaxed);
         let servos = self.servo_census.load(std::sync::atomic::Ordering::Relaxed);
         let p = crate::debug::process_stats();
         crate::debug::tapline!(

--- a/vantage-diorama/src/lens/build.rs
+++ b/vantage-diorama/src/lens/build.rs
@@ -40,6 +40,7 @@ impl LensBuilder {
             defaults: self.defaults,
             runtime,
             activity: self.activity,
+            debug: self.debug,
         })
     }
 }

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -108,18 +108,14 @@ impl ChunkSink {
         Ok(())
     }
 
-    /// Commit everything pushed so far, in one write.
+    /// Commit everything pushed so far, in one write, and report a
+    /// [`FlushReport`] of how many rows were written and — tap permitting —
+    /// the cache's row count before and after, the numbers behind the
+    /// "cache write" debug line.
     ///
     /// Called by the loader once `on_load_chunk` returns — and it must run
     /// before anything reads the cache back (the post-load re-sort rebuilds the
     /// visible map from it), or the load appears to have fetched nothing.
-    pub(crate) async fn flush(&self) -> Result<()> {
-        self.flush_counted().await.map(|_| ())
-    }
-
-    /// [`flush`](Self::flush), plus a [`FlushReport`] of how many rows were
-    /// written and — tap permitting — the cache's row count before and after,
-    /// the numbers behind the "cache write" debug line.
     ///
     /// The before/after counts are skipped (and reported as `0`) unless
     /// `self.debug` is set: they exist only for that debug line, so with the
@@ -192,7 +188,7 @@ fn wide_data_signals<'a>(
     (columns.into_iter().collect(), payload_bytes)
 }
 
-/// The result of [`ChunkSink::flush_counted`] — how many rows a chunk write
+/// The result of `ChunkSink::flush_counted` — how many rows a chunk write
 /// committed, and (tap permitting) the cache's row count before and after,
 /// plus the wide-data signal: the field-name union across the batch and its
 /// total encoded size. Source for the "cache write" debug line's

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -45,6 +45,14 @@ pub struct ChunkSink {
     /// is also what lets a whole datasource share one store without each
     /// table's load queueing behind another's.
     pub(crate) buffer: BufferedRows,
+    /// The owning Dio's debug tap state, captured at construction.
+    ///
+    /// `flush_counted` reads this to decide whether the extra before/after
+    /// `count()` calls it does purely to report the "cache write" debug line
+    /// are worth paying for. With the tap off, nothing reads that report, so
+    /// the counts would be pure overhead — the one thing the debug stream is
+    /// not allowed to cost a datasource that never opted in.
+    pub(crate) debug: bool,
 }
 
 impl std::fmt::Debug for ChunkSink {
@@ -106,17 +114,54 @@ impl ChunkSink {
     /// before anything reads the cache back (the post-load re-sort rebuilds the
     /// visible map from it), or the load appears to have fetched nothing.
     pub(crate) async fn flush(&self) -> Result<()> {
+        self.flush_counted().await.map(|_| ())
+    }
+
+    /// [`flush`](Self::flush), plus a [`FlushReport`] of how many rows were
+    /// written and — tap permitting — the cache's row count before and after,
+    /// the numbers behind the "cache write" debug line.
+    ///
+    /// The before/after counts are skipped (and reported as `0`) unless
+    /// `self.debug` is set: they exist only for that debug line, so with the
+    /// tap off they'd be pure overhead nothing observes.
+    pub(crate) async fn flush_counted(&self) -> Result<FlushReport> {
         let rows: indexmap::IndexMap<String, Record<CborValue>> = {
             let Ok(mut buffer) = self.buffer.lock() else {
-                return Ok(());
+                return Ok(FlushReport::default());
             };
             std::mem::take(&mut *buffer).into_iter().collect()
         };
         if rows.is_empty() {
-            return Ok(());
+            return Ok(FlushReport::default());
         }
-        self.cache.insert_values(rows).await
+        let written = rows.len();
+        if !self.debug {
+            self.cache.insert_values(rows).await?;
+            return Ok(FlushReport {
+                written,
+                ..Default::default()
+            });
+        }
+        let cache_rows_before = self.cache.count().await?;
+        self.cache.insert_values(rows).await?;
+        let cache_rows_after = self.cache.count().await?;
+        Ok(FlushReport {
+            written,
+            cache_rows_before,
+            cache_rows_after,
+        })
     }
+}
+
+/// The result of [`ChunkSink::flush_counted`] — how many rows a chunk write
+/// committed, and (tap permitting) the cache's row count before and after.
+/// Source for the "cache write" debug line's `written`/`new`/`updated`/
+/// `cached_rows` fields.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FlushReport {
+    pub written: usize,
+    pub cache_rows_before: i64,
+    pub cache_rows_after: i64,
 }
 
 /// One row's worth of payload — exposed publicly for callers that

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -164,18 +164,21 @@ impl ChunkSink {
 /// Field-name union (insertion order, deduped) and total ciborium-encoded
 /// size across a batch of buffered records — the raw material for the
 /// "columns" debug line's `received_count`/`received_sample`/`payload_bytes`.
-/// Dedup is by linear scan, which is fine: it's bounded by the record's own
-/// column count, not by row count.
+/// Dedup goes through an `IndexSet` (O(1) membership, insertion order
+/// preserved on iteration) rather than a `Vec` scanned with `contains`: a
+/// full page of wide rows is exactly rows × columns, and a linear scan per
+/// key would make that quadratic in the columns — the one case this line
+/// exists to make visible.
 fn wide_data_signals<'a>(
     records: impl Iterator<Item = &'a Record<CborValue>>,
 ) -> (Vec<String>, usize) {
-    let mut columns: Vec<String> = Vec::new();
+    let mut columns: indexmap::IndexSet<String> = indexmap::IndexSet::new();
     let mut payload_bytes = 0usize;
     for record in records {
         for key in record.keys() {
-            if !columns.iter().any(|c| c == key) {
-                columns.push(key.clone());
-            }
+            // `insert` is a no-op (and doesn't reorder) when the key is
+            // already present, so no separate `contains` check is needed.
+            columns.insert(key.clone());
         }
         let map: Vec<(CborValue, CborValue)> = record
             .iter()
@@ -186,7 +189,7 @@ fn wide_data_signals<'a>(
             payload_bytes += buf.len();
         }
     }
-    (columns, payload_bytes)
+    (columns.into_iter().collect(), payload_bytes)
 }
 
 /// The result of [`ChunkSink::flush_counted`] — how many rows a chunk write

--- a/vantage-diorama/src/lens/chunk_sink.rs
+++ b/vantage-diorama/src/lens/chunk_sink.rs
@@ -142,6 +142,12 @@ impl ChunkSink {
                 ..Default::default()
             });
         }
+        // The wide-data signal for the "columns" debug line: the union of
+        // field names across this chunk and the total CBOR-encoded size.
+        // Computed here (buffer already collected, one pass) rather than
+        // per-`push`, and only reached because `self.debug` is set — a sink
+        // built with the tap off never pays for the encoding.
+        let (columns_received, payload_bytes) = wide_data_signals(rows.values());
         let cache_rows_before = self.cache.count().await?;
         self.cache.insert_values(rows).await?;
         let cache_rows_after = self.cache.count().await?;
@@ -149,19 +155,57 @@ impl ChunkSink {
             written,
             cache_rows_before,
             cache_rows_after,
+            columns_received,
+            payload_bytes,
         })
     }
 }
 
+/// Field-name union (insertion order, deduped) and total ciborium-encoded
+/// size across a batch of buffered records — the raw material for the
+/// "columns" debug line's `received_count`/`received_sample`/`payload_bytes`.
+/// Dedup is by linear scan, which is fine: it's bounded by the record's own
+/// column count, not by row count.
+fn wide_data_signals<'a>(
+    records: impl Iterator<Item = &'a Record<CborValue>>,
+) -> (Vec<String>, usize) {
+    let mut columns: Vec<String> = Vec::new();
+    let mut payload_bytes = 0usize;
+    for record in records {
+        for key in record.keys() {
+            if !columns.iter().any(|c| c == key) {
+                columns.push(key.clone());
+            }
+        }
+        let map: Vec<(CborValue, CborValue)> = record
+            .iter()
+            .map(|(k, v)| (CborValue::Text(k.clone()), v.clone()))
+            .collect();
+        let mut buf = Vec::new();
+        if ciborium::into_writer(&CborValue::Map(map), &mut buf).is_ok() {
+            payload_bytes += buf.len();
+        }
+    }
+    (columns, payload_bytes)
+}
+
 /// The result of [`ChunkSink::flush_counted`] — how many rows a chunk write
-/// committed, and (tap permitting) the cache's row count before and after.
-/// Source for the "cache write" debug line's `written`/`new`/`updated`/
-/// `cached_rows` fields.
-#[derive(Debug, Clone, Copy, Default)]
+/// committed, and (tap permitting) the cache's row count before and after,
+/// plus the wide-data signal: the field-name union across the batch and its
+/// total encoded size. Source for the "cache write" debug line's
+/// `written`/`new`/`updated`/`cached_rows` fields and the "columns" line's
+/// `received_count`/`received_sample`/`payload_bytes`.
+///
+/// `columns_received` and `payload_bytes` are empty/`0` unless the sink's
+/// tap is on — they exist only for the "columns" line, so with the tap off
+/// they'd be pure overhead nothing observes.
+#[derive(Debug, Clone, Default)]
 pub struct FlushReport {
     pub written: usize,
     pub cache_rows_before: i64,
     pub cache_rows_after: i64,
+    pub columns_received: Vec<String>,
+    pub payload_bytes: usize,
 }
 
 /// One row's worth of payload — exposed publicly for callers that

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -65,6 +65,9 @@ impl Lens {
             // Nothing to wait for unless a detached `on_start` is about to be
             // spawned below; that branch clears it before spawning.
             seed_complete: std::sync::atomic::AtomicBool::new(true),
+            req_seq: std::sync::atomic::AtomicU64::new(0),
+            servo_census: std::sync::atomic::AtomicUsize::new(0),
+            record_census: std::sync::atomic::AtomicUsize::new(0),
         });
         let dio = Dio { inner };
 

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -24,11 +24,11 @@ use crate::ops::{ChangeEvent, ChangeFlash, QueryDescriptor};
 pub use activity::{Activity, ActivitySignal};
 pub use cache_backend::{CacheBackend, CacheStatus, CacheTable};
 pub use callbacks::{
-    ChunkQuery,
-    DioCallback, DioEventCallback, DioFlashCallback, DioListPageCallback, DioLoadChunkCallback,
-    DioLoadDetailCallback, DioTotalProviderCallback, LensCallbacks, boxed_dio_callback,
-    boxed_dio_event_callback, boxed_dio_flash_callback, boxed_list_page_callback,
-    boxed_load_chunk_callback, boxed_load_detail_callback, boxed_total_provider_callback,
+    ChunkQuery, DioCallback, DioEventCallback, DioFlashCallback, DioListPageCallback,
+    DioLoadChunkCallback, DioLoadDetailCallback, DioTotalProviderCallback, LensCallbacks,
+    boxed_dio_callback, boxed_dio_event_callback, boxed_dio_flash_callback,
+    boxed_list_page_callback, boxed_load_chunk_callback, boxed_load_detail_callback,
+    boxed_total_provider_callback,
 };
 pub use chunk_sink::{ChunkRow, ChunkSink, SceneryChunkTarget};
 pub use defaults::LensDefaults;

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -47,6 +47,9 @@ pub struct Lens {
     /// App-activity signal driving adaptive refresh cadence. Shared with the UI
     /// (cloned), so flipping it re-paces every Dio's refresh loop at once.
     pub(crate) activity: ActivitySignal,
+    /// The official debug stream's tap. Off by default; see
+    /// [`debug_datasource`](LensBuilder::debug_datasource).
+    pub(crate) debug: crate::debug::DebugTap,
 }
 
 impl Lens {
@@ -92,6 +95,7 @@ pub struct LensBuilder {
     pub(crate) defaults: LensDefaults,
     pub(crate) runtime: Option<Handle>,
     pub(crate) activity: ActivitySignal,
+    pub(crate) debug: crate::debug::DebugTap,
 }
 
 impl Default for LensBuilder {
@@ -116,6 +120,7 @@ impl LensBuilder {
             defaults: LensDefaults::default(),
             runtime: None,
             activity: ActivitySignal::new(),
+            debug: crate::debug::DebugTap::off(),
         }
     }
 
@@ -324,6 +329,15 @@ impl LensBuilder {
     /// views demanding rows; raise for parallel hydration.
     pub fn augment_workers(mut self, workers: usize) -> Self {
         self.defaults.augment_workers = workers;
+        self
+    }
+
+    /// Enable the official debug stream for every Dio this Lens produces.
+    /// `name` is the datasource name stamped as `ds=` on every line of the
+    /// `vantage_diorama::debug` target. Off by default; when off, the
+    /// stream emits nothing.
+    pub fn debug_datasource(mut self, name: impl Into<String>) -> Self {
+        self.debug = crate::debug::DebugTap::for_datasource(name);
         self
     }
 

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod augment;
 pub mod composition;
+pub mod debug;
 pub mod dio;
 pub mod error;
 pub mod lens;
@@ -14,6 +15,7 @@ pub mod stats;
 
 pub use augment::{Augmentation, BuildFn, Detail, Fetch, FetchFn, MergeRule, Source};
 pub use composition::Diorama;
+pub use debug::{DebugTap, ProcessStats, process_stats};
 pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
 pub use dio::{Dio, DioEvent, DioShell, Generation, WeakDio, WriteCapabilities};
 pub use error::{DioError, LensBuildError};

--- a/vantage-diorama/src/scenery/record.rs
+++ b/vantage-diorama/src/scenery/record.rs
@@ -186,11 +186,18 @@ pub(crate) struct RecordSceneryImpl {
 
 struct RecordSceneryGuard {
     task: tokio::task::JoinHandle<()>,
+    /// Weak — the guard must not keep the Dio alive; it only reaches back
+    /// in to decrement the census and emit the closing line.
+    dio_weak: Weak<DioInner>,
 }
 
 impl Drop for RecordSceneryGuard {
     fn drop(&mut self) {
         self.task.abort();
+        if let Some(dio) = self.dio_weak.upgrade() {
+            dio.record_census.fetch_sub(1, Ordering::Relaxed);
+            dio.emit_census("record scenery", "closed");
+        }
     }
 }
 
@@ -248,8 +255,14 @@ pub(crate) fn spawn_record_scenery(
         reload_loop(task_state, bus_rx).await;
     });
 
+    dio.record_census.fetch_add(1, Ordering::Relaxed);
+    dio.emit_census("record scenery", "opened");
+
     Arc::new(RecordSceneryImpl {
         inner: state,
-        _guard: RecordSceneryGuard { task },
+        _guard: RecordSceneryGuard {
+            task,
+            dio_weak: Arc::downgrade(dio),
+        },
     }) as Arc<dyn RecordScenery>
 }

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -287,6 +287,9 @@ impl TableSceneryBuilder {
             registry_key: Mutex::new(Some(key.clone())),
             augment_ticket,
             list_in_flight: Mutex::new(false),
+            debug_tap: dio.tap().clone(),
+            dio_name: dio.master.read().unwrap().name().to_string(),
+            last_debug_state: Mutex::new(None),
         });
 
         // 1. total_provider runs once per open, result cached.

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -515,16 +515,19 @@ impl TableSceneryBuilder {
         }
 
         let scenery: Arc<dyn TableScenery> = Arc::new(TableSceneryImpl {
-            inner: state,
             _guard: SceneryGuard {
                 tasks: vec![reactor_handle, viewport_handle],
+                dio_weak: state.dio_weak.clone(),
             },
+            inner: state,
         });
 
         // Publish to the dedup registry. If a concurrent open won the race for
         // this key, `register_table_scenery` returns the winner and our
         // `scenery` drops here — its guard aborts the redundant tasks.
-        Ok(dio.register_table_scenery(key, scenery))
+        let scenery = dio.register_table_scenery(key, scenery);
+        dio.emit_census("table scenery", "opened");
+        Ok(scenery)
     }
 }
 

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -416,12 +416,26 @@ impl TableSceneryBuilder {
                     cached_rows,
                     "warm cache seeded the paged view; refresh-on-open replaces it silently",
                 );
+                crate::debug::tapline!(
+                    state.debug_tap,
+                    dio = table.as_str(),
+                    mode = "warm",
+                    rows = cached_rows,
+                    "cache seed",
+                );
             } else {
                 tracing::debug!(
                     target: "vantage_diorama::cache",
                     table = %table,
                     cached_rows,
                     "cache empty — paged view opens loading; the on-open fetch is authoritative",
+                );
+                crate::debug::tapline!(
+                    state.debug_tap,
+                    dio = table.as_str(),
+                    mode = "cold",
+                    rows = cached_rows,
+                    "cache seed",
                 );
             }
             state.bump_generation();
@@ -437,11 +451,19 @@ impl TableSceneryBuilder {
             if state.paged {
                 restore_meta_total(&state, &dio).await;
             }
+            let seeded_rows = state.rows.read().unwrap().len();
             tracing::debug!(
                 target: "vantage_diorama::cache",
                 table = %dio.master.read().unwrap().name(),
-                seeded_rows = state.rows.read().unwrap().len(),
+                seeded_rows,
                 "cache seeded the visible map",
+            );
+            crate::debug::tapline!(
+                state.debug_tap,
+                dio = dio.master.read().unwrap().name(),
+                mode = if seeded_rows > 0 { "warm" } else { "cold" },
+                rows = seeded_rows,
+                "cache seed",
             );
             // The cache IS the row set for this shape, so a seed that found
             // rows IS the answer. A seed that found none is not: a cold cache

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -429,7 +429,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             // short-circuits before counting, so `cache_rows_after` would read
             // `0` — not the cache's real size, just "not measured" — and a
             // "cache write" line for zero rows written is not a write at all.
-            if let Some(report) = flush_report
+            if let Some(report) = &flush_report
                 && report.written > 0
             {
                 crate::debug::tapline!(
@@ -481,6 +481,51 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 cached_after,
                 "load return",
             );
+            // The wide-data detector: how many distinct fields this chunk
+            // carried against how many the open sceneries actually asked
+            // for, and the encoded weight of the page. `demanded_columns`
+            // does a live scan of the table sceneries, so it's only worth
+            // paying for when the tap is on — same reasoning as gating the
+            // encoding itself in `ChunkSink::flush_counted`.
+            if tap.enabled() {
+                let demanded = dio_inner.demanded_columns();
+                let received: &[String] = flush_report
+                    .as_ref()
+                    .map(|r| r.columns_received.as_slice())
+                    .unwrap_or(&[]);
+                let payload_bytes = flush_report.as_ref().map(|r| r.payload_bytes).unwrap_or(0);
+                let received_count = received.len();
+                const SAMPLE: usize = 8;
+                let received_sample = if received_count > SAMPLE {
+                    format!(
+                        "{}+{} more",
+                        received[..SAMPLE].join(","),
+                        received_count - SAMPLE
+                    )
+                } else {
+                    received.join(",")
+                };
+                let (demanded_str, undemanded_count) = match &demanded {
+                    None => ("all".to_string(), 0),
+                    Some(set) => {
+                        let mut names: Vec<&str> = set.iter().map(String::as_str).collect();
+                        names.sort_unstable();
+                        let undemanded = received.iter().filter(|c| !set.contains(*c)).count();
+                        (names.join(","), undemanded)
+                    }
+                };
+                crate::debug::tapline!(
+                    tap,
+                    dio = dio_inner.master.read().unwrap().name(),
+                    demanded = demanded_str,
+                    received_count,
+                    received_sample,
+                    undemanded_count,
+                    payload_bytes,
+                    rows = pushed,
+                    "columns",
+                );
+            }
             // Where the grand total came from. A total the source stated in the
             // same response as the rows (`ChunkSink::set_total`) outranks
             // anything inferred here: a short page can equally mean "the source

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -437,9 +437,9 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     dio = dio_inner.master.read().unwrap().name(),
                     written = report.written,
                     new = (report.cache_rows_after - report.cache_rows_before) as usize,
-                    updated = report
-                        .written
-                        .saturating_sub((report.cache_rows_after - report.cache_rows_before) as usize),
+                    updated = report.written.saturating_sub(
+                        (report.cache_rows_after - report.cache_rows_before) as usize
+                    ),
                     cached_rows = report.cache_rows_after,
                     known_total = state.total.read().unwrap().unwrap_or(0),
                     cached_pct = match state.total.read().unwrap().unwrap_or(0) {
@@ -592,7 +592,10 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 // Single-pass paged mode only: a two-pass view's list pass
                 // enumerated the whole set — its size is knowledge, not an
                 // inference to extend.
-                if !state.two_pass && effective_len > 0 && horizon_reached && !state.total_ever_stated()
+                if !state.two_pass
+                    && effective_len > 0
+                    && horizon_reached
+                    && !state.total_ever_stated()
                 {
                     let extended = effective_range.end + effective_len;
                     tracing::debug!(

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -436,6 +436,10 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     tap,
                     dio = dio_inner.master.read().unwrap().name(),
                     written = report.written,
+                    // A concurrent flush from another in-flight load between the
+                    // before/after `count()` calls could in principle make this
+                    // go negative and underflow; accepted here since it's a
+                    // debug-only line, not a value anything downstream trusts.
                     new = (report.cache_rows_after - report.cache_rows_before) as usize,
                     updated = report.written.saturating_sub(
                         (report.cache_rows_after - report.cache_rows_before) as usize
@@ -498,7 +502,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 const SAMPLE: usize = 8;
                 let received_sample = if received_count > SAMPLE {
                     format!(
-                        "{}+{} more",
+                        "{} +{} more",
                         received[..SAMPLE].join(","),
                         received_count - SAMPLE
                     )

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -330,6 +330,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         cache: dio_inner.cache.clone(),
         pending: dio_inner.pending_flashes.clone(),
         buffer: Default::default(),
+        debug: tap.enabled(),
     };
     // The sink is moved into the callback; keep a clone so the buffered rows
     // can be committed once it returns.
@@ -399,15 +400,55 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     // failed commit fails the load: the rows are bound in the visible map but
     // absent from the cache, and the next re-sort would rebuild the map without
     // them — better to report the load failed than to silently lose the page.
-    if result.is_ok() {
-        result = writer.flush().await;
-    }
+    // `flush_counted` also carries the before/after cache row counts the
+    // "cache write" debug line reports — free of extra cost when the tap is
+    // off, since the sink itself skips the counting in that case.
+    let flush_report = if result.is_ok() {
+        match writer.flush_counted().await {
+            Ok(report) => Some(report),
+            Err(e) => {
+                result = Err(e);
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     *state.load_in_flight.lock().unwrap() = None;
 
     let cached_after = state.rows.read().unwrap().len();
     match result {
         Ok(()) => {
+            // The counterpart of "load return": what the flush just committed,
+            // split into rows that were genuinely new vs. rows that already had
+            // a cached value and got overwritten, plus how much of the known
+            // total is now cached. `flush_report` is always `Some` here — flush
+            // only fails when `result` does, which routes to the `Err` arm.
+            // Nothing to report when the page came back empty: `flush_counted`
+            // short-circuits before counting, so `cache_rows_after` would read
+            // `0` — not the cache's real size, just "not measured" — and a
+            // "cache write" line for zero rows written is not a write at all.
+            if let Some(report) = flush_report
+                && report.written > 0
+            {
+                crate::debug::tapline!(
+                    tap,
+                    dio = dio_inner.master.read().unwrap().name(),
+                    written = report.written,
+                    new = (report.cache_rows_after - report.cache_rows_before) as usize,
+                    updated = report
+                        .written
+                        .saturating_sub((report.cache_rows_after - report.cache_rows_before) as usize),
+                    cached_rows = report.cache_rows_after,
+                    known_total = state.total.read().unwrap().unwrap_or(0),
+                    cached_pct = match state.total.read().unwrap().unwrap_or(0) {
+                        0 => 0,
+                        total => 100 * report.cache_rows_after as usize / total,
+                    },
+                    "cache write",
+                );
+            }
             // The window came back — whatever it contained, this view now has
             // an answer rather than a not-yet.
             state.mark_settled("chunk load succeeded");

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -166,6 +166,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         tracing::warn!(target: "vantage_diorama::viewport", "fire_chunk_load: dio dropped");
         return;
     };
+    let tap = dio_inner.tap();
 
     // Remember the window the grid last asked for so a refresh can re-fetch
     // exactly it in place (see `TableSceneryState::refresh_loaded_viewport`).
@@ -238,6 +239,13 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     rows = visible_cached,
                     "CACHE — served locally, no master fetch",
                 );
+                crate::debug::tapline!(
+                    tap,
+                    dio = dio_inner.master.read().unwrap().name(),
+                    range = ?visible,
+                    rows = visible_cached,
+                    "cache hit — viewport served locally",
+                );
                 return;
             }
         }
@@ -297,6 +305,12 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         *guard = Some(effective_range.clone());
     }
 
+    // Only allocate a request id when the tap is enabled — it's the one
+    // correlator that ties this fetch's "load dispatch" to its "load return"
+    // / "load failed" in the debug stream, and paying for it off the tap is
+    // pointless.
+    let req = tap.enabled().then(|| dio_inner.next_req());
+
     // Recompute overlap on the effective range so the log shows the
     // shift working.
     let effective_len = effective_range.end - effective_range.start;
@@ -325,6 +339,13 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         inner: dio_inner.clone(),
     };
     let t = std::time::Instant::now();
+    // Built here (rather than beside the `cb` call below) so the "load
+    // dispatch" tapline can report the query the fetch is about to run —
+    // sort/search included.
+    let query = crate::lens::ChunkQuery {
+        sort: state.sort.read().unwrap().clone(),
+        search: state.search.read().unwrap().clone(),
+    };
     tracing::debug!(
         target: "vantage_diorama::viewport",
         visible = ?visible,
@@ -356,14 +377,23 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         force_load,
         "MASTER — fetching from the datasource",
     );
+    crate::debug::tapline!(
+        tap,
+        req = req.unwrap_or_default(),
+        dio = dio_inner.master.read().unwrap().name(),
+        visible = ?visible,
+        effective = ?effective_range,
+        rows_to_fetch = effective_to_fetch,
+        already_cached = effective_cached,
+        sort = ?query.sort,
+        search = ?query.search,
+        force_load,
+        "load dispatch",
+    );
     // Clear the dirty flag so it reflects only the rows this load writes;
     // `write_chunk_row` sets it when a row's content actually changes.
     state.reset_load_dirty();
     let total_before = *state.total.read().unwrap();
-    let query = crate::lens::ChunkQuery {
-        sort: state.sort.read().unwrap().clone(),
-        search: state.search.read().unwrap().clone(),
-    };
     let mut result = cb(&dio, effective_range.clone(), query, sink).await;
     // Commit the page in one write, before anything reads the cache back. A
     // failed commit fails the load: the rows are bound in the visible map but
@@ -401,6 +431,15 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 ms,
                 "MASTER — fetch returned",
             );
+            crate::debug::tapline!(
+                tap,
+                req = req.unwrap_or_default(),
+                dio = dio_inner.master.read().unwrap().name(),
+                received = pushed,
+                ms,
+                cached_after,
+                "load return",
+            );
             // Where the grand total came from. A total the source stated in the
             // same response as the rows (`ChunkSink::set_total`) outranks
             // anything inferred here: a short page can equally mean "the source
@@ -417,6 +456,13 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     total = ?stated,
                     "total stated by the fetch itself — no count request needed",
                 );
+                crate::debug::tapline!(
+                    tap,
+                    dio = dio_inner.master.read().unwrap().name(),
+                    total = stated.unwrap_or_default(),
+                    provenance = "stated",
+                    "total",
+                );
                 let changed = stated != total_before;
                 // Remember a stated, un-narrowed total in the cache meta, so
                 // the NEXT open of this view can size its geometry before any
@@ -424,20 +470,28 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 // whole and its row count visibly jumping when the first
                 // counted response lands. A total under an active search
                 // describes the narrowed set and must not be remembered.
-                if changed && state.search.read().unwrap().is_none() {
-                    if let Some(total) = stated {
-                        if let Err(e) = dio_inner.cache.set_meta_total(total as u64).await {
-                            tracing::debug!(
-                                target: "vantage_diorama::cache",
-                                error = %e,
-                                "persisting the stated total failed — the next open loses its head start",
-                            );
-                        }
-                    }
+                if changed
+                    && state.search.read().unwrap().is_none()
+                    && let Some(total) = stated
+                    && let Err(e) = dio_inner.cache.set_meta_total(total as u64).await
+                {
+                    tracing::debug!(
+                        target: "vantage_diorama::cache",
+                        error = %e,
+                        "persisting the stated total failed — the next open loses its head start",
+                    );
                 }
                 changed
             } else if pushed < effective_len {
-                state.set_total(Some(effective_range.start + pushed))
+                let total = effective_range.start + pushed;
+                crate::debug::tapline!(
+                    tap,
+                    dio = dio_inner.master.read().unwrap().name(),
+                    total,
+                    provenance = "short-page",
+                    "total",
+                );
+                state.set_total(Some(total))
             } else {
                 // A FULL page from a source that has never stated a total. If
                 // it reached the advertised end, that end was only ever our
@@ -460,6 +514,13 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                         table = %dio_inner.master.read().unwrap().name(),
                         extended,
                         "full page reached the inferred horizon — extending it",
+                    );
+                    crate::debug::tapline!(
+                        tap,
+                        dio = dio_inner.master.read().unwrap().name(),
+                        total = extended,
+                        provenance = "horizon-extended",
+                        "total",
                     );
                     state.set_total(Some(extended))
                 } else {
@@ -527,6 +588,13 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                              promises more than it delivers; capping the set at what \
                              is reachable so the fetch is not repeated forever",
                         );
+                        crate::debug::tapline!(
+                            tap,
+                            dio = dio_inner.master.read().unwrap().name(),
+                            total = hole,
+                            provenance = "hole-clamped",
+                            "total",
+                        );
                         total_changed |= state.set_total(Some(hole));
                     }
                 }
@@ -543,6 +611,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             if force_load || resorted || dirty || total_changed {
                 state.bump_generation();
             }
+            state.note_state("chunk load");
             tracing::debug!(
                 target: "vantage_diorama::viewport",
                 effective = ?effective_range,
@@ -562,6 +631,14 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 ms = t.elapsed().as_secs_f64() * 1000.0,
                 error = %e,
                 "fire_chunk_load: FAILED",
+            );
+            crate::debug::tapline!(
+                tap,
+                req = req.unwrap_or_default(),
+                dio = dio_inner.master.read().unwrap().name(),
+                ms = t.elapsed().as_millis() as u64,
+                error = %e,
+                "load failed",
             );
             let _ = dio_inner.event_bus.send(DioEvent::LoadFailed {
                 range: effective_range,

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use vantage_vista::VistaCapabilities;
 
-use crate::dio::Generation;
+use crate::dio::{DioInner, Generation};
 
 use super::enriched_record::EnrichedRecord;
 
@@ -209,12 +209,19 @@ pub(crate) struct TableSceneryImpl {
 /// touching the winner's registry entry.
 struct SceneryGuard {
     tasks: Vec<tokio::task::JoinHandle<()>>,
+    /// Weak — the guard must not keep the Dio alive; it only reaches back
+    /// in to emit the closing census line, and only if the Dio is still
+    /// there to receive it.
+    dio_weak: std::sync::Weak<DioInner>,
 }
 
 impl Drop for SceneryGuard {
     fn drop(&mut self) {
         for task in &self.tasks {
             task.abort();
+        }
+        if let Some(dio) = self.dio_weak.upgrade() {
+            dio.emit_census("table scenery", "closed");
         }
     }
 }

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -109,6 +109,20 @@ pub enum LoadState {
     Complete,
 }
 
+impl LoadState {
+    /// Bare-word rendering for the debug stream's `"state"` line — passed as
+    /// a plain `&str` field (not `?self`) so the capture harness Debug-quotes
+    /// it (`to="Complete"`), matching every other string field this stream
+    /// emits.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            LoadState::Loading => "Loading",
+            LoadState::Partial => "Partial",
+            LoadState::Complete => "Complete",
+        }
+    }
+}
+
 /// Breakdown of the row statuses currently materialized in a scenery's sparse
 /// map. Cheap to compute (iterates only loaded rows, not the full row count) —
 /// the per-scenery slice of the diagnostics surface.
@@ -226,20 +240,28 @@ impl Drop for SceneryGuard {
     }
 }
 
+/// The [`LoadState`] computation, shared by [`TableScenery::load_state`] and
+/// [`TableSceneryState::note_state`](state::TableSceneryState::note_state) so
+/// the trait method and the debug stream can never disagree about what state
+/// a scenery is in.
+pub(crate) fn compute_load_state(state: &TableSceneryState) -> LoadState {
+    if !state.settled.load(std::sync::atomic::Ordering::SeqCst) {
+        return LoadState::Loading;
+    }
+    // A known total the visible map has not reached means rows are still
+    // coming — the ordinary state of a paged grid before it is scrolled.
+    // With no total there is nothing to be short of, so what is loaded is
+    // all there is.
+    let loaded = state.rows.read().unwrap().len();
+    match *state.total.read().unwrap() {
+        Some(total) if loaded < total => LoadState::Partial,
+        _ => LoadState::Complete,
+    }
+}
+
 impl TableScenery for TableSceneryImpl {
     fn load_state(&self) -> LoadState {
-        if !self.inner.settled.load(std::sync::atomic::Ordering::SeqCst) {
-            return LoadState::Loading;
-        }
-        // A known total the visible map has not reached means rows are still
-        // coming — the ordinary state of a paged grid before it is scrolled.
-        // With no total there is nothing to be short of, so what is loaded is
-        // all there is.
-        let loaded = self.inner.rows.read().unwrap().len();
-        match *self.inner.total.read().unwrap() {
-            Some(total) if loaded < total => LoadState::Partial,
-            _ => LoadState::Complete,
-        }
+        compute_load_state(&self.inner)
     }
 
     fn row_count(&self) -> usize {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -165,6 +165,21 @@ pub(crate) struct TableSceneryState {
     /// True while a list-page fetch is dispatched, so overlapping
     /// `request_load_more` calls don't double-page.
     pub(crate) list_in_flight: Mutex<bool>,
+
+    // ---- debug stream -------------------------------------------------
+    //
+    /// This scenery's Dio's debug tap, cloned at open. `note_state` needs it
+    /// from [`mark_settled`](Self::mark_settled), which has no `DioInner` (it
+    /// runs deep inside the loader after the Dio has already been consulted) —
+    /// carrying the tap here means `note_state` needs no other path to reach it.
+    pub(crate) debug_tap: crate::debug::DebugTap,
+    /// The Dio's master name at open, for the same reason `debug_tap` is
+    /// carried here rather than reached through `dio_weak`.
+    pub(crate) dio_name: String,
+    /// The [`LoadState`](super::LoadState) last emitted by
+    /// [`note_state`](Self::note_state), so a repeat call (settling, then the
+    /// same load's generation bump) doesn't double-log an unchanged state.
+    pub(crate) last_debug_state: Mutex<Option<super::LoadState>>,
 }
 
 impl TableSceneryState {
@@ -219,7 +234,34 @@ impl TableSceneryState {
                 two_pass = self.two_pass,
                 "scenery settled — the grid now shows this as the answer",
             );
+            self.note_state(reason);
         }
+    }
+
+    /// Emit a `"state"` debug line when this scenery's [`LoadState`](super::LoadState)
+    /// has changed since the last call. Checks the tap BEFORE computing the
+    /// state — the computation takes the `rows`/`total` locks, a cost the
+    /// off path must not pay.
+    pub(crate) fn note_state(&self, reason: &'static str) {
+        if !self.debug_tap.enabled() {
+            return;
+        }
+        let to = super::compute_load_state(self);
+        let mut last = self.last_debug_state.lock().unwrap();
+        if *last == Some(to) {
+            return;
+        }
+        let from = *last;
+        *last = Some(to);
+        drop(last);
+        crate::debug::tapline!(
+            self.debug_tap,
+            dio = self.dio_name.as_str(),
+            from = from.map(|s| s.as_str()).unwrap_or("None"),
+            to = to.as_str(),
+            reason,
+            "state",
+        );
     }
 
     pub(crate) fn bump_generation(&self) {
@@ -368,14 +410,14 @@ impl TableSceneryState {
                 self.set_total(Some(total));
                 // Remember it for the next open's head start (skipped under
                 // an active search — that total describes the narrowed set).
-                if self.search.read().unwrap().is_none() {
-                    if let Err(e) = dio_inner.cache.set_meta_total(total as u64).await {
-                        tracing::debug!(
-                            target: "vantage_diorama::cache",
-                            error = %e,
-                            "persisting the provider total failed",
-                        );
-                    }
+                if self.search.read().unwrap().is_none()
+                    && let Err(e) = dio_inner.cache.set_meta_total(total as u64).await
+                {
+                    tracing::debug!(
+                        target: "vantage_diorama::cache",
+                        error = %e,
+                        "persisting the provider total failed",
+                    );
                 }
             }
             Err(e) => tracing::error!(error = %e, "refresh_total failed"),

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -280,6 +280,21 @@ async fn list_page_into(
     let dio = Dio {
         inner: dio_inner.clone(),
     };
+    // Only allocate a request id when the tap is enabled — the one
+    // correlator that ties this page's "list page dispatch" to its "list
+    // page return" in the debug stream.
+    let req = state.debug_tap.enabled().then(|| dio_inner.next_req());
+    crate::debug::tapline!(
+        state.debug_tap,
+        req = req.unwrap_or_default(),
+        dio = state.dio_name.as_str(),
+        offset,
+        limit,
+        conditions = ?q.conditions,
+        sort = ?q.sort,
+        "list page dispatch",
+    );
+    let t = std::time::Instant::now();
     let rows = if let Some(cb) = dio_inner.lens.callbacks.on_list_page.as_ref() {
         cb(&dio, q).await?
     } else {
@@ -341,7 +356,18 @@ async fn list_page_into(
         }
         new_ids.push(id.clone());
     }
-    Ok(index.append_page(new_ids, limit))
+    let rows_len = rows.len();
+    let appended = index.append_page(new_ids, limit);
+    crate::debug::tapline!(
+        state.debug_tap,
+        req = req.unwrap_or_default(),
+        rows = rows_len,
+        ms = t.elapsed().as_millis() as u64,
+        index_len = index.len(),
+        complete = index.is_complete(),
+        "list page return",
+    );
+    Ok(appended)
 }
 
 /// Soft-refresh a two-pass scenery after its `(conditions, sort)` changed.
@@ -735,6 +761,14 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
         settled_empty_skips,
         memo_skips,
         "detail pass census",
+    );
+    crate::debug::tapline!(
+        state.debug_tap,
+        dio = state.dio_name.as_str(),
+        requested,
+        pending = pending.len(),
+        already_complete,
+        "detail pass",
     );
     if pending.is_empty() {
         return;

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -126,11 +126,20 @@ pub struct Servo {
 /// stops reacting instead of living for the Dio's whole lifetime.
 struct ServoGuard {
     task: tokio::task::JoinHandle<()>,
+    /// Weak, deliberately — `Servo` itself already holds the strong `Dio`
+    /// that keeps the write pipeline alive while the form is open. The
+    /// guard must not extend that lifetime further; it only reaches back
+    /// in to decrement the census and emit the closing line.
+    dio_weak: Weak<DioInner>,
 }
 
 impl Drop for ServoGuard {
     fn drop(&mut self) {
         self.task.abort();
+        if let Some(dio) = self.dio_weak.upgrade() {
+            dio.servo_census.fetch_sub(1, Ordering::Relaxed);
+            dio.emit_census("servo", "closed");
+        }
     }
 }
 
@@ -596,11 +605,14 @@ pub(crate) fn spawn_servo(dio: &Dio, id: Option<String>, strategy: IdStrategy) -
         .inner
         .lens
         .runtime
-        .spawn(track_loop(task_state, dio_weak, bus_rx));
+        .spawn(track_loop(task_state, dio_weak.clone(), bus_rx));
+
+    dio.inner.servo_census.fetch_add(1, Ordering::Relaxed);
+    dio.inner.emit_census("servo", "opened");
 
     Servo {
         dio: dio.clone(),
         state,
-        _guard: ServoGuard { task },
+        _guard: ServoGuard { task, dio_weak },
     }
 }

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -185,6 +185,59 @@ pub fn reset_fetch_stats() {
     }
 }
 
+/// Render a session summary block with fetch stats, live counts, and process stats.
+/// Returns one string per line, no trailing newlines, in this order:
+/// - header: "— diorama session summary —"
+/// - per table (busiest first): "{table}: {fetches} fetches ({repeats} repeats), {rows_received} rows ({rows_redundant} redundant), {ms_total}ms total, {ms_max}ms max"
+/// - live: "live: {dios} dios, {table_sceneries} table sceneries, {record_sceneries} record sceneries, {servos} servos"
+/// - process: "process: uptime {uptime_ms}ms, cpu {cpu_ms}ms, peak rss {peak_rss_mb}MB"
+pub fn debug_summary_lines() -> Vec<String> {
+    let mut lines = Vec::new();
+
+    // Header
+    lines.push("— diorama session summary —".to_string());
+
+    // Per-table stats (already sorted busiest first by fetch_stats())
+    for stat in fetch_stats() {
+        let line = format!(
+            "{}: {} fetches ({} repeats), {} rows ({} redundant), {}ms total, {}ms max",
+            stat.table,
+            stat.fetches,
+            stat.repeats,
+            stat.rows_received,
+            stat.rows_redundant,
+            stat.ms_total,
+            stat.ms_max
+        );
+        lines.push(line);
+    }
+
+    // Live counts
+    let live = live_counts();
+    lines.push(format!(
+        "live: {} dios, {} table sceneries, {} record sceneries, {} servos",
+        live.dios, live.table_sceneries, live.record_sceneries, live.servos
+    ));
+
+    // Process stats
+    let proc = crate::debug::process_stats();
+    let peak_rss_mb = proc.peak_rss_bytes / (1024 * 1024);
+    lines.push(format!(
+        "process: uptime {}ms, cpu {}ms, peak rss {}MB",
+        proc.uptime_ms, proc.cpu_ms, peak_rss_mb
+    ));
+
+    lines
+}
+
+/// Log the debug summary lines via tracing at info level.
+/// Unconditional — the embedder decides when to call this.
+pub fn emit_debug_summary() {
+    for line in debug_summary_lines() {
+        tracing::info!(target: "vantage_diorama::debug", "{}", line);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,5 +268,19 @@ mod tests {
             stats[1].worst_range, None,
             "fetched once, nothing to report"
         );
+    }
+
+    #[test]
+    fn summary_renders_ledger_live_and_process_lines() {
+        reset_fetch_stats();
+        record_fetch("book", &(0..20), 20, 0, 12);
+        record_fetch("book", &(0..20), 20, 20, 9);
+        let lines = debug_summary_lines();
+        assert!(lines[0].contains("session summary"));
+        let book = lines.iter().find(|l| l.starts_with("book:")).unwrap();
+        assert!(book.contains("2 fetches (1 repeats)"), "{book}");
+        assert!(book.contains("(20 redundant)"), "{book}");
+        assert!(lines.iter().any(|l| l.starts_with("live:")));
+        assert!(lines.iter().any(|l| l.starts_with("process:")));
     }
 }

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -242,8 +242,13 @@ pub fn emit_debug_summary() {
 mod tests {
     use super::*;
 
+    // These two scenarios share the process-global `LEDGER` and each needs
+    // to `reset_fetch_stats()` before recording its own fixture. Run as
+    // separate `#[test]` fns, cargo's default parallel test threads could
+    // interleave the resets and wipe one scenario's records mid-assert —
+    // so both live in one test, run strictly in sequence.
     #[test]
-    fn repeats_and_waste_are_counted_per_range() {
+    fn repeats_and_waste_are_counted_per_range_then_summary_renders_lines() {
         reset_fetch_stats();
         record_fetch("events", &(0..100), 35, 0, 3000);
         record_fetch("events", &(35..42), 7, 7, 2000);
@@ -268,10 +273,7 @@ mod tests {
             stats[1].worst_range, None,
             "fetched once, nothing to report"
         );
-    }
 
-    #[test]
-    fn summary_renders_ledger_live_and_process_lines() {
         reset_fetch_stats();
         record_fetch("book", &(0..20), 20, 0, 12);
         record_fetch("book", &(0..20), 20, 20, 9);

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -4,8 +4,8 @@ use std::fmt::Write as _;
 use std::sync::{Arc, Mutex};
 
 use tracing::field::{Field, Visit};
-use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::Layer;
+use tracing_subscriber::layer::{Context, SubscriberExt};
 
 use ciborium::Value as CborValue;
 use vantage_diorama::Lens;
@@ -128,7 +128,10 @@ async fn census_lines_fire_on_scenery_open_and_drop() {
     assert_eq!(opens.len(), 1);
     assert!(opens[0].contains("dio=\"books\""), "line: {}", opens[0]);
     assert!(opens[0].contains("table_sceneries=1"), "line: {}", opens[0]);
-    assert!(opens[0].contains("uptime_ms="), "census carries process stats");
+    assert!(
+        opens[0].contains("uptime_ms="),
+        "census carries process stats"
+    );
 
     drop(scenery);
     // Guard teardown is synchronous; the census drop line is emitted from Drop.
@@ -281,10 +284,7 @@ async fn column_line_exposes_undemanded_wide_fields() {
                     r.insert("id".to_string(), CborValue::Text("row0".to_string()));
                     r.insert("name".to_string(), CborValue::Text("Row Zero".to_string()));
                     for n in 1..=50 {
-                        r.insert(
-                            format!("extra_{n:04}"),
-                            CborValue::Text("x".repeat(1024)),
-                        );
+                        r.insert(format!("extra_{n:04}"), CborValue::Text("x".repeat(1024)));
                     }
                     sink.set_total(1);
                     sink.push(idx, "row0".to_string(), r).await?;
@@ -351,10 +351,7 @@ async fn column_line_dedups_across_multiple_wide_rows() {
                     r.insert("id".to_string(), CborValue::Text(format!("row{idx}")));
                     r.insert("name".to_string(), CborValue::Text(format!("Row {idx}")));
                     for n in 1..=50 {
-                        r.insert(
-                            format!("extra_{n:04}"),
-                            CborValue::Text("x".repeat(1024)),
-                        );
+                        r.insert(format!("extra_{n:04}"), CborValue::Text("x".repeat(1024)));
                     }
                     sink.push(idx, format!("row{idx}"), r).await?;
                 }

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -1,0 +1,106 @@
+//! Integration tests for the official debug stream (`vantage_diorama::debug`).
+
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::Layer;
+
+use vantage_diorama::Lens;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+/// Collects every `vantage_diorama::debug` event as one flat string:
+/// `"<message> ds=<..> <field>=<..> ..."` — order of fields as emitted.
+struct CaptureLayer(Arc<Mutex<Vec<String>>>);
+
+struct FlatVisitor {
+    message: String,
+    fields: String,
+}
+
+impl Visit for FlatVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            let _ = write!(self.message, "{value:?}");
+        } else {
+            let _ = write!(self.fields, " {}={value:?}", field.name());
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        if event.metadata().target() != "vantage_diorama::debug" {
+            return;
+        }
+        let mut v = FlatVisitor {
+            message: String::new(),
+            fields: String::new(),
+        };
+        event.record(&mut v);
+        self.0
+            .lock()
+            .unwrap()
+            .push(format!("{}{}", v.message, v.fields));
+    }
+}
+
+/// Install a thread-local subscriber that captures every
+/// `vantage_diorama::debug` event as a flat string. Returns the guard
+/// (drop it to uninstall) and the shared log the events land in.
+///
+/// Unused by this task's own test (which only checks the tap reaches the
+/// Dio, off means off) — later tasks in this stream add events and use
+/// this to assert on the emitted lines.
+#[allow(dead_code)]
+pub fn capture() -> (tracing::subscriber::DefaultGuard, Arc<Mutex<Vec<String>>>) {
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer(log.clone()));
+    (tracing::subscriber::set_default(subscriber), log)
+}
+
+/// Captured lines whose flattened text contains `needle`.
+#[allow(dead_code)]
+pub fn lines_containing(log: &Arc<Mutex<Vec<String>>>, needle: &str) -> Vec<String> {
+    log.lock()
+        .unwrap()
+        .iter()
+        .filter(|l| l.contains(needle))
+        .cloned()
+        .collect()
+}
+
+/// Minimal master Vista — an `id` column only, no rows. These tests only
+/// exercise the tap plumbing, not data flow.
+fn master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_id_column("id");
+    Vista::new("books", Box::new(MockShell::new().with_metadata(metadata)))
+}
+
+#[tokio::test]
+async fn builder_flag_reaches_the_dio_and_off_means_off() {
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .debug_datasource("faker-ds")
+            .runtime(tokio::runtime::Handle::current())
+            .build()
+            .unwrap(),
+    );
+    let dio = lens.make_dio(master()).await.unwrap();
+    assert!(dio.debug_tap().enabled());
+    assert_eq!(dio.debug_tap().ds(), "faker-ds");
+
+    let quiet = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .runtime(tokio::runtime::Handle::current())
+            .build()
+            .unwrap(),
+    );
+    let dio = quiet.make_dio(master()).await.unwrap();
+    assert!(!dio.debug_tap().enabled());
+}

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -104,3 +104,29 @@ async fn builder_flag_reaches_the_dio_and_off_means_off() {
     let dio = quiet.make_dio(master()).await.unwrap();
     assert!(!dio.debug_tap().enabled());
 }
+
+#[tokio::test]
+async fn census_lines_fire_on_scenery_open_and_drop() {
+    let (_guard, log) = capture();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .debug_datasource("faker-ds")
+            .runtime(tokio::runtime::Handle::current())
+            .build()
+            .unwrap(),
+    );
+    let dio = lens.make_dio(master()).await.unwrap();
+
+    let scenery = dio.table_scenery().open().await.unwrap();
+    let opens = lines_containing(&log, "census: table scenery opened");
+    assert_eq!(opens.len(), 1);
+    assert!(opens[0].contains("dio=\"books\""), "line: {}", opens[0]);
+    assert!(opens[0].contains("table_sceneries=1"), "line: {}", opens[0]);
+    assert!(opens[0].contains("uptime_ms="), "census carries process stats");
+
+    drop(scenery);
+    // Guard teardown is synchronous; the census drop line is emitted from Drop.
+    let closes = lines_containing(&log, "census: table scenery closed");
+    assert_eq!(closes.len(), 1);
+}

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -257,6 +257,75 @@ async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
     );
 }
 
+/// A single row with 50 fat extra fields — the wide-data case the "columns"
+/// line exists to surface. The scenery is opened plainly (no `.columns()`
+/// demand), so the Dio's demand union is `None` and the line reports
+/// `demanded="all"`; `received_count`/`payload_bytes` are the interesting
+/// signal here.
+#[tokio::test]
+async fn column_line_exposes_undemanded_wide_fields() {
+    let (_guard, log) = capture();
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .debug_datasource("faker-ds")
+            .viewport_debounce(std::time::Duration::from_millis(1))
+            .runtime(tokio::runtime::Handle::current())
+            .on_load_chunk(move |_dio, range, _query, sink| async move {
+                for idx in range {
+                    if idx != 0 {
+                        continue;
+                    }
+                    let mut r = Record::new();
+                    r.insert("id".to_string(), CborValue::Text("row0".to_string()));
+                    r.insert("name".to_string(), CborValue::Text("Row Zero".to_string()));
+                    for n in 1..=50 {
+                        r.insert(
+                            format!("extra_{n:04}"),
+                            CborValue::Text("x".repeat(1024)),
+                        );
+                    }
+                    sink.set_total(1);
+                    sink.push(idx, "row0".to_string(), r).await?;
+                }
+                Ok(())
+            })
+            .build()
+            .unwrap(),
+    );
+
+    let dio = lens
+        .make_dio(chunk_master(&[("name", "String")]))
+        .await
+        .unwrap();
+    let scenery = dio.table_scenery().open().await.unwrap();
+
+    scenery.set_viewport(0..1);
+    wait_until("first load return", || {
+        lines_containing(&log, "load return").len() == 1
+    })
+    .await;
+
+    let cols = lines_containing(&log, "columns");
+    assert_eq!(cols.len(), 1, "{cols:?}");
+    assert!(cols[0].contains("demanded=\"all\""), "{}", cols[0]);
+    assert!(cols[0].contains("received_count=52"), "{}", cols[0]);
+    assert!(cols[0].contains("payload_bytes="), "{}", cols[0]);
+    // payload should be dominated by the extras: > 50KB for 1 row wouldn't
+    // hold for all rows; just assert it's large.
+    let bytes: usize = cols[0]
+        .split("payload_bytes=")
+        .nth(1)
+        .unwrap()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(bytes > 50_000, "wide payload must be visible: {bytes}");
+}
+
 /// A chunk load's cache write reports how many of the written rows were new
 /// vs. already-cached updates, and the resulting percent-cached against the
 /// known total.

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -396,6 +396,93 @@ async fn column_line_dedups_across_multiple_wide_rows() {
     assert!(bytes > 500_000, "multi-row payload must scale: {bytes}");
 }
 
+/// Two-pass (list/detail) lifecycle: a list pass over a 40-row index (one
+/// page — the default page size of 100 covers it in a single dispatch) then a
+/// detail pass over the first viewport. Asserts the list page's dispatch/
+/// return are correlated by `req`, and that a "detail pass" line reports the
+/// 10-row viewport as `requested=10`.
+#[tokio::test]
+async fn two_pass_list_and_detail_lifecycle_is_logged() {
+    let (_guard, log) = capture();
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .debug_datasource("faker-ds")
+            .viewport_debounce(std::time::Duration::from_millis(1))
+            .runtime(tokio::runtime::Handle::current())
+            .on_list_page(move |_dio, q| async move {
+                let start = q.offset.min(40);
+                let end = (q.offset + q.limit).min(40);
+                let mut out = Vec::new();
+                for i in start..end {
+                    let mut r = Record::new();
+                    r.insert("name".to_string(), CborValue::Text(format!("Row {i}")));
+                    out.push((format!("id{i}"), r));
+                }
+                Ok(out)
+            })
+            .on_load_detail(move |_dio, id| async move {
+                let mut r = Record::new();
+                r.insert(
+                    "detail".to_string(),
+                    CborValue::Text(format!("Detail for {id}")),
+                );
+                Ok(r)
+            })
+            .build()
+            .unwrap(),
+    );
+
+    let dio = lens.make_dio(master()).await.unwrap();
+    let scenery = dio.table_scenery().open().await.unwrap();
+
+    // The seed list page runs detached from `open()`; wait for it to land.
+    wait_until("list page return", || {
+        lines_containing(&log, "list page return").len() == 1
+    })
+    .await;
+
+    let dispatch = lines_containing(&log, "list page dispatch");
+    let ret = lines_containing(&log, "list page return");
+    assert_eq!(dispatch.len(), 1, "{dispatch:?}");
+    assert_eq!(ret.len(), 1, "{ret:?}");
+    let req = dispatch[0]
+        .split("req=")
+        .nth(1)
+        .unwrap()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .to_string();
+    assert!(ret[0].contains(&format!("req={req}")), "{}", ret[0]);
+    assert!(dispatch[0].contains("offset=0"), "{}", dispatch[0]);
+    assert!(dispatch[0].contains("limit="), "{}", dispatch[0]);
+    assert!(ret[0].contains("rows=40"), "{}", ret[0]);
+    assert!(ret[0].contains("index_len=40"), "{}", ret[0]);
+    assert!(ret[0].contains("complete=true"), "{}", ret[0]);
+
+    // Detail pass over the first 10 rows.
+    scenery.set_viewport(0..10);
+    wait_until("detail pass requested=10", || {
+        lines_containing(&log, "detail pass")
+            .iter()
+            .any(|l| l.contains("requested=10"))
+    })
+    .await;
+
+    let detail_lines = lines_containing(&log, "detail pass");
+    assert!(
+        detail_lines.iter().any(|l| l.contains("requested=10")),
+        "{detail_lines:?}"
+    );
+    assert!(
+        detail_lines[0].contains("dio=\"books\""),
+        "{}",
+        detail_lines[0]
+    );
+}
+
 /// A chunk load's cache write reports how many of the written rows were new
 /// vs. already-cached updates, and the resulting percent-cached against the
 /// known total.

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -256,3 +256,67 @@ async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
         "no re-fetch"
     );
 }
+
+/// A chunk load's cache write reports how many of the written rows were new
+/// vs. already-cached updates, and the resulting percent-cached against the
+/// known total.
+#[tokio::test]
+async fn cache_writes_report_new_updated_and_percentage() {
+    let (_guard, log) = capture();
+
+    let backend: Backend = Arc::new(Mutex::new(
+        (0..100)
+            .map(|i| {
+                let mut r = Record::new();
+                r.insert("v".to_string(), CborValue::Text(format!("row{i}")));
+                (format!("id{i}"), r)
+            })
+            .collect(),
+    ));
+
+    let lens = {
+        let backend = backend.clone();
+        Arc::new(
+            Lens::new()
+                .cache_in_memory()
+                .debug_datasource("faker-ds")
+                .viewport_debounce(std::time::Duration::from_millis(1))
+                .runtime(tokio::runtime::Handle::current())
+                .on_load_chunk(move |_dio, range, _query, sink| {
+                    let backend = backend.clone();
+                    async move {
+                        let rows = backend.lock().unwrap().clone();
+                        sink.set_total(rows.len());
+                        for idx in range {
+                            if let Some((id, r)) = rows.get(idx) {
+                                sink.push(idx, id.clone(), r.clone()).await?;
+                            }
+                        }
+                        Ok(())
+                    }
+                })
+                .build()
+                .unwrap(),
+        )
+    };
+
+    let dio = lens
+        .make_dio(chunk_master(&[("v", "String")]))
+        .await
+        .unwrap();
+    let scenery = dio.table_scenery().open().await.unwrap();
+
+    scenery.set_viewport(0..30);
+    wait_until("first load return", || {
+        lines_containing(&log, "load return").len() == 1
+    })
+    .await;
+
+    let writes = lines_containing(&log, "cache write");
+    assert_eq!(writes.len(), 1, "{writes:?}");
+    assert!(writes[0].contains("new=30"), "{}", writes[0]);
+    assert!(writes[0].contains("updated=0"), "{}", writes[0]);
+    assert!(writes[0].contains("known_total=100"), "{}", writes[0]);
+    // 30 of 100 rows → 30%.
+    assert!(writes[0].contains("cached_pct=30"), "{}", writes[0]);
+}

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::{Context, SubscriberExt};
 
 use ciborium::Value as CborValue;
-use vantage_diorama::Lens;
+use vantage_diorama::{Lens, LoadState};
 use vantage_types::Record;
 use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
 
@@ -542,4 +542,82 @@ async fn cache_writes_report_new_updated_and_percentage() {
     assert!(writes[0].contains("known_total=100"), "{}", writes[0]);
     // 30 of 100 rows → 30%.
     assert!(writes[0].contains("cached_pct=30"), "{}", writes[0]);
+}
+
+/// The off-path silence regression: a lens built with no `.debug_datasource`
+/// call must produce zero `vantage_diorama::debug` events across the same
+/// load lifecycle `load_lifecycle_is_correlated_and_cache_hits_are_logged`
+/// exercises — dispatch, return, the `Loading -> Complete` transition, and a
+/// second viewport pass that hits cache. There is no log line to wait on when
+/// the tap is off (that is the point), so this drives the same viewports and
+/// waits on the scenery's own `LoadState` reaching `Complete` — row
+/// materialization the caller can observe without the debug stream.
+#[tokio::test]
+async fn a_non_debug_lens_emits_nothing_on_the_load_path() {
+    let (_guard, log) = capture();
+
+    let backend: Backend = Arc::new(Mutex::new(
+        (0..100)
+            .map(|i| {
+                let mut r = Record::new();
+                r.insert("v".to_string(), CborValue::Text(format!("row{i}")));
+                (format!("id{i}"), r)
+            })
+            .collect(),
+    ));
+
+    let lens = {
+        let backend = backend.clone();
+        Arc::new(
+            Lens::new()
+                .cache_in_memory()
+                .viewport_debounce(std::time::Duration::from_millis(1))
+                .runtime(tokio::runtime::Handle::current())
+                .on_load_chunk(move |_dio, range, _query, sink| {
+                    let backend = backend.clone();
+                    async move {
+                        let rows = backend.lock().unwrap().clone();
+                        sink.set_total(rows.len());
+                        for idx in range {
+                            if let Some((id, r)) = rows.get(idx) {
+                                sink.push(idx, id.clone(), r.clone()).await?;
+                            }
+                        }
+                        Ok(())
+                    }
+                })
+                .build()
+                .unwrap(),
+        )
+    };
+
+    let dio = lens
+        .make_dio(chunk_master(&[("v", "String")]))
+        .await
+        .unwrap();
+    assert!(!dio.debug_tap().enabled());
+    let scenery = dio.table_scenery().open().await.unwrap();
+
+    // The whole set in one viewport, exactly as the debug-on lifecycle test
+    // drives it — settles the scenery at `Complete` once the load lands.
+    scenery.set_viewport(0..100);
+    wait_until("first load reaches Complete", || {
+        scenery.load_state() == LoadState::Complete
+    })
+    .await;
+
+    // Second pass over a viewport already fully covered by the cache — a
+    // cache hit, same as the debug-on test. A hit changes no observable
+    // scenery state (already `Complete`), so there is nothing to poll for;
+    // sleeping past the 1ms viewport debounce is enough to let it settle
+    // before the final assertion.
+    scenery.set_viewport(0..30);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(scenery.load_state(), LoadState::Complete);
+
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "debug-off lens must emit nothing: {:?}",
+        log.lock().unwrap()
+    );
 }

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -326,6 +326,76 @@ async fn column_line_exposes_undemanded_wide_fields() {
     assert!(bytes > 50_000, "wide payload must be visible: {bytes}");
 }
 
+/// The wide-data detector's column union must dedup ACROSS rows, not just
+/// within one: ten rows sharing the same 52-column shape should still report
+/// `received_count=52` (not 520), proving the union doesn't just concatenate
+/// every row's field names. `payload_bytes` should scale with row count, and
+/// `rows` should report the full batch.
+#[tokio::test]
+async fn column_line_dedups_across_multiple_wide_rows() {
+    let (_guard, log) = capture();
+
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .debug_datasource("faker-ds")
+            .viewport_debounce(std::time::Duration::from_millis(1))
+            .runtime(tokio::runtime::Handle::current())
+            .on_load_chunk(move |_dio, range, _query, sink| async move {
+                sink.set_total(10);
+                for idx in range {
+                    if idx >= 10 {
+                        continue;
+                    }
+                    let mut r = Record::new();
+                    r.insert("id".to_string(), CborValue::Text(format!("row{idx}")));
+                    r.insert("name".to_string(), CborValue::Text(format!("Row {idx}")));
+                    for n in 1..=50 {
+                        r.insert(
+                            format!("extra_{n:04}"),
+                            CborValue::Text("x".repeat(1024)),
+                        );
+                    }
+                    sink.push(idx, format!("row{idx}"), r).await?;
+                }
+                Ok(())
+            })
+            .build()
+            .unwrap(),
+    );
+
+    let dio = lens
+        .make_dio(chunk_master(&[("name", "String")]))
+        .await
+        .unwrap();
+    let scenery = dio.table_scenery().open().await.unwrap();
+
+    scenery.set_viewport(0..10);
+    wait_until("first load return", || {
+        lines_containing(&log, "load return").len() == 1
+    })
+    .await;
+
+    let cols = lines_containing(&log, "columns");
+    assert_eq!(cols.len(), 1, "{cols:?}");
+    assert!(cols[0].contains("demanded=\"all\""), "{}", cols[0]);
+    // Same 52 fields on every row — the union must not grow with row count.
+    assert!(cols[0].contains("received_count=52"), "{}", cols[0]);
+    assert!(cols[0].contains("rows=10"), "{}", cols[0]);
+    let bytes: usize = cols[0]
+        .split("payload_bytes=")
+        .nth(1)
+        .unwrap()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    // Ten rows of the same wide shape: an order of magnitude past the
+    // single-row test's >50KB floor.
+    assert!(bytes > 500_000, "multi-row payload must scale: {bytes}");
+}
+
 /// A chunk load's cache write reports how many of the written rows were new
 /// vs. already-cached updates, and the resulting percent-cached against the
 /// known total.

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -7,8 +7,13 @@ use tracing::field::{Field, Visit};
 use tracing_subscriber::layer::{Context, SubscriberExt};
 use tracing_subscriber::Layer;
 
+use ciborium::Value as CborValue;
 use vantage_diorama::Lens;
+use vantage_types::Record;
 use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+mod support;
+use support::chunk::{Backend, master as chunk_master};
 
 /// Collects every `vantage_diorama::debug` event as one flat string:
 /// `"<message> ds=<..> <field>=<..> ..."` — order of fields as emitted.
@@ -129,4 +134,125 @@ async fn census_lines_fire_on_scenery_open_and_drop() {
     // Guard teardown is synchronous; the census drop line is emitted from Drop.
     let closes = lines_containing(&log, "census: table scenery closed");
     assert_eq!(closes.len(), 1);
+}
+
+/// Poll `pred` until it holds, with a bounded timeout — mirrors the
+/// wait-for-condition pattern `tests/support/chunk.rs` uses around generation
+/// watches, but polling the captured log instead (there is no single
+/// generation bump to wait on: the second viewport pass settles on a "cache
+/// hit" line, not a load).
+async fn wait_until(label: &str, mut pred: impl FnMut() -> bool) {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while !pred() {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for: {label}"));
+}
+
+/// A 100-row paged master served by `on_load_chunk`, with the debug tap on.
+/// Exercises the full load lifecycle: dispatch/return correlated by `req`,
+/// the resulting `Loading -> Complete` state transition, the stated total's
+/// provenance, and a second pass over the same viewport hitting cache instead
+/// of re-dispatching.
+#[tokio::test]
+async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
+    let (_guard, log) = capture();
+
+    let backend: Backend = Arc::new(Mutex::new(
+        (0..100)
+            .map(|i| {
+                let mut r = Record::new();
+                r.insert("v".to_string(), CborValue::Text(format!("row{i}")));
+                (format!("id{i}"), r)
+            })
+            .collect(),
+    ));
+
+    let lens = {
+        let backend = backend.clone();
+        Arc::new(
+            Lens::new()
+                .cache_in_memory()
+                .debug_datasource("faker-ds")
+                .viewport_debounce(std::time::Duration::from_millis(1))
+                .runtime(tokio::runtime::Handle::current())
+                .on_load_chunk(move |_dio, range, _query, sink| {
+                    let backend = backend.clone();
+                    async move {
+                        let rows = backend.lock().unwrap().clone();
+                        sink.set_total(rows.len());
+                        for idx in range {
+                            if let Some((id, r)) = rows.get(idx) {
+                                sink.push(idx, id.clone(), r.clone()).await?;
+                            }
+                        }
+                        Ok(())
+                    }
+                })
+                .build()
+                .unwrap(),
+        )
+    };
+
+    let dio = lens
+        .make_dio(chunk_master(&[("v", "String")]))
+        .await
+        .unwrap();
+    let scenery = dio.table_scenery().open().await.unwrap();
+
+    // The whole set in one viewport, so this first load covers rows 0..100
+    // and — together with the fetch's own `set_total(100)` — settles the
+    // scenery at `Complete`, not merely `Partial`.
+    scenery.set_viewport(0..100);
+    wait_until("first load return", || {
+        lines_containing(&log, "load return").len() == 1
+    })
+    .await;
+
+    let dispatch = lines_containing(&log, "load dispatch");
+    let ret = lines_containing(&log, "load return");
+    assert_eq!(dispatch.len(), 1);
+    assert_eq!(ret.len(), 1);
+    // The same req id ties them together.
+    let req = dispatch[0]
+        .split("req=")
+        .nth(1)
+        .unwrap()
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .to_string();
+    assert!(ret[0].contains(&format!("req={req}")));
+    assert!(ret[0].contains("ms="));
+
+    // A state transition to Complete was logged.
+    let states = lines_containing(&log, "state");
+    assert!(
+        states.iter().any(|l| l.contains("to=\"Complete\"")),
+        "{states:?}"
+    );
+
+    // The stated total (from `sink.set_total`) is provenance "stated".
+    let totals = lines_containing(&log, "total");
+    assert!(
+        totals
+            .iter()
+            .any(|l| l.contains("total=100") && l.contains("provenance=\"stated\"")),
+        "{totals:?}"
+    );
+
+    // Second pass over a viewport already fully covered by the cache: cache
+    // hit, no second dispatch.
+    scenery.set_viewport(0..30);
+    wait_until("cache hit on second pass", || {
+        lines_containing(&log, "cache hit").len() == 1
+    })
+    .await;
+    assert_eq!(
+        lines_containing(&log, "load dispatch").len(),
+        1,
+        "no re-fetch"
+    );
 }

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.11 — 2026-07-30
+
+- Track vantage-diorama 0.11. No behavior changes here.
+
 ## 0.6.10 — 2026-07-28
 
 - Track vantage-diorama 0.10. The requirement stayed at `0.9` when diorama

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2139,12 +2139,13 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "ciborium",
  "futures",
  "indexmap",
+ "libc",
  "redb",
  "serde",
  "thiserror 2.0.18",
@@ -2174,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.10", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.11", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"


### PR DESCRIPTION
Adds the official per-datasource debug feature to vantage-diorama and vantage-diorama-aggregate. Spec: `vantage-ui/agents/specs/2026-07-30-diorama-debug-census-design.md` (sections 1–2; the vantage-ui flag plumbing and the diorama-test-suite acceptance app are the next PRs in the stack). Stacked on `faker-shapes`.

## What it is

A `DebugTap` on the Lens — `LensBuilder::debug_datasource(name)` — makes every Dio, scenery, servo, and derived aggregate under that datasource emit a curated event stream at `info` level under the single target `vantage_diorama::debug`. No `RUST_LOG` needed; the flag alone is the switch. Off (the default) is byte-identical to before this PR, enforced by a gating macro and a regression test that drives a full load with the tap off and asserts zero events.

## The stream

Every line carries `ds=`; per-dio lines carry `dio=`. Frozen message strings (documented in `src/debug.rs` and `ARCHITECTURE.md`, and greppable by the future acceptance harness):

- `load dispatch` / `load return` / `load failed` — correlated by `req=N`, with range, sort, search, already-cached count, and `ms`
- `cache hit — viewport served locally` — the no-fetch path, made visible
- `total` — every total change with its provenance (`stated` / `short-page` / `horizon-extended` / `hole-clamped`)
- `state` — LoadState transitions (Loading → Partial → Complete) with the settling reason
- `cache write` (new/updated/percent-cached) and `cache seed` (warm/cold)
- `columns` — demanded vs received columns plus per-fetch payload bytes: the wide-data detector
- `census: <kind> <verb>` — consumer counts per Dio on every scenery/servo open/close, with process wall/CPU/peak-RSS
- `list page dispatch` / `list page return` / `detail pass` — the two-pass path with its QueryDescriptor
- `aggregate recompute` — trigger, rows in/out, ms, unchanged-skip; inherited automatically from the source dio's tap
- `stats::emit_debug_summary()` — end-of-session block: per-table fetch ledger (fetches, repeats, redundant rows), live objects, process cost

## Notes for the downstream harness

- Line *ordering* within one load is not part of the contract (the `state` line precedes `load return`).
- `from="None"` on a view's first `state` line is provisional; may become `from="Loading"` before the harness freezes greps.
- `derive()` intentionally emits two `trigger="initial"` recompute lines (eager compute, then seed pass with `unchanged=true`).

Versions: vantage-diorama 0.11.0, vantage-diorama-aggregate 0.6.5, vantage-faker 0.6.11 (pin bump).