### PR TITLE
faker: shaped backend personalities, rhai mutation effect, diorama search/horizon groundwork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2570,6 +2570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,10 +5215,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -5657,6 +5670,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "vantage-cmd",
  "vantage-core",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.10.1 — 2026-07-30
+
+- **Search rides the chunk pipeline.** `ChunkQuery` carries the scenery's
+  search text into `on_load_chunk`; `set_search` pushes down to a master that
+  `can_search` and falls back to an eager local predicate otherwise. A paged
+  view keeps its rows in place while the narrowed window loads
+  (stale-while-revalidate) instead of collapsing to zero on every keystroke.
+- **Unknown-total windowed sources grow on scroll.** A viewport pressed
+  against the inferred end probes past it even when fully cached (the horizon
+  probe), so a source that never states a total no longer walls the set at
+  its first page — with a grid-step-scroll regression test.
+- **Warm reopens get their final geometry before any fetch.** A stated grand
+  total is remembered in the cache meta and restored at seed; paged views
+  seed from a warm cache and settle at once, while a cold cache keeps the
+  loading state.
+
 ## 0.10.0 — 2026-07-28
 
 **A scenery reads its own shape, not its lens's offers**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -30,6 +30,8 @@ uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 tempfile = "3"
+# Diagnostic output in loader tests (`with_test_writer` + env filter).
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util", "sync", "time"] }
 vantage-csv = { path = "../vantage-csv", features = ["vista"] }
 vantage-sql = { path = "../vantage-sql", features = ["sqlite", "vista"] }

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -658,10 +658,10 @@ impl Dio {
         &self,
         offset: usize,
         limit: usize,
-        sort: Option<(String, crate::SortDir)>,
+        query: impl Into<crate::ChunkQuery>,
     ) -> Result<Vec<(String, Record<CborValue>)>> {
         Ok(self
-            .fetch_window_ordered_counted(offset, limit, sort)
+            .fetch_window_ordered_counted(offset, limit, query)
             .await?
             .0)
     }
@@ -677,20 +677,41 @@ impl Dio {
         &self,
         offset: usize,
         limit: usize,
-        sort: Option<(String, crate::SortDir)>,
+        query: impl Into<crate::ChunkQuery>,
     ) -> Result<(Vec<(String, Record<CborValue>)>, Option<i64>)> {
+        let query: crate::ChunkQuery = query.into();
         let master = self.master();
-        if let Some((col, dir)) = sort
-            && master.capabilities().can_order
+        let caps = master.capabilities();
+
+        // What the master can actually be asked for. A search it can't push
+        // down is DROPPED here, loudly — evaluating it over one window would
+        // silently search a slice, and the scenery's `search_supported` gate
+        // exists so consumers never offer what would land in this branch.
+        let push_sort = query.sort.clone().filter(|_| caps.can_order);
+        let push_search = query.search.clone().filter(|_| caps.can_search);
+        if query.search.is_some() && push_search.is_none() {
+            tracing::warn!(
+                target: "vantage_diorama::search",
+                table = %master.name(),
+                "chunk query carries a search the master cannot push down — ignored",
+            );
+        }
+
+        if (push_sort.is_some() || push_search.is_some())
             && let Some(shell) = master.source.clone_shell()
         {
-            let mut ordered = Vista::new(master.name(), shell);
-            let vdir = match dir {
-                crate::SortDir::Asc => vantage_vista::SortDirection::Ascending,
-                crate::SortDir::Desc => vantage_vista::SortDirection::Descending,
-            };
-            ordered.add_order(&col, vdir)?;
-            return ordered.fetch_window_counted(offset, limit).await;
+            let mut narrowed = Vista::new(master.name(), shell);
+            if let Some((col, dir)) = push_sort {
+                let vdir = match dir {
+                    crate::SortDir::Asc => vantage_vista::SortDirection::Ascending,
+                    crate::SortDir::Desc => vantage_vista::SortDirection::Descending,
+                };
+                narrowed.add_order(&col, vdir)?;
+            }
+            if let Some(text) = push_search {
+                narrowed.add_search(text)?;
+            }
+            return narrowed.fetch_window_counted(offset, limit).await;
         }
         master.fetch_window_counted(offset, limit).await
     }

--- a/vantage-diorama/src/lens/cache_backend.rs
+++ b/vantage-diorama/src/lens/cache_backend.rs
@@ -98,6 +98,23 @@ pub trait CacheTable: Send + Sync + 'static {
 
     async fn count(&self) -> Result<i64>;
 
+    /// The master set's grand total as last STATED by a fetch (a counted
+    /// window response or a `total_provider`) — persisted so a reopened
+    /// paged view can size itself to its final geometry before any fetch
+    /// runs, instead of growing in a visible step when the first counted
+    /// response lands. `None` = never learned. Defaults keep meta-less
+    /// backends valid: they simply reopen without a remembered total.
+    async fn meta_total(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    /// Persist the stated grand total — see [`Self::meta_total`]. Callers
+    /// must not write totals of a *narrowed* fetch (an active quicksearch):
+    /// the meta describes the table the next open will show.
+    async fn set_meta_total(&self, _total: u64) -> Result<()> {
+        Ok(())
+    }
+
     /// Read a record together with its persisted [`CacheStatus`]. The
     /// default treats any stored record as `Complete`; persisting backends
     /// override this.

--- a/vantage-diorama/src/lens/callbacks.rs
+++ b/vantage-diorama/src/lens/callbacks.rs
@@ -40,21 +40,38 @@ pub type DioTotalProviderFuture<'a> = Pin<Box<dyn Future<Output = Result<usize>>
 pub type DioTotalProviderCallback =
     Box<dyn for<'a> Fn(&'a Dio) -> DioTotalProviderFuture<'a> + Send + Sync + 'static>;
 
+/// How the requesting scenery wants a chunk shaped: its active order and its
+/// active quicksearch. Carried by value into every chunk fetch, because two
+/// sceneries over one Dio (a grid and a picker) load concurrently and must
+/// never see each other's narrowing.
+///
+/// `From<Option<(String, SortDir)>>` keeps sort-only construction terse for
+/// callers that predate search.
+#[derive(Debug, Clone, Default)]
+pub struct ChunkQuery {
+    /// The scenery's active order (`None` if unsorted).
+    pub sort: Option<(String, SortDir)>,
+    /// The scenery's active quicksearch text (`None` when not searching).
+    pub search: Option<String>,
+}
+
+impl From<Option<(String, SortDir)>> for ChunkQuery {
+    fn from(sort: Option<(String, SortDir)>) -> Self {
+        Self { sort, search: None }
+    }
+}
+
 /// Callback that fetches a contiguous range of rows from the master
 /// and pushes them into the Scenery via [`ChunkSink::push`]. Returns
 /// `Ok(())` once it is done pushing for this invocation.
 ///
-/// The `sort` is the requesting scenery's active order (`None` if unsorted).
+/// The [`ChunkQuery`] is the requesting scenery's active order + search.
 /// Callbacks should fetch through [`Dio::fetch_window_ordered`], which pushes
-/// the sort to a `can_order` master and otherwise returns the native-order
-/// window (the scenery then re-sorts over the cache).
+/// what the master supports (`can_order`, `can_search`) to a narrowed clone
+/// and otherwise returns the native window (the scenery then refines over
+/// the cache where it honestly can).
 pub type DioLoadChunkCallback = Box<
-    dyn for<'a> Fn(
-            &'a Dio,
-            Range<usize>,
-            Option<(String, SortDir)>,
-            ChunkSink,
-        ) -> DioCallbackFuture<'a>
+    dyn for<'a> Fn(&'a Dio, Range<usize>, ChunkQuery, ChunkSink) -> DioCallbackFuture<'a>
         + Send
         + Sync
         + 'static,
@@ -146,13 +163,10 @@ where
 /// Wrap a user closure into a [`DioLoadChunkCallback`].
 pub fn boxed_load_chunk_callback<F, Fut>(f: F) -> DioLoadChunkCallback
 where
-    F: for<'a> Fn(&'a Dio, Range<usize>, Option<(String, SortDir)>, ChunkSink) -> Fut
-        + Send
-        + Sync
-        + 'static,
+    F: for<'a> Fn(&'a Dio, Range<usize>, ChunkQuery, ChunkSink) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + 'static,
 {
-    Box::new(move |dio, range, sort, sink| Box::pin(f(dio, range, sort, sink)))
+    Box::new(move |dio, range, query, sink| Box::pin(f(dio, range, query, sink)))
 }
 
 /// Wrap a user closure into a [`DioListPageCallback`].

--- a/vantage-diorama/src/lens/memory_cache.rs
+++ b/vantage-diorama/src/lens/memory_cache.rs
@@ -64,6 +64,8 @@ impl CacheBackend for MemoryCache {
 #[derive(Default)]
 pub struct MemoryCacheTable {
     rows: Mutex<IndexMap<String, (Record<CborValue>, CacheStatus)>>,
+    /// See [`CacheTable::meta_total`].
+    meta_total: Mutex<Option<u64>>,
 }
 
 impl MemoryCacheTable {
@@ -129,6 +131,17 @@ impl CacheTable for MemoryCacheTable {
     async fn count(&self) -> Result<i64> {
         Self::yield_point().await;
         Ok(self.lock().len() as i64)
+    }
+
+    async fn meta_total(&self) -> Result<Option<u64>> {
+        Self::yield_point().await;
+        Ok(*self.meta_total.lock().expect("meta_total mutex poisoned"))
+    }
+
+    async fn set_meta_total(&self, total: u64) -> Result<()> {
+        Self::yield_point().await;
+        *self.meta_total.lock().expect("meta_total mutex poisoned") = Some(total);
+        Ok(())
     }
 
     async fn insert_value_with_status(

--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -24,6 +24,7 @@ use crate::ops::{ChangeEvent, ChangeFlash, QueryDescriptor};
 pub use activity::{Activity, ActivitySignal};
 pub use cache_backend::{CacheBackend, CacheStatus, CacheTable};
 pub use callbacks::{
+    ChunkQuery,
     DioCallback, DioEventCallback, DioFlashCallback, DioListPageCallback, DioLoadChunkCallback,
     DioLoadDetailCallback, DioTotalProviderCallback, LensCallbacks, boxed_dio_callback,
     boxed_dio_event_callback, boxed_dio_flash_callback, boxed_list_page_callback,
@@ -242,7 +243,7 @@ impl LensBuilder {
     /// `ViewportChanged` and never load.
     pub fn on_load_chunk<F, Fut>(mut self, f: F) -> Self
     where
-        F: for<'a> Fn(&'a Dio, Range<usize>, Option<(String, crate::SortDir)>, ChunkSink) -> Fut
+        F: for<'a> Fn(&'a Dio, Range<usize>, callbacks::ChunkQuery, ChunkSink) -> Fut
             + Send
             + Sync
             + 'static,

--- a/vantage-diorama/src/lens/redb_cache.rs
+++ b/vantage-diorama/src/lens/redb_cache.rs
@@ -472,6 +472,66 @@ impl CacheTable for RedbCacheTable {
         .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
     }
 
+    /// Meta lives in a SIBLING table (`{name}\u{1}meta`) so it can never
+    /// collide with a row id in the record table.
+    async fn meta_total(&self) -> Result<Option<u64>> {
+        let db = self.db.clone();
+        let name = format!("{}\u{1}meta", self.name);
+        tokio::task::spawn_blocking(move || -> Result<Option<u64>> {
+            let txn = db
+                .begin_read()
+                .map_err(|e| error!("redb begin_read failed", detail = e.to_string()))?;
+            let table =
+                match txn.open_table(TableDefinition::<&'static str, &'static [u8]>::new(&name)) {
+                    Ok(t) => t,
+                    Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+                    Err(e) => {
+                        return Err(error!(
+                            "redb open_table failed",
+                            table = name,
+                            detail = e.to_string()
+                        ));
+                    }
+                };
+            let Some(raw) = table
+                .get("total")
+                .map_err(|e| error!("redb get failed", detail = e.to_string()))?
+            else {
+                return Ok(None);
+            };
+            let bytes: [u8; 8] = raw
+                .value()
+                .try_into()
+                .map_err(|_| error!("redb meta total: malformed value"))?;
+            Ok(Some(u64::from_le_bytes(bytes)))
+        })
+        .await
+        .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
+    }
+
+    async fn set_meta_total(&self, total: u64) -> Result<()> {
+        let db = self.db.clone();
+        let name = format!("{}\u{1}meta", self.name);
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let txn = db
+                .begin_write()
+                .map_err(|e| error!("redb begin_write failed", detail = e.to_string()))?;
+            {
+                let mut table = txn
+                    .open_table(TableDefinition::<&'static str, &'static [u8]>::new(&name))
+                    .map_err(|e| error!("redb open_table failed", detail = e.to_string()))?;
+                table
+                    .insert("total", total.to_le_bytes().as_slice())
+                    .map_err(|e| error!("redb insert failed", detail = e.to_string()))?;
+            }
+            txn.commit()
+                .map_err(|e| error!("redb commit failed", detail = e.to_string()))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| error!("blocking task panicked", detail = e.to_string()))?
+    }
+
     async fn insert_value_with_status(
         &self,
         id: &str,

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -18,8 +18,8 @@ pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
 pub use dio::{Dio, DioEvent, DioShell, Generation, WeakDio, WriteCapabilities};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
-    Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkRow, ChunkSink,
-    DioCallback, DioEventCallback, DioFlashCallback, DioLoadChunkCallback,
+    Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkQuery, ChunkRow,
+    ChunkSink, DioCallback, DioEventCallback, DioFlashCallback, DioLoadChunkCallback,
     DioTotalProviderCallback, Lens, LensBuilder, LensCallbacks, LensDefaults, MemoryCache,
     MemoryCacheTable, RedbCache, RedbCacheTable,
 };

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -378,35 +378,48 @@ impl TableSceneryBuilder {
                 }
             }
         } else if state.paged && dio.lens.callbacks.on_start.is_none() {
-            // Pure paged lens (lazy chunk loading, no eager `on_start` warm): the
-            // row ORDER is the master's, fetched a page at a time — NOT the cache's
-            // id-keyed iteration order. Seeding densely from the cache here would
-            // both show the wrong order and make the viewport loader treat every
-            // row as already-cached and skip the authoritative fetch, so a warm
-            // cache (the redb file surviving a restart) would pin the grid to a
-            // stale, mis-ordered set until a forced refresh. Leave the map empty;
-            // the first viewport load fills it in the master's order.
-            // `total_provider` (above) already sized the scrollbar, so the grid
-            // shows its loading state, not a blank count.
+            // Pure paged lens (lazy chunk loading, no eager `on_start` warm).
             //
-            // A hybrid lens that DOES warm via `on_start` (cache seeded in the
-            // master's list order) still reseeds below, so its cache-aware
-            // "skip already-loaded ranges" optimisation is preserved.
+            // A WARM cache is shown at once rather than thrown away: navigating
+            // back to a grid whose rows are still cached must not flash a
+            // loading skeleton over data we already hold. `reseed_from_cache`
+            // orders the cached rows by the view's active sort, so a sorted
+            // grid opens in the right order; the `refresh_on_open` force-fetch
+            // below then replaces the visible window with the authoritative
+            // server rows *silently* — the view is already settled, so the swap
+            // carries no loading feedback. If the client sort can't reproduce
+            // the server's order exactly, the first screen reshuffles once when
+            // the fetch lands; the alternative is a skeleton over cached rows,
+            // which is worse. A non-contiguous cache compacts here, but the
+            // forced refetch corrects the first screen and scrolling corrects
+            // the rest.
             //
-            // This is the single most expensive decision an open makes, and it
-            // is invisible without saying so: a warm cache sitting unused looks
-            // exactly like a cold one from the outside.
-            // Both read before the macro: the count is awaited, and a lock
-            // taken inside the argument list would be held across that await.
+            // A COLD cache leaves the map empty so the grid shows its loading
+            // state; the on-open fetch is authoritative and fills the master's
+            // order. This is the "cache is not present" case the loading
+            // skeleton exists for.
+            //
+            // Both reads happen before the macro: the count is awaited, and a
+            // lock taken inside the argument list would be held across it.
             let table = dio.master.read().unwrap().name().to_string();
             let cached_rows = dio.cache.count().await.unwrap_or(0);
-            tracing::debug!(
-                target: "vantage_diorama::cache",
-                table = %table,
-                cached_rows,
-                "cache NOT seeded — paged lens; rows come from the master in its \
-                 own order, so the on-open fetch is authoritative",
-            );
+            if cached_rows > 0 {
+                state.reseed_from_cache().await?;
+                state.mark_settled("open: paged view seeded from warm cache");
+                tracing::debug!(
+                    target: "vantage_diorama::cache",
+                    table = %table,
+                    cached_rows,
+                    "warm cache seeded the paged view; refresh-on-open replaces it silently",
+                );
+            } else {
+                tracing::debug!(
+                    target: "vantage_diorama::cache",
+                    table = %table,
+                    cached_rows,
+                    "cache empty — paged view opens loading; the on-open fetch is authoritative",
+                );
+            }
             state.bump_generation();
         } else {
             // Eager single-pass (or `on_start`-warmed hybrid): the cache IS the

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -274,6 +274,7 @@ impl TableSceneryBuilder {
             load_dirty: std::sync::atomic::AtomicBool::new(false),
             load_push_count: AtomicUsize::new(0),
             load_total_reported: std::sync::atomic::AtomicBool::new(false),
+            total_ever_stated: std::sync::atomic::AtomicBool::new(false),
             paged: pages_lazily(&dio, &master_capabilities),
             settled: std::sync::atomic::AtomicBool::new(false),
             master_capabilities,
@@ -307,6 +308,11 @@ impl TableSceneryBuilder {
                 "total_provider — grand total fetched, blocking the open",
             );
             *state.total.write().unwrap() = Some(total);
+            // A provider-stated total is a fact, like one stated in a fetch
+            // response — the unknown-total horizon rule must never override it.
+            state
+                .total_ever_stated
+                .store(true, std::sync::atomic::Ordering::SeqCst);
         }
 
         // 2. Seed the sparse map.

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -280,6 +280,7 @@ impl TableSceneryBuilder {
             master_capabilities,
             two_pass,
             ui_filters: RwLock::new(Vec::new()),
+            search: RwLock::new(None),
             titles_only,
             demand,
             index: RwLock::new(index),

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -405,6 +405,7 @@ impl TableSceneryBuilder {
             let cached_rows = dio.cache.count().await.unwrap_or(0);
             if cached_rows > 0 {
                 state.reseed_from_cache().await?;
+                restore_meta_total(&state, &dio).await;
                 state.mark_settled("open: paged view seeded from warm cache");
                 tracing::debug!(
                     target: "vantage_diorama::cache",
@@ -425,6 +426,14 @@ impl TableSceneryBuilder {
             // Eager single-pass (or `on_start`-warmed hybrid): the cache IS the
             // row set; seed (and order) from it directly.
             state.reseed_from_cache().await?;
+            // A PAGED view under a hybrid lens (the shared backend lens
+            // carries both offers) sizes itself from the remembered total, so
+            // a warm reopen has its final geometry from the first frame — the
+            // alternative is a visible jump when the first counted response
+            // lands. Eager views derive their count from the rows themselves.
+            if state.paged {
+                restore_meta_total(&state, &dio).await;
+            }
             tracing::debug!(
                 target: "vantage_diorama::cache",
                 table = %dio.master.read().unwrap().name(),
@@ -516,6 +525,34 @@ impl TableSceneryBuilder {
         // this key, `register_table_scenery` returns the winner and our
         // `scenery` drops here — its guard aborts the redundant tasks.
         Ok(dio.register_table_scenery(key, scenery))
+    }
+}
+
+/// Restore the grand total remembered by the last session's stated fetch
+/// (see `CacheTable::meta_total`), so a warm reopen advertises its final row
+/// count before any fetch runs. Latched as stated — it WAS stated, last time
+/// — so the unknown-total horizon rule stays out of the way; the on-open
+/// refetch re-states (and re-persists) the current truth.
+async fn restore_meta_total(state: &Arc<TableSceneryState>, dio: &Arc<DioInner>) {
+    match dio.cache.meta_total().await {
+        Ok(Some(total)) => {
+            state
+                .total_ever_stated
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            state.set_total(Some(total as usize));
+            tracing::debug!(
+                target: "vantage_diorama::cache",
+                table = %dio.master.read().unwrap().name(),
+                total,
+                "restored the remembered grand total",
+            );
+        }
+        Ok(None) => {}
+        Err(e) => tracing::debug!(
+            target: "vantage_diorama::cache",
+            error = %e,
+            "reading the remembered total failed — geometry arrives with the first fetch",
+        ),
     }
 }
 

--- a/vantage-diorama/src/scenery/table/capped.rs
+++ b/vantage-diorama/src/scenery/table/capped.rs
@@ -69,6 +69,14 @@ impl TableScenery for CappedScenery {
         }
     }
 
+    fn set_search(&self, query: Option<String>) {
+        self.inner.set_search(query);
+    }
+
+    fn search_supported(&self) -> bool {
+        self.inner.search_supported()
+    }
+
     fn request_refresh(&self) {
         self.inner.request_refresh();
     }

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -27,6 +27,23 @@ pub(crate) fn record_get_path<'a>(rec: &'a Record<CborValue>, path: &str) -> Opt
     Some(current)
 }
 
+/// Local quicksearch predicate: case-insensitive substring over every text
+/// field of the record (the same semantics drivers use server-side, so a
+/// table behaves alike whichever side evaluates). `None`/blank matches all.
+pub(crate) fn matches_search(rec: &Record<CborValue>, query: Option<&str>) -> bool {
+    let Some(query) = query else {
+        return true;
+    };
+    let needle = query.to_lowercase();
+    if needle.is_empty() {
+        return true;
+    }
+    rec.values().any(|v| match v {
+        CborValue::Text(s) => s.to_lowercase().contains(&needle),
+        _ => false,
+    })
+}
+
 pub(crate) fn matches_conditions(rec: &Record<CborValue>, conds: &[(String, CborValue)]) -> bool {
     conds
         .iter()

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -196,11 +196,37 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
         visible.clone().filter(|i| rows.contains_key(i)).count()
     };
 
+    // Unknown-total horizon probe. When the source has never stated a total,
+    // the advertised end is only our inference — and a viewport pressed
+    // against it must ASK past it, even when every visible row is cached.
+    // Without this, a warm cache walls the set at its seeded size forever:
+    // the visible range is fully cached, no fetch fires, and the fetch is
+    // the only thing that can extend the horizon.
+    // What the view believes the set's end is: the inferred total, or — on a
+    // cache-seeded reopen, where no total survived — the seeded row count.
+    let advertised_end =
+        total.unwrap_or_else(|| state.rows.read().unwrap().keys().max().map_or(0, |i| i + 1));
+    let horizon_probe = state.paged
+        && !state.two_pass
+        && !force_load
+        && !state.total_ever_stated()
+        && advertised_end > 0
+        && visible.end >= advertised_end;
+
     // Decide what to actually fetch. `force_load` callers
     // (`request_load_more`) have already pre-computed a range; respect
     // it. For viewport-driven loads, shift toward the uncached side.
     let effective_range = if force_load {
         visible.clone()
+    } else if horizon_probe {
+        // Unclamped (`total: None`): the fetch may run past the inferred end.
+        // Fully-cached viewport → probe one page starting AT the end; rows
+        // coming back mean the set grew (or was always bigger), nothing back
+        // means the inference was right and the hole clamp keeps it.
+        match compute_fetch_range(&state, &visible, None) {
+            Some(r) => r,
+            None => advertised_end..advertised_end + state.page_size,
+        }
     } else {
         match compute_fetch_range(&state, &visible, total) {
             Some(r) => r,

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -391,7 +391,32 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             } else if pushed < effective_len {
                 state.set_total(Some(effective_range.start + pushed))
             } else {
-                false
+                // A FULL page from a source that has never stated a total. If
+                // it reached the advertised end, that end was only ever our
+                // own inference — a horizon, not a wall. Extend it by one
+                // page so the view can keep scrolling and asking (the
+                // grows-as-you-scroll mode); the set's real end arrives as a
+                // short page (exact) or an empty fetch (the hole clamp
+                // below). Without this, a total-less windowed source pinned
+                // its row count at the first page and no scroll could ever
+                // request more.
+                let horizon_reached = total_before.is_none_or(|t| effective_range.end >= t);
+                // Single-pass paged mode only: a two-pass view's list pass
+                // enumerated the whole set — its size is knowledge, not an
+                // inference to extend.
+                if !state.two_pass && effective_len > 0 && horizon_reached && !state.total_ever_stated()
+                {
+                    let extended = effective_range.end + effective_len;
+                    tracing::debug!(
+                        target: "vantage_diorama::source",
+                        table = %dio_inner.master.read().unwrap().name(),
+                        extended,
+                        "full page reached the inferred horizon — extending it",
+                    );
+                    state.set_total(Some(extended))
+                } else {
+                    false
+                }
             };
             // A client-side sort can't push down to a paged, non-orderable
             // master, so this load (a viewport fetch, a scroll, or a refresh's

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -410,13 +410,32 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             // self-correcting from a fetch already made — including for a list
             // opened before its rows existed, counted once at 0.
             let mut total_changed = if state.take_load_total_reported() {
+                let stated = *state.total.read().unwrap();
                 tracing::debug!(
                     target: "vantage_diorama::source",
                     table = %dio_inner.master.read().unwrap().name(),
-                    total = ?*state.total.read().unwrap(),
+                    total = ?stated,
                     "total stated by the fetch itself — no count request needed",
                 );
-                *state.total.read().unwrap() != total_before
+                let changed = stated != total_before;
+                // Remember a stated, un-narrowed total in the cache meta, so
+                // the NEXT open of this view can size its geometry before any
+                // fetch — the difference between a warm reopen appearing
+                // whole and its row count visibly jumping when the first
+                // counted response lands. A total under an active search
+                // describes the narrowed set and must not be remembered.
+                if changed && state.search.read().unwrap().is_none() {
+                    if let Some(total) = stated {
+                        if let Err(e) = dio_inner.cache.set_meta_total(total as u64).await {
+                            tracing::debug!(
+                                target: "vantage_diorama::cache",
+                                error = %e,
+                                "persisting the stated total failed — the next open loses its head start",
+                            );
+                        }
+                    }
+                }
+                changed
             } else if pushed < effective_len {
                 state.set_total(Some(effective_range.start + pushed))
             } else {

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -360,8 +360,11 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     // `write_chunk_row` sets it when a row's content actually changes.
     state.reset_load_dirty();
     let total_before = *state.total.read().unwrap();
-    let sort = state.sort.read().unwrap().clone();
-    let mut result = cb(&dio, effective_range.clone(), sort, sink).await;
+    let query = crate::lens::ChunkQuery {
+        sort: state.sort.read().unwrap().clone(),
+        search: state.search.read().unwrap().clone(),
+    };
+    let mut result = cb(&dio, effective_range.clone(), query, sink).await;
     // Commit the page in one write, before anything reads the cache back. A
     // failed commit fails the load: the rows are bound in the visible map but
     // absent from the cache, and the next re-sort would rebuild the map without

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -398,13 +398,14 @@ impl TableScenery for TableSceneryImpl {
         self.inner.deregister();
         *self.inner.search.write().unwrap() = normalized;
         if self.inner.paged {
-            // Every cached index belongs to the previous query's row space —
-            // rows, ids and total all restart under the new one. The refetch
-            // of the current viewport carries the search via `ChunkQuery`.
-            self.inner.rows.write().unwrap().clear();
-            self.inner.id_to_idx.write().unwrap().clear();
-            self.inner.set_total(None);
-            self.inner.bump_generation();
+            // Stale-while-revalidate: keep the current rows and count on
+            // screen and refetch the viewport in place. The refetch reads the
+            // new search from `state` (via `ChunkQuery`) and overwrites each
+            // slot as ordered rows land; the counted response then updates the
+            // total, at which point any tail beyond the new (smaller) set falls
+            // outside `row_count` and stops being addressed. Clearing here
+            // instead would blank the grid for the whole round trip — a
+            // collapse-to-zero on every keystroke.
             self.inner.refresh_loaded_viewport();
         } else {
             // Eager: the reseed applies the predicate over the cache.

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -160,6 +160,20 @@ pub trait TableScenery: Send + Sync {
     /// them reference augmented columns). Empty vec clears.
     fn set_filters(&self, filters: Vec<(String, ciborium::Value)>);
 
+    /// Replace the quicksearch text (replace semantics; `None` or blank
+    /// clears). Paged sceneries push it into every chunk fetch — callers
+    /// should offer search only when [`Self::search_supported`] says so.
+    /// Eager sceneries filter locally over their (complete) cache. Default
+    /// no-op for wrappers that don't search.
+    fn set_search(&self, _query: Option<String>) {}
+
+    /// Whether [`Self::set_search`] will do something honest here: a paged
+    /// scenery needs the master's `can_search` (a local filter would silently
+    /// search only the loaded slice); an eager one always can.
+    fn search_supported(&self) -> bool {
+        false
+    }
+
     fn subscribe(&self) -> watch::Receiver<Generation>;
 
     /// Snapshot of the master Vista's capability flags taken at open
@@ -366,6 +380,44 @@ impl TableScenery for TableSceneryImpl {
         // The cached total belongs to the unfiltered set.
         self.inner.set_total(None);
         self.inner.reload_notify.notify_one();
+    }
+
+    fn set_search(&self, query: Option<String>) {
+        let normalized = query.filter(|q| !q.trim().is_empty());
+        if *self.inner.search.read().unwrap() == normalized {
+            return;
+        }
+        tracing::debug!(
+            target: "vantage_diorama::search",
+            query = ?normalized,
+            paged = self.inner.paged,
+            "set_search",
+        );
+        // Reshaping a shared view is not this consumer's to do — same rule
+        // as `set_sort`/`set_filters`.
+        self.inner.deregister();
+        *self.inner.search.write().unwrap() = normalized;
+        if self.inner.paged {
+            // Every cached index belongs to the previous query's row space —
+            // rows, ids and total all restart under the new one. The refetch
+            // of the current viewport carries the search via `ChunkQuery`.
+            self.inner.rows.write().unwrap().clear();
+            self.inner.id_to_idx.write().unwrap().clear();
+            self.inner.set_total(None);
+            self.inner.bump_generation();
+            self.inner.refresh_loaded_viewport();
+        } else {
+            // Eager: the reseed applies the predicate over the cache.
+            self.inner.reload_notify.notify_one();
+        }
+    }
+
+    fn search_supported(&self) -> bool {
+        if self.inner.paged {
+            self.inner.master_capabilities.can_search
+        } else {
+            true
+        }
     }
 
     fn subscribe(&self) -> watch::Receiver<Generation> {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -82,6 +82,14 @@ pub(crate) struct TableSceneryState {
     /// the grid off at its first screen.
     pub(crate) load_total_reported: std::sync::atomic::AtomicBool,
 
+    /// Whether ANY fetch has ever stated a grand total (as opposed to totals
+    /// this side inferred from short pages). Latched, never cleared: a source
+    /// either reports totals or it doesn't. While it never has, a full page
+    /// reaching the advertised end means "horizon", not "end" — the loader
+    /// extends the addressable set so scrolling can keep asking (the
+    /// grows-as-you-scroll mode for window-paged, total-less sources).
+    pub(crate) total_ever_stated: std::sync::atomic::AtomicBool,
+
     /// Whether this view has finished its first load.
     ///
     /// "No rows" and "no rows *yet*" are the same picture and opposite
@@ -228,6 +236,11 @@ impl TableSceneryState {
         self.load_total_reported.swap(false, Ordering::SeqCst)
     }
 
+    /// Whether any fetch has ever stated a total — see the field docs.
+    pub(crate) fn total_ever_stated(&self) -> bool {
+        self.total_ever_stated.load(Ordering::SeqCst)
+    }
+
     /// Read and clear the chunk-load dirty flag. `true` means the load changed
     /// at least one row's content (so a generation bump is warranted).
     pub(crate) fn take_load_dirty(&self) -> bool {
@@ -339,6 +352,9 @@ impl TableSceneryState {
         };
         match cb(&dio).await {
             Ok(total) => {
+                // Stated, not inferred — latch it so the unknown-total
+                // horizon rule stays out of the way (see `total_ever_stated`).
+                self.total_ever_stated.store(true, Ordering::SeqCst);
                 self.set_total(Some(total));
             }
             Err(e) => tracing::error!(error = %e, "refresh_total failed"),
@@ -479,6 +495,7 @@ impl SceneryChunkTarget for TableSceneryState {
     /// request on open, which is the one network call `open()` used to await.
     fn set_chunk_total(&self, total: usize) -> bool {
         self.load_total_reported.store(true, Ordering::SeqCst);
+        self.total_ever_stated.store(true, Ordering::SeqCst);
         self.set_total(Some(total))
     }
 

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -366,6 +366,17 @@ impl TableSceneryState {
                 // horizon rule stays out of the way (see `total_ever_stated`).
                 self.total_ever_stated.store(true, Ordering::SeqCst);
                 self.set_total(Some(total));
+                // Remember it for the next open's head start (skipped under
+                // an active search — that total describes the narrowed set).
+                if self.search.read().unwrap().is_none() {
+                    if let Err(e) = dio_inner.cache.set_meta_total(total as u64).await {
+                        tracing::debug!(
+                            target: "vantage_diorama::cache",
+                            error = %e,
+                            "persisting the provider total failed",
+                        );
+                    }
+                }
             }
             Err(e) => tracing::error!(error = %e, "refresh_total failed"),
         }

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -12,7 +12,9 @@ use crate::dio::{DioInner, Generation};
 use crate::lens::SceneryChunkTarget;
 use crate::scenery::enriched_record::{EnrichedRecord, RowStatus};
 
-use super::helpers::{cmp_sort, matches_conditions, matches_op_conditions, record_get_path};
+use super::helpers::{
+    cmp_sort, matches_conditions, matches_op_conditions, matches_search, record_get_path,
+};
 use super::{SortDir, ViewportRequest};
 
 /// Internal state shared by the public scenery handle, the reactor
@@ -130,6 +132,12 @@ pub(crate) struct TableSceneryState {
     /// ANDed with `conditions` in the local refine chain, kept separate
     /// so chips can never clobber query narrowing.
     pub(crate) ui_filters: RwLock<Vec<(String, CborValue)>>,
+
+    /// Active quicksearch text (`None` when not searching). Paged sceneries
+    /// carry it into every chunk fetch (`ChunkQuery`); eager ones apply it as
+    /// a local predicate in `reseed_from_cache` — honest there, because the
+    /// cache is (or becomes) the complete set.
+    pub(crate) search: RwLock<Option<String>>,
     /// Dropdown / autocomplete projection: serve the cheap list columns and
     /// **skip the detail pass** even on a two-pass table. The list pass still
     /// runs (rows carry id + title columns); per-row hydration never fires.
@@ -293,11 +301,13 @@ impl TableSceneryState {
         let conditions = self.conditions.read().unwrap().clone();
         let op_conditions = self.op_conditions.read().unwrap().clone();
         let sort = self.sort.read().unwrap().clone();
+        let search = self.search.read().unwrap().clone();
 
         let mut filtered: Vec<(String, Record<CborValue>)> = all
             .into_iter()
             .filter(|(_, rec)| matches_conditions(rec, &conditions))
             .filter(|(_, rec)| matches_op_conditions(rec, &op_conditions))
+            .filter(|(_, rec)| matches_search(rec, search.as_deref()))
             .collect();
 
         if let Some((col, dir)) = sort {

--- a/vantage-diorama/tests/chunk_unknown_total_growth.rs
+++ b/vantage-diorama/tests/chunk_unknown_total_growth.rs
@@ -67,6 +67,40 @@ async fn wait_for(what: &str, scenery: &Arc<dyn TableScenery>, mut ok: impl FnMu
     panic!("timed out waiting for: {what}");
 }
 
+/// A grid-faithful scroll: overlapping ~21-row viewports stepping down in
+/// small increments, exactly what wheel-scrolling a `RecordGridDio` emits.
+/// The set must keep growing under this motion until the real end pins it —
+/// no wall partway, whatever the interplay of cached runs, phantom pages
+/// and horizon extensions.
+#[tokio::test(flavor = "multi_thread")]
+async fn grid_step_scroll_reaches_the_exact_end() -> Result<()> {
+    const VIEW: usize = 21;
+    let tmp = TempDir::new().unwrap();
+    let lens = total_less_lens(tmp.path().join("c.redb"));
+    let dio = lens.make_dio(master_cols(&[("v", "String")])).await?;
+    let scenery = dio.table_scenery().open().await?;
+
+    wait_for("first rows", &scenery, || scenery.row_count() > 0).await;
+
+    let mut top = 0usize;
+    for _ in 0..400 {
+        let rows = scenery.row_count();
+        if rows == REAL_TOTAL && scenery.row(REAL_TOTAL - 1).is_some() {
+            assert_eq!(scenery.estimated_total(), Some(REAL_TOTAL));
+            return Ok(());
+        }
+        // One wheel notch down, clamped like a real grid to its content.
+        top = (top + 7).min(rows.saturating_sub(VIEW));
+        scenery.set_viewport(top..(top + VIEW).min(rows));
+        tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+    }
+    panic!(
+        "scroll never reached the end: rows={} total={:?}",
+        scenery.row_count(),
+        scenery.estimated_total()
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn full_pages_extend_the_horizon_until_a_short_page_ends_it() -> Result<()> {
     let tmp = TempDir::new().unwrap();

--- a/vantage-diorama/tests/chunk_unknown_total_growth.rs
+++ b/vantage-diorama/tests/chunk_unknown_total_growth.rs
@@ -1,0 +1,124 @@
+//! A window-paged source that never states a total.
+//!
+//! Offset-paginated APIs without a count endpoint exist everywhere: they
+//! serve any `[offset, limit)` you ask for and tell you nothing about how
+//! many rows there are. The only honest presentation is a list that grows as
+//! you scroll — a full page means "there may be more", a short page means
+//! "that was the end".
+//!
+//! Before the horizon rule, the first full page pinned the inferred total at
+//! its own size: `row_count` equalled the loaded rows, the viewport could
+//! never reach past them, and no scroll could ever request more — the set
+//! froze at one page.
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::{Lens, TableScenery};
+use vantage_types::Record;
+
+mod support;
+use support::chunk::master as master_cols;
+
+/// What the backend actually holds. Deliberately NOT a multiple of any page
+/// size in play, so the exact end arrives as a short page.
+const REAL_TOTAL: usize = 133;
+
+fn rec(v: usize) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("v".to_string(), CborValue::Text(format!("v{v}")));
+    r
+}
+
+/// Paged lens with no `total_provider` and no `set_total` — the source
+/// serves windows and states nothing, ever.
+fn total_less_lens(cache: std::path::PathBuf) -> Arc<Lens> {
+    let rows: Vec<(String, Record<CborValue>)> = (0..REAL_TOTAL)
+        .map(|i| (format!("id{i:04}"), rec(i)))
+        .collect();
+    Lens::new()
+        .cache_at(cache)
+        .on_load_chunk(move |_dio, range, _sort, sink| {
+            let rows = rows.clone();
+            async move {
+                for idx in range {
+                    if let Some((id, r)) = rows.get(idx) {
+                        sink.push(idx, id.clone(), r.clone()).await?;
+                    }
+                }
+                Ok(())
+            }
+        })
+        .build()
+        .map(Arc::new)
+        .expect("build lens")
+}
+
+async fn wait_for(what: &str, scenery: &Arc<dyn TableScenery>, mut ok: impl FnMut() -> bool) {
+    let mut rx = scenery.subscribe();
+    for _ in 0..100 {
+        if ok() {
+            return;
+        }
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(100), rx.changed()).await;
+    }
+    panic!("timed out waiting for: {what}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn full_pages_extend_the_horizon_until_a_short_page_ends_it() -> Result<()> {
+    let tmp = TempDir::new().unwrap();
+    let lens = total_less_lens(tmp.path().join("c.redb"));
+    let dio = lens.make_dio(master_cols(&[("v", "String")])).await?;
+    let scenery = dio.table_scenery().open().await?;
+
+    // The opening fetch returns a full page; the advertised set must reach
+    // PAST the loaded rows, or no scroll can ever ask for more.
+    wait_for("first page + horizon", &scenery, || {
+        let n = scenery.row_count();
+        n > 0 && scenery.row(n - 1).is_none()
+    })
+    .await;
+    assert!(
+        scenery.has_more(),
+        "a total-less source with a full first page has more"
+    );
+
+    // Scroll to the horizon until the set stops growing; each round must
+    // load rows the previous horizon exposed.
+    let mut last = 0;
+    for round in 0..64 {
+        let n = scenery.row_count();
+        if n == last && round > 0 {
+            break;
+        }
+        last = n;
+        scenery.set_viewport(n.saturating_sub(20)..n);
+        wait_for("horizon rows load or end", &scenery, || {
+            scenery.row_count() != n || scenery.row(n.saturating_sub(1)).is_some()
+        })
+        .await;
+        // Let a follow-up horizon extension land before sampling.
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        if scenery.row_count() == REAL_TOTAL {
+            break;
+        }
+    }
+
+    // The short page pinned the exact end.
+    wait_for("exact total", &scenery, || {
+        scenery.row_count() == REAL_TOTAL
+    })
+    .await;
+    assert_eq!(scenery.estimated_total(), Some(REAL_TOTAL));
+
+    // And every advertised row is real — no phantom tail left behind.
+    wait_for("tail hydrated", &scenery, || {
+        scenery.row(REAL_TOTAL - 1).is_some()
+    })
+    .await;
+
+    Ok(())
+}

--- a/vantage-diorama/tests/chunk_warm_cache_order.rs
+++ b/vantage-diorama/tests/chunk_warm_cache_order.rs
@@ -81,3 +81,56 @@ async fn warm_cache_reopen_shows_master_order_not_id_order() -> Result<()> {
     );
     Ok(())
 }
+
+/// A warm reopen shows its cached rows *immediately* — settled, non-empty, no
+/// loading state — so navigating back to a grid never flashes a loading
+/// skeleton over data already held. A cold open (empty cache) still reports
+/// loading. The authoritative order is restored silently by the on-open
+/// refetch (covered by the test above).
+#[tokio::test]
+async fn warm_reopen_is_settled_at_once_cold_open_is_loading() -> Result<()> {
+    use vantage_diorama::LoadState;
+
+    let tmp = TempDir::new().unwrap();
+    let cache = tmp.path().join("c.redb");
+    let backend: Backend = Arc::new(Mutex::new(vec![
+        ("1".into(), rec("one", 10)),
+        ("2".into(), rec("two", 30)),
+        ("3".into(), rec("three", 20)),
+    ]));
+    let lens = paged_lens(cache, backend.clone());
+    let dio = lens.make_dio(master()).await?;
+
+    // Cold open: nothing cached yet, so the view reports loading.
+    {
+        let cold = dio.table_scenery().open().await?;
+        assert_eq!(
+            cold.load_state(),
+            LoadState::Loading,
+            "a cold paged open (empty cache) reports loading",
+        );
+        let mut rx = cold.subscribe();
+        let g = u64::from(*rx.borrow_and_update());
+        cold.set_viewport(0..3);
+        wait_for_gen(&mut rx, g).await;
+        settle().await;
+    }
+
+    // Warm reopen: the cache holds the rows — the view is settled with rows
+    // the instant it opens, before any fetch has run.
+    let warm = dio.table_scenery().open().await?;
+    assert!(
+        !warm.is_loading(),
+        "a warm paged reopen must not report loading",
+    );
+    assert_eq!(
+        warm.row_count(),
+        3,
+        "a warm paged reopen shows its cached rows at once",
+    );
+    assert!(
+        warm.row(0).is_some(),
+        "the first cached row is present immediately, so no skeleton renders",
+    );
+    Ok(())
+}

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.6.11 — 2026-07-30
+
+- **`BackendShape` / `ShapedShell`** — one struct is a whole backend
+  personality: advertised `capabilities` (anything unadvertised refuses as
+  unsupported), `page_size`, per-operation-class latency (`list`/`get`/
+  `window`/`count`, plus `search_extra` while a filter is active), a
+  `FaultSchedule` (`error_rate`, scheduled `offline` windows, `cursor_expiry`,
+  `total_lie`, `boundary_skew`), undeclared fat `extra_fields`, `weirdness`
+  (a share of string cells drawn from an anomaly pool), and a `seed` for
+  deterministic replay. `FakerTable::build_shaped` reads the same store
+  through the shaped shell.
+- **`RhaiEffect`** (feature `rhai`) — a scripted mutation loop: seeds `count`
+  rows, then evaluates a Rhai script every `interval` with mutation verbs
+  (`ids`, `get`, `set`, `patch`, `insert`, `delete`, `fake`, `rand_int`,
+  `rand_float`, `pick`); every verb writes the store and broadcasts the
+  matching `ChangeEvent`.
+- `ValueGen::seeded` and `with_weirdness` — deterministic, anomaly-capable
+  value generation; the effect rng is decorrelated from the value rng.
+- Every tolled operation on a shaped shell emits a `tracing::debug!` under
+  `vantage_faker::shape` — the tap request accounting reads.
+
 ## 0.6.10 — 2026-07-28
 
 - Track vantage-diorama 0.10. The requirement stayed at `0.9` when diorama

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -14,6 +14,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +425,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,13 +798,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
 ]
 
@@ -832,7 +878,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1120,6 +1166,9 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1216,6 +1265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1351,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1416,6 +1477,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "rhai"
+version = "1.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
+dependencies = [
+ "ahash 0.8.12",
+ "bitflags",
+ "num-traits",
+ "once_cell",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+ "thin-vec",
+ "web-time",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1635,6 +1724,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1749,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1758,6 +1864,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-vec"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1907,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2060,6 +2181,7 @@ dependencies = [
  "cucumber",
  "fake",
  "indexmap",
+ "rhai",
  "tempfile",
  "tokio",
  "tracing",
@@ -2180,6 +2302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2405,6 +2546,12 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.10"
+version = "0.6.11"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -32,7 +32,14 @@ tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
 # Third-party realistic value generation (names, emails, addresses, …).
 fake = "5"
 
+# `effect: rhai` — scripted mutation loops. Same rhai as vantage-vista's
+# scripting feature, kept optional so the default build stays light.
+rhai = { version = "1.25", optional = true }
+
 tracing = "0.1"
+
+[features]
+rhai = ["dep:rhai"]
 
 [dev-dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
@@ -42,7 +49,8 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista-factory = { version = "0.6", path = "../vantage-vista-factory" }
 # Styled table output for the `fifo_cli` example.
 vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
-tokio = { version = "1", features = ["full"] }
+# `test-util` for the paused-clock latency/offline/cursor-expiry tests.
+tokio = { version = "1", features = ["full", "test-util"] }
 tempfile = "3"
 cucumber = { version = "0.21", default-features = false, features = ["macros"] }
 

--- a/vantage-faker/src/effect.rs
+++ b/vantage-faker/src/effect.rs
@@ -7,13 +7,15 @@
 //! match statement to edit.
 
 use std::collections::VecDeque;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use fake::Fake;
+use fake::rand::rngs::StdRng;
+use fake::rand::{RngExt as _, SeedableRng as _};
 use tokio::sync::broadcast;
 use tokio::time::{Instant, interval};
 use vantage_diorama::ChangeEvent;
@@ -21,6 +23,7 @@ use vantage_types::Record;
 use vantage_vista::mocks::MockShell;
 
 use crate::FakerColumn;
+use crate::shape::ExtraFields;
 use crate::value_gen::ValueGen;
 
 /// Shared handle an effect uses to mutate the store and broadcast deltas.
@@ -35,6 +38,12 @@ pub struct FakerCtx {
     columns: Vec<FakerColumn>,
     id_column: String,
     values: ValueGen,
+    /// Undeclared per-record payload (the fat-response personality) — see
+    /// [`ExtraFields`].
+    extra: Option<ExtraFields>,
+    /// Effect-side randomness (script `rand_*`/`pick` verbs), separate from
+    /// `values`' stream so a seed replays both independently.
+    rng: Mutex<StdRng>,
     seq: AtomicU64,
 }
 
@@ -51,12 +60,50 @@ impl FakerCtx {
             columns,
             id_column,
             values: ValueGen::new(),
+            extra: None,
+            rng: Mutex::new(crate::value_gen::entropy_rng()),
             seq: AtomicU64::new(0),
         }
     }
 
+    /// Swap in a configured generator (seeded / weird).
+    pub fn with_values(mut self, values: ValueGen) -> Self {
+        self.values = values;
+        self
+    }
+
+    /// Ride `extra.count` fields of `extra.size`-char filler on every
+    /// generated record.
+    pub fn with_extra_fields(mut self, extra: Option<ExtraFields>) -> Self {
+        self.extra = extra;
+        self
+    }
+
+    /// Seed the effect-side rng (decorrelated from the value stream).
+    pub fn with_seed(mut self, seed: Option<u64>) -> Self {
+        if let Some(seed) = seed {
+            self.rng = Mutex::new(StdRng::seed_from_u64(seed ^ 0x0EFF_EC75));
+        }
+        self
+    }
+
     fn generate(&self, id: &str) -> Record<CborValue> {
-        self.values.record_for(&self.columns, &self.id_column, id)
+        let mut rec = self.values.record_for(&self.columns, &self.id_column, id);
+        if let Some(extra) = self.extra {
+            for i in 1..=extra.count {
+                // Deterministic filler, prefixed per row/field so nothing
+                // accidentally dedups — content is irrelevant, weight is not.
+                let head = format!("{id}:{i}:");
+                let mut s = String::with_capacity(extra.size);
+                s.push_str(&head);
+                while s.len() < extra.size {
+                    s.push('x');
+                }
+                s.truncate(extra.size);
+                rec.insert(format!("extra_{i:04}"), CborValue::Text(s));
+            }
+        }
+        rec
     }
 
     /// Reverse-monotonic id: newest rows get the *smallest* key, so the cache's
@@ -98,6 +145,99 @@ impl FakerCtx {
         let _ = self
             .events
             .send(ChangeEvent::Deleted { id: id.to_string() });
+    }
+
+    // ---- Store reads + scripted mutation verbs -----------------------------
+    //
+    // The surface a scripted effect (rhai) drives: read the store, mutate it,
+    // and have every mutation broadcast the matching `ChangeEvent` — the
+    // script *is* "perform change, and it's being sent up".
+
+    /// Ids currently in the store, in store order.
+    pub fn record_ids(&self) -> Vec<String> {
+        self.shell.record_ids()
+    }
+
+    /// Snapshot one record by id.
+    pub fn get_record(&self, id: &str) -> Option<Record<CborValue>> {
+        self.shell.get_record(id)
+    }
+
+    /// Number of records currently held.
+    pub fn record_count(&self) -> usize {
+        self.shell.len()
+    }
+
+    /// Overwrite one field of an existing record and broadcast an `Updated`
+    /// carrying the full new record. No-op (and no event) if the id is gone —
+    /// a script racing an expiry must not resurrect ghosts.
+    pub fn update_field(&self, id: &str, field: &str, value: CborValue) {
+        self.shell.set_field(id, field, value);
+        if let Some(record) = self.shell.get_record(id) {
+            let _ = self.events.send(ChangeEvent::Updated {
+                id: id.to_string(),
+                new: Some(record),
+            });
+        }
+    }
+
+    /// Merge `partial` into an existing record; one `Updated` for the batch.
+    pub fn patch_record(&self, id: &str, partial: &Record<CborValue>) {
+        for (field, value) in partial {
+            self.shell.set_field(id, field, value.clone());
+        }
+        if let Some(record) = self.shell.get_record(id) {
+            let _ = self.events.send(ChangeEvent::Updated {
+                id: id.to_string(),
+                new: Some(record),
+            });
+        }
+    }
+
+    /// Insert a scripted record (id assigned, id column filled) and broadcast
+    /// an `Inserted`. Returns the new id.
+    pub fn insert_record(&self, mut record: Record<CborValue>) -> String {
+        let id = self.next_fifo_id();
+        record.insert(self.id_column.clone(), CborValue::Text(id.clone()));
+        self.shell.set_record(&id, record.clone());
+        let _ = self.events.send(ChangeEvent::Inserted {
+            id: id.clone(),
+            new: Some(record),
+        });
+        id
+    }
+
+    /// One value in the style of [`ValueGen`] — `kind` matched as a column
+    /// name first, then as a type.
+    pub fn fake_value(&self, kind: &str) -> CborValue {
+        self.values.value_for(&FakerColumn {
+            name: kind.to_string(),
+            ty: kind.to_string(),
+            flags: vec![],
+        })
+    }
+
+    /// Inclusive integer draw from the effect-side rng.
+    pub fn rand_int(&self, lo: i64, hi: i64) -> i64 {
+        let hi = hi.max(lo);
+        self.rng.lock().unwrap().random_range(lo..=hi)
+    }
+
+    /// Draw from `[lo, hi)` on the effect-side rng.
+    pub fn rand_float(&self, lo: f64, hi: f64) -> f64 {
+        if hi <= lo {
+            return lo;
+        }
+        self.rng.lock().unwrap().random_range(lo..hi)
+    }
+
+    /// Index draw for a `pick` over `len` items. `None` when empty.
+    pub fn rand_index(&self, len: usize) -> Option<usize> {
+        if len == 0 {
+            None
+        } else {
+            Some(self.rng.lock().unwrap().random_range(0..len))
+        }
     }
 }
 

--- a/vantage-faker/src/lib.rs
+++ b/vantage-faker/src/lib.rs
@@ -18,6 +18,9 @@
 pub mod effect;
 pub mod live_folder;
 pub mod pulse;
+#[cfg(feature = "rhai")]
+pub mod rhai_effect;
+pub mod shape;
 pub mod value_gen;
 
 use tokio::sync::broadcast;
@@ -25,12 +28,19 @@ use tokio::task::JoinHandle;
 use vantage_diorama::ChangeEvent;
 use vantage_vista::Vista;
 use vantage_vista::mocks::MockShell;
+// `clone_shell` on the seeded store, in `build_shaped`.
+use vantage_vista::source::TableShell as _;
 
 pub use effect::{FakerCtx, FakerEffect, FifoEffect, StaticEffect};
 pub use live_folder::{
     EVENT_TYPES, Entry, EntryKind, LiveFolderConfig, LiveFolderSim, PushMode, format_ts,
 };
 pub use pulse::{PulseConfig, PulseKey, PulseRole, PulseSim};
+#[cfg(feature = "rhai")]
+pub use rhai_effect::RhaiEffect;
+pub use shape::{
+    BackendShape, ExtraFields, FaultSchedule, Latency, LatencyModel, Offline, ShapedShell,
+};
 pub use value_gen::ValueGen;
 
 /// One column of a faker table: a name, a declared type, and free-form flags
@@ -85,6 +95,54 @@ impl FakerTable {
         effect.seed(&ctx);
 
         let vista = Vista::new(name, Box::new(shell));
+
+        let task = effect.is_live().then(|| {
+            AbortOnDrop(tokio::spawn(async move {
+                effect.run(ctx).await;
+            }))
+        });
+
+        Self {
+            vista,
+            events,
+            _task: task,
+        }
+    }
+
+    /// [`build`](Self::build) with a [`BackendShape`]: the store is the same,
+    /// but the Vista reads it through a [`ShapedShell`] enforcing the shape's
+    /// capabilities, latency and faults. The shape's `seed`/`weirdness`/
+    /// `extra_fields` configure generation, so one struct is the whole
+    /// backend personality.
+    pub fn build_shaped(
+        name: impl Into<String>,
+        columns: Vec<FakerColumn>,
+        id_column: impl Into<String>,
+        effect: Box<dyn FakerEffect>,
+        shape: BackendShape,
+    ) -> Self {
+        let shell = MockShell::new();
+        let (events, _) = broadcast::channel(EVENT_CAPACITY);
+
+        let values = match shape.seed {
+            Some(seed) => ValueGen::seeded(seed),
+            None => ValueGen::new(),
+        }
+        .with_weirdness(shape.weirdness);
+
+        let ctx = std::sync::Arc::new(
+            FakerCtx::new(shell.clone(), events.clone(), columns, id_column.into())
+                .with_values(values)
+                .with_extra_fields(shape.extra_fields)
+                .with_seed(shape.seed),
+        );
+
+        effect.seed(&ctx);
+
+        let inner = shell
+            .clone_shell()
+            .expect("MockShell::clone_shell always succeeds");
+        let vista = Vista::new(name, Box::new(ShapedShell::new(inner, shape)));
 
         let task = effect.is_live().then(|| {
             AbortOnDrop(tokio::spawn(async move {

--- a/vantage-faker/src/rhai_effect.rs
+++ b/vantage-faker/src/rhai_effect.rs
@@ -1,0 +1,351 @@
+//! Scripted mutation — a [`FakerEffect`] whose behavior is a Rhai script.
+//!
+//! The script runs once per `interval` tick against the shared store, with a
+//! `tick` counter in scope. Every mutation verb writes the store **and**
+//! broadcasts the matching `ChangeEvent`, so the script literally is
+//! "perform change, and it's being sent up". Seeding stays declarative
+//! (`count` rows via `ValueGen` before the loop starts) — scripts describe
+//! only *change*.
+//!
+//! Verbs: `ids()`, `get(id)`, `count()` read the store; `set(id, field, v)`,
+//! `patch(id, #{…})`, `insert(#{…})`, `delete(id)` mutate and broadcast;
+//! `fake(kind)`, `rand_int(a,b)`, `rand_float(a,b)`, `pick(array)` generate.
+//!
+//! A Rhai `Engine` is not `Send`, so each tick's evaluation runs inside
+//! `spawn_blocking` with a fresh engine — for the scripts these scenarios
+//! carry (a handful of statements at ≤50 ticks/s) construction cost is
+//! noise. A script that fails stops the loop after logging once: a static
+//! script that failed will fail every tick, and a sim whose data stops
+//! moving is a louder, cheaper signal than an error log at 50 Hz.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use rhai::{Dynamic, Engine, Map as RhaiMap};
+use tokio::time::interval;
+use vantage_types::Record;
+
+use crate::effect::{FakerCtx, FakerEffect};
+
+/// Seed `count` rows, then run `script` every `interval`.
+pub struct RhaiEffect {
+    pub count: usize,
+    pub interval: Duration,
+    pub script: String,
+}
+
+#[async_trait]
+impl FakerEffect for RhaiEffect {
+    fn seed(&self, ctx: &FakerCtx) {
+        for _ in 0..self.count {
+            ctx.seed_one();
+        }
+    }
+
+    fn is_live(&self) -> bool {
+        true
+    }
+
+    async fn run(&self, ctx: Arc<FakerCtx>) {
+        let mut ticker = interval(self.interval);
+        let mut tick: i64 = 0;
+        loop {
+            ticker.tick().await;
+            let script = self.script.clone();
+            let tick_ctx = ctx.clone();
+            let result =
+                tokio::task::spawn_blocking(move || run_tick(&tick_ctx, &script, tick)).await;
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::error!(error = %e, tick, "rhai faker effect failed; stopping its mutation loop");
+                    return;
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, tick, "rhai faker effect panicked; stopping its mutation loop");
+                    return;
+                }
+            }
+            tick += 1;
+        }
+    }
+}
+
+/// One evaluation: fresh engine, verbs bound to `ctx`, `tick` in scope.
+fn run_tick(ctx: &Arc<FakerCtx>, script: &str, tick: i64) -> std::result::Result<(), String> {
+    let mut engine = Engine::new();
+    register_verbs(&mut engine, ctx);
+    let mut scope = rhai::Scope::new();
+    scope.push("tick", tick);
+    engine
+        .run_with_scope(&mut scope, script)
+        .map_err(|e| e.to_string())
+}
+
+fn register_verbs(engine: &mut Engine, ctx: &Arc<FakerCtx>) {
+    let c = ctx.clone();
+    engine.register_fn("ids", move || -> rhai::Array {
+        c.record_ids().into_iter().map(Dynamic::from).collect()
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("get", move |id: &str| -> Dynamic {
+        match c.get_record(id) {
+            Some(rec) => Dynamic::from_map(record_to_map(&rec)),
+            None => Dynamic::UNIT,
+        }
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("count", move || -> i64 { c.record_count() as i64 });
+
+    let c = ctx.clone();
+    engine.register_fn("set", move |id: &str, field: &str, value: Dynamic| {
+        c.update_field(id, field, dynamic_to_cbor(&value));
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("patch", move |id: &str, map: RhaiMap| {
+        c.patch_record(id, &map_to_record(&map));
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("insert", move |map: RhaiMap| -> String {
+        c.insert_record(map_to_record(&map))
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("delete", move |id: &str| {
+        c.expire(id);
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("fake", move |kind: &str| -> Dynamic {
+        cbor_to_dynamic(&c.fake_value(kind))
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("rand_int", move |lo: i64, hi: i64| -> i64 { c.rand_int(lo, hi) });
+
+    let c = ctx.clone();
+    engine.register_fn("rand_float", move |lo: f64, hi: f64| -> f64 {
+        c.rand_float(lo, hi)
+    });
+
+    let c = ctx.clone();
+    engine.register_fn("pick", move |arr: rhai::Array| -> Dynamic {
+        match c.rand_index(arr.len()) {
+            Some(ix) => arr[ix].clone(),
+            None => Dynamic::UNIT,
+        }
+    });
+}
+
+// ---- Value round-tripping (the scalar subset scripts touch) ---------------
+
+fn dynamic_to_cbor(v: &Dynamic) -> CborValue {
+    if v.is_unit() {
+        CborValue::Null
+    } else if let Ok(i) = v.as_int() {
+        CborValue::Integer(i.into())
+    } else if let Ok(f) = v.as_float() {
+        CborValue::Float(f)
+    } else if let Ok(b) = v.as_bool() {
+        CborValue::Bool(b)
+    } else {
+        CborValue::Text(v.to_string())
+    }
+}
+
+fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
+    match v {
+        CborValue::Text(s) => Dynamic::from(s.clone()),
+        CborValue::Integer(i) => Dynamic::from(i128::from(*i) as i64),
+        CborValue::Float(f) => Dynamic::from(*f),
+        CborValue::Bool(b) => Dynamic::from(*b),
+        CborValue::Null => Dynamic::UNIT,
+        other => Dynamic::from(format!("{other:?}")),
+    }
+}
+
+fn record_to_map(rec: &Record<CborValue>) -> RhaiMap {
+    rec.iter()
+        .map(|(k, v)| (k.as_str().into(), cbor_to_dynamic(v)))
+        .collect()
+}
+
+fn map_to_record(map: &RhaiMap) -> Record<CborValue> {
+    let mut rec = Record::new();
+    for (k, v) in map {
+        rec.insert(k.to_string(), dynamic_to_cbor(v));
+    }
+    rec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::broadcast;
+    use vantage_diorama::ChangeEvent;
+    use vantage_vista::mocks::MockShell;
+
+    use crate::FakerColumn;
+    use crate::value_gen::ValueGen;
+
+    fn ctx() -> (Arc<FakerCtx>, broadcast::Receiver<ChangeEvent>) {
+        let (tx, rx) = broadcast::channel(256);
+        let columns = vec![
+            FakerColumn {
+                name: "id".into(),
+                ty: "string".into(),
+                flags: vec!["id".into()],
+            },
+            FakerColumn {
+                name: "name".into(),
+                ty: "string".into(),
+                flags: vec![],
+            },
+            FakerColumn {
+                name: "balance".into(),
+                ty: "money".into(),
+                flags: vec![],
+            },
+        ];
+        let ctx = Arc::new(
+            FakerCtx::new(MockShell::new(), tx, columns, "id".into())
+                .with_values(ValueGen::seeded(1))
+                .with_seed(Some(1)),
+        );
+        (ctx, rx)
+    }
+
+    fn drain(rx: &mut broadcast::Receiver<ChangeEvent>) -> Vec<ChangeEvent> {
+        let mut out = Vec::new();
+        while let Ok(e) = rx.try_recv() {
+            out.push(e);
+        }
+        out
+    }
+
+    #[test]
+    fn title_flip_script_updates_and_broadcasts() {
+        let (ctx, mut rx) = ctx();
+        for _ in 0..3 {
+            ctx.seed_one();
+        }
+        let script = r#"
+            let id = pick(ids());
+            let n = get(id).name;
+            set(id, "name", if tick % 2 == 0 { n.to_upper() } else { n.to_lower() });
+        "#;
+        run_tick(&ctx, script, 0).unwrap();
+        let events = drain(&mut rx);
+        assert_eq!(events.len(), 1);
+        let ChangeEvent::Updated { id, new } = &events[0] else {
+            panic!("expected Updated, got {:?}", events[0]);
+        };
+        let name = match new.as_ref().unwrap().get("name").unwrap() {
+            CborValue::Text(s) => s.clone(),
+            other => panic!("expected text name, got {other:?}"),
+        };
+        assert_eq!(name, name.to_uppercase(), "tick 0 upper-cases");
+        assert!(ctx.get_record(id).is_some());
+    }
+
+    #[test]
+    fn revolving_script_holds_population_steady() {
+        let (ctx, mut rx) = ctx();
+        for _ in 0..10 {
+            ctx.seed_one();
+        }
+        let script = r#"
+            if count() > 10 { delete(pick(ids())) };
+            insert(#{ name: fake("name"), balance: rand_float(0.0, 900000.0) / 100.0 });
+        "#;
+        for tick in 0..5 {
+            run_tick(&ctx, script, tick).unwrap();
+        }
+        // 10 seeds → first tick inserts (11), later ticks delete+insert.
+        assert_eq!(ctx.record_count(), 11);
+        let events = drain(&mut rx);
+        let inserts = events
+            .iter()
+            .filter(|e| matches!(e, ChangeEvent::Inserted { .. }))
+            .count();
+        let deletes = events
+            .iter()
+            .filter(|e| matches!(e, ChangeEvent::Deleted { .. }))
+            .count();
+        assert_eq!(inserts, 5);
+        assert_eq!(deletes, 4);
+    }
+
+    #[test]
+    fn batch_patch_script_emits_one_updated_per_row() {
+        let (ctx, mut rx) = ctx();
+        for _ in 0..4 {
+            ctx.seed_one();
+        }
+        let script = r#"
+            for id in ids() {
+                patch(id, #{ balance: get(id).balance + rand_float(-5.0, 5.0) });
+            }
+        "#;
+        run_tick(&ctx, script, 0).unwrap();
+        let updates = drain(&mut rx)
+            .iter()
+            .filter(|e| matches!(e, ChangeEvent::Updated { .. }))
+            .count();
+        assert_eq!(updates, 4);
+    }
+
+    #[test]
+    fn a_broken_script_reports_not_panics() {
+        let (ctx, _rx) = ctx();
+        let err = run_tick(&ctx, "no_such_verb()", 0).unwrap_err();
+        assert!(err.contains("no_such_verb"), "error names the problem: {err}");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn live_effect_broadcasts_scripted_updates() {
+        // The full public path, like the fifo live test: build → subscribe →
+        // observe. Real (short) interval; spawn_blocking needs real threads.
+        let table = crate::FakerTable::build(
+            "scripted",
+            vec![
+                FakerColumn {
+                    name: "id".into(),
+                    ty: "string".into(),
+                    flags: vec!["id".into()],
+                },
+                FakerColumn {
+                    name: "name".into(),
+                    ty: "string".into(),
+                    flags: vec![],
+                },
+            ],
+            "id",
+            Box::new(RhaiEffect {
+                count: 2,
+                interval: Duration::from_millis(10),
+                script: r#"set(pick(ids()), "name", "ticked")"#.into(),
+            }),
+        );
+        let mut rx = table.events.subscribe();
+        let got = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match rx.recv().await {
+                    Ok(ChangeEvent::Updated { .. }) => return true,
+                    Ok(_) => continue,
+                    Err(_) => return false,
+                }
+            }
+        })
+        .await
+        .expect("expected an Updated within 2s");
+        assert!(got);
+        drop(table); // aborts the loop
+    }
+}

--- a/vantage-faker/src/shape.rs
+++ b/vantage-faker/src/shape.rs
@@ -199,6 +199,9 @@ impl ShapedShell {
     /// Pay a request's toll: scheduled outage, then latency, then the error
     /// draw — an offline backend refuses fast, a flaky one fails slowly,
     /// like their real counterparts.
+    ///
+    /// Every tolled request logs at debug under `vantage_faker::shape` —
+    /// the tap the select tester's request accounting reads.
     async fn toll(&self, class: OpClass) -> Result<()> {
         if let Some(off) = self.shape.faults.offline {
             let elapsed = self.epoch.elapsed();
@@ -323,6 +326,7 @@ impl TableShell for ShapedShell {
         &self,
         vista: &Vista,
     ) -> Result<IndexMap<String, Record<CborValue>>> {
+        tracing::debug!(target: "vantage_faker::shape", op = "list", "request");
         self.toll(OpClass::List).await?;
         self.inner.list_vista_values(vista).await
     }
@@ -332,6 +336,7 @@ impl TableShell for ShapedShell {
         vista: &Vista,
         id: &String,
     ) -> Result<Option<Record<CborValue>>> {
+        tracing::debug!(target: "vantage_faker::shape", op = "get", id = %id, "request");
         self.toll(OpClass::Get).await?;
         self.inner.get_vista_value(vista, id).await
     }
@@ -355,6 +360,7 @@ impl TableShell for ShapedShell {
             "fetch_window",
             "can_fetch_window",
         )?;
+        tracing::debug!(target: "vantage_faker::shape", op = "window", offset, limit, "request");
         self.toll(OpClass::Window).await?;
         let offset = self.skewed_offset(offset);
         self.inner.fetch_window(vista, offset, limit).await
@@ -415,6 +421,7 @@ impl TableShell for ShapedShell {
 
     async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
         self.gate(self.shape.capabilities.can_count, "get_vista_count", "can_count")?;
+        tracing::debug!(target: "vantage_faker::shape", op = "count", "request");
         self.toll(OpClass::Count).await?;
         self.lied_total(vista).await
     }

--- a/vantage-faker/src/shape.rs
+++ b/vantage-faker/src/shape.rs
@@ -1,0 +1,538 @@
+//! Backend personality: a [`TableShell`] decorator that makes an in-memory
+//! store behave like any real backend — paged or cursor-driven, sluggish or
+//! flaky, honest or lying.
+//!
+//! [`BackendShape`] is the single place a scenario's personality is written
+//! down; [`ShapedShell`] enforces it. The shell *advertises* exactly the
+//! capabilities the shape lists and *refuses* everything else through the
+//! standard [`TableShell::default_error`] discipline, so a consumer that
+//! ignores capability flags fails loudly instead of silently working against
+//! a backend that production will not provide.
+//!
+//! Everything nondeterministic (latency jitter, fault draws, boundary skew)
+//! draws from one seeded rng, so a scenario with a `seed` replays
+//! identically. Time-based behavior (the offline schedule, cursor expiry)
+//! reads the tokio clock, so tests drive it with `tokio::time::advance`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use ciborium::Value as CborValue;
+use fake::rand::rngs::StdRng;
+use fake::rand::{RngExt as _, SeedableRng as _};
+use indexmap::IndexMap;
+use tokio::time::Instant;
+use vantage_core::{Result, error};
+use vantage_types::Record;
+use vantage_vista::capabilities::VistaCapabilities;
+use vantage_vista::column::Column;
+use vantage_vista::reference::Reference;
+use vantage_vista::source::TableShell;
+use vantage_vista::Vista;
+
+/// A latency band: each request draws uniformly from `[min, max]`.
+#[derive(Clone, Copy, Debug)]
+pub struct Latency {
+    pub min: Duration,
+    pub max: Duration,
+}
+
+impl Latency {
+    pub fn fixed(d: Duration) -> Self {
+        Self { min: d, max: d }
+    }
+
+    pub fn between(min: Duration, max: Duration) -> Self {
+        Self {
+            min,
+            max: max.max(min),
+        }
+    }
+
+    fn draw(&self, rng: &mut StdRng) -> Duration {
+        if self.max <= self.min {
+            return self.min;
+        }
+        let spread = (self.max - self.min).as_millis() as u64;
+        self.min + Duration::from_millis(rng.random_range(0..=spread))
+    }
+}
+
+/// Per-operation-class latency. Absent class = instant. Real backends are
+/// asymmetric — a fast get-by-id next to a slow list is a personality, not
+/// an accident — so each class is tuned independently.
+#[derive(Clone, Debug, Default)]
+pub struct LatencyModel {
+    pub list: Option<Latency>,
+    pub get: Option<Latency>,
+    pub window: Option<Latency>,
+    pub count: Option<Latency>,
+    /// Added on top of `list`/`window` while a search filter is active —
+    /// the "search is the expensive endpoint" personality.
+    pub search_extra: Option<Latency>,
+}
+
+/// Scheduled unavailability: within every `period`, the backend is down for
+/// the final `down`. The window starts *online* so a scenario's first paint
+/// works, then the outage arrives on schedule.
+#[derive(Clone, Copy, Debug)]
+pub struct Offline {
+    pub down: Duration,
+    pub period: Duration,
+}
+
+/// The vices. All default off.
+#[derive(Clone, Debug, Default)]
+pub struct FaultSchedule {
+    /// Fraction of tolled requests failing with an injected error.
+    pub error_rate: f64,
+    pub offline: Option<Offline>,
+    /// A `fetch_next` token older than this is dead (the 410 case).
+    pub cursor_expiry: Option<Duration>,
+    /// Reported totals are off by this much from the truth (clamped ≥ 0).
+    pub total_lie: i64,
+    /// Windowed fetches occasionally shift their offset by ±1 — the
+    /// duplicate/missing row an offset-paginated API produces under churn.
+    pub boundary_skew: bool,
+}
+
+/// Undeclared payload riding along on every record: `count` extra fields of
+/// `size`-char strings — the fat API response the query didn't ask for.
+/// Applied at generation time (see `FakerCtx`), recorded here so a shape is
+/// the complete personality description.
+#[derive(Clone, Copy, Debug)]
+pub struct ExtraFields {
+    pub count: usize,
+    pub size: usize,
+}
+
+/// The complete personality of one shaped backend.
+#[derive(Clone, Debug)]
+pub struct BackendShape {
+    /// Exactly what the backend advertises; everything else is refused.
+    pub capabilities: VistaCapabilities,
+    /// The server's page for `fetch_page`/`fetch_next` (and the starting
+    /// size where `can_set_page_size` allows negotiation).
+    pub page_size: usize,
+    pub latency: LatencyModel,
+    pub faults: FaultSchedule,
+    pub extra_fields: Option<ExtraFields>,
+    /// Fraction of generated string cells drawn from the anomaly pool.
+    pub weirdness: f64,
+    /// Deterministic replay when set — drives value generation, fault draws
+    /// and latency jitter alike.
+    pub seed: Option<u64>,
+}
+
+impl Default for BackendShape {
+    /// The classic `MockShell` profile: full CRUD, order, search, no paging,
+    /// no faults, instant.
+    fn default() -> Self {
+        Self {
+            capabilities: VistaCapabilities {
+                can_count: true,
+                can_insert: true,
+                can_update: true,
+                can_delete: true,
+                can_order: true,
+                can_search: true,
+                ..VistaCapabilities::default()
+            },
+            page_size: 25,
+            latency: LatencyModel::default(),
+            faults: FaultSchedule::default(),
+            extra_fields: None,
+            weirdness: 0.0,
+            seed: None,
+        }
+    }
+}
+
+/// Which latency band a request draws from.
+#[derive(Clone, Copy)]
+enum OpClass {
+    List,
+    Get,
+    Window,
+    Count,
+}
+
+/// [`TableShell`] decorator enforcing a [`BackendShape`] over an inner shell
+/// (in practice a `MockShell` clone sharing the effect's store).
+pub struct ShapedShell {
+    inner: Box<dyn TableShell>,
+    shape: Arc<BackendShape>,
+    /// One stream for jitter and fault draws, shared across clones so a
+    /// seeded run is a single deterministic sequence.
+    rng: Arc<Mutex<StdRng>>,
+    /// Time zero for the offline schedule and cursor-token ages.
+    epoch: Instant,
+    /// Current negotiated page size — per handle, like any query state.
+    page_size: usize,
+    /// Whether a search filter is active on THIS handle (adds
+    /// `search_extra` latency to list/window tolls). Arc'd only so `&self`
+    /// async methods can observe what `&mut self` setters flipped.
+    searching: Arc<AtomicBool>,
+}
+
+impl ShapedShell {
+    pub fn new(inner: Box<dyn TableShell>, shape: BackendShape) -> Self {
+        // Decorrelate from ValueGen's stream: same seed must not make the
+        // 3rd fault draw equal the 3rd generated cell.
+        let rng = match shape.seed {
+            Some(seed) => StdRng::seed_from_u64(seed ^ 0x5AAD_F00D_u64),
+            None => crate::value_gen::entropy_rng(),
+        };
+        let page_size = shape.page_size.max(1);
+        Self {
+            inner,
+            shape: Arc::new(shape),
+            rng: Arc::new(Mutex::new(rng)),
+            epoch: Instant::now(),
+            page_size,
+            searching: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Pay a request's toll: scheduled outage, then latency, then the error
+    /// draw — an offline backend refuses fast, a flaky one fails slowly,
+    /// like their real counterparts.
+    async fn toll(&self, class: OpClass) -> Result<()> {
+        if let Some(off) = self.shape.faults.offline {
+            let elapsed = self.epoch.elapsed();
+            let period = off.period.max(off.down);
+            let into_period =
+                Duration::from_nanos((elapsed.as_nanos() % period.as_nanos().max(1)) as u64);
+            if into_period >= period.saturating_sub(off.down) {
+                return Err(error!("shaped source is offline (scheduled outage)"));
+            }
+        }
+
+        let (delay, failed) = {
+            let rng = &mut *self.rng.lock().unwrap();
+            let band = match class {
+                OpClass::List => self.shape.latency.list,
+                OpClass::Get => self.shape.latency.get,
+                OpClass::Window => self.shape.latency.window,
+                OpClass::Count => self.shape.latency.count,
+            };
+            let mut delay = band.map(|b| b.draw(rng)).unwrap_or_default();
+            if matches!(class, OpClass::List | OpClass::Window)
+                && self.searching.load(Ordering::Relaxed)
+            {
+                if let Some(extra) = self.shape.latency.search_extra {
+                    delay += extra.draw(rng);
+                }
+            }
+            let failed = self.shape.faults.error_rate > 0.0
+                && rng.random_range(0.0..1.0) < self.shape.faults.error_rate;
+            (delay, failed)
+        };
+
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
+        if failed {
+            return Err(error!("shaped source request failed (injected fault)"));
+        }
+        Ok(())
+    }
+
+    /// Offset after the boundary-skew vice: occasionally ±1, producing the
+    /// duplicated or missing row of offset pagination under churn.
+    fn skewed_offset(&self, offset: usize) -> usize {
+        if !self.shape.faults.boundary_skew || offset == 0 {
+            return offset;
+        }
+        let draw: f64 = self.rng.lock().unwrap().random_range(0.0..1.0);
+        if draw < 0.2 {
+            offset - 1 // last row of the previous window repeats
+        } else if draw < 0.4 {
+            offset + 1 // one row is silently skipped
+        } else {
+            offset
+        }
+    }
+
+    /// Reported total = truth + the configured lie, clamped to zero.
+    async fn lied_total(&self, vista: &Vista) -> Result<i64> {
+        let truth = self.inner.get_vista_count(vista).await?;
+        Ok((truth + self.shape.faults.total_lie).max(0))
+    }
+
+    fn cursor_token(&self, offset: usize) -> CborValue {
+        CborValue::Array(vec![
+            CborValue::Integer((offset as i64).into()),
+            CborValue::Integer((self.epoch.elapsed().as_millis() as i64).into()),
+        ])
+    }
+
+    fn decode_cursor(&self, token: &CborValue) -> Result<usize> {
+        let CborValue::Array(parts) = token else {
+            return Err(error!("shaped source: malformed cursor token"));
+        };
+        let (Some(CborValue::Integer(offset)), Some(CborValue::Integer(issued_ms))) =
+            (parts.first(), parts.get(1))
+        else {
+            return Err(error!("shaped source: malformed cursor token"));
+        };
+        if let Some(expiry) = self.shape.faults.cursor_expiry {
+            let issued = Duration::from_millis(i128::from(*issued_ms).max(0) as u64);
+            if self.epoch.elapsed().saturating_sub(issued) > expiry {
+                return Err(error!("shaped source: cursor token expired"));
+            }
+        }
+        Ok(i128::from(*offset).max(0) as usize)
+    }
+
+    fn gate(&self, allowed: bool, method: &str, capability: &str) -> Result<()> {
+        if allowed {
+            Ok(())
+        } else {
+            Err(self.default_error(method, capability))
+        }
+    }
+}
+
+#[async_trait]
+#[allow(clippy::ptr_arg)]
+impl TableShell for ShapedShell {
+    fn columns(&self) -> &IndexMap<String, Column> {
+        self.inner.columns()
+    }
+
+    fn references(&self) -> &IndexMap<String, Reference> {
+        self.inner.references()
+    }
+
+    fn id_column(&self) -> Option<&str> {
+        self.inner.id_column()
+    }
+
+    fn capabilities(&self) -> &VistaCapabilities {
+        &self.shape.capabilities
+    }
+
+    fn driver_name(&self) -> &'static str {
+        "faker-shaped"
+    }
+
+    async fn list_vista_values(
+        &self,
+        vista: &Vista,
+    ) -> Result<IndexMap<String, Record<CborValue>>> {
+        self.toll(OpClass::List).await?;
+        self.inner.list_vista_values(vista).await
+    }
+
+    async fn get_vista_value(
+        &self,
+        vista: &Vista,
+        id: &String,
+    ) -> Result<Option<Record<CborValue>>> {
+        self.toll(OpClass::Get).await?;
+        self.inner.get_vista_value(vista, id).await
+    }
+
+    async fn get_vista_some_value(
+        &self,
+        vista: &Vista,
+    ) -> Result<Option<(String, Record<CborValue>)>> {
+        self.toll(OpClass::Get).await?;
+        self.inner.get_vista_some_value(vista).await
+    }
+
+    async fn fetch_window(
+        &self,
+        vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        self.gate(
+            self.shape.capabilities.can_fetch_window,
+            "fetch_window",
+            "can_fetch_window",
+        )?;
+        self.toll(OpClass::Window).await?;
+        let offset = self.skewed_offset(offset);
+        self.inner.fetch_window(vista, offset, limit).await
+    }
+
+    /// The total rides the same response envelope as the rows (no second
+    /// toll) — and only exists where the shape can count.
+    async fn fetch_window_counted(
+        &self,
+        vista: &Vista,
+        offset: usize,
+        limit: usize,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<i64>)> {
+        let rows = self.fetch_window(vista, offset, limit).await?;
+        let total = if self.shape.capabilities.can_count {
+            Some(self.lied_total(vista).await?)
+        } else {
+            None
+        };
+        Ok((rows, total))
+    }
+
+    async fn fetch_page(
+        &self,
+        vista: &Vista,
+        page: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        self.gate(
+            self.shape.capabilities.can_fetch_page,
+            "fetch_page",
+            "can_fetch_page",
+        )?;
+        self.toll(OpClass::Window).await?;
+        let offset = self.skewed_offset(page.saturating_sub(1) * self.page_size);
+        self.inner.fetch_window(vista, offset, self.page_size).await
+    }
+
+    async fn fetch_next(
+        &self,
+        vista: &Vista,
+        token: Option<CborValue>,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<CborValue>)> {
+        self.gate(
+            self.shape.capabilities.can_fetch_next,
+            "fetch_next",
+            "can_fetch_next",
+        )?;
+        self.toll(OpClass::Window).await?;
+        let offset = match &token {
+            None => 0,
+            Some(t) => self.decode_cursor(t)?,
+        };
+        let offset = self.skewed_offset(offset);
+        let rows = self.inner.fetch_window(vista, offset, self.page_size).await?;
+        let next = (rows.len() == self.page_size).then(|| self.cursor_token(offset + rows.len()));
+        Ok((rows, next))
+    }
+
+    async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
+        self.gate(self.shape.capabilities.can_count, "get_vista_count", "can_count")?;
+        self.toll(OpClass::Count).await?;
+        self.lied_total(vista).await
+    }
+
+    // ---- Writes: forwarded when advertised, no toll — the scenarios stress
+    // the read path; write latency is a personality nobody asked for yet.
+
+    async fn insert_vista_value(
+        &self,
+        vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        self.gate(self.shape.capabilities.can_insert, "insert_vista_value", "can_insert")?;
+        self.inner.insert_vista_value(vista, id, record).await
+    }
+
+    async fn replace_vista_value(
+        &self,
+        vista: &Vista,
+        id: &String,
+        record: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        self.gate(self.shape.capabilities.can_update, "replace_vista_value", "can_update")?;
+        self.inner.replace_vista_value(vista, id, record).await
+    }
+
+    async fn patch_vista_value(
+        &self,
+        vista: &Vista,
+        id: &String,
+        partial: &Record<CborValue>,
+    ) -> Result<Record<CborValue>> {
+        self.gate(self.shape.capabilities.can_update, "patch_vista_value", "can_update")?;
+        self.inner.patch_vista_value(vista, id, partial).await
+    }
+
+    async fn delete_vista_value(&self, vista: &Vista, id: &String) -> Result<()> {
+        self.gate(self.shape.capabilities.can_delete, "delete_vista_value", "can_delete")?;
+        self.inner.delete_vista_value(vista, id).await
+    }
+
+    async fn delete_vista_all_values(&self, vista: &Vista) -> Result<()> {
+        self.gate(
+            self.shape.capabilities.can_delete,
+            "delete_vista_all_values",
+            "can_delete",
+        )?;
+        self.inner.delete_vista_all_values(vista).await
+    }
+
+    async fn insert_vista_return_id_value(
+        &self,
+        vista: &Vista,
+        record: &Record<CborValue>,
+    ) -> Result<String> {
+        self.gate(
+            self.shape.capabilities.can_insert,
+            "insert_vista_return_id_value",
+            "can_insert",
+        )?;
+        self.inner.insert_vista_return_id_value(vista, record).await
+    }
+
+    // ---- Query state ------------------------------------------------------
+
+    fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
+        // Equality push-down is universal — not gated, per the capability
+        // contract.
+        self.inner.add_eq_condition(field, value)
+    }
+
+    fn add_search(&mut self, text: &str) -> Result<()> {
+        self.gate(self.shape.capabilities.can_search, "add_search", "can_search")?;
+        self.inner.add_search(text)?;
+        self.searching.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn clear_search(&mut self) -> Result<()> {
+        self.gate(self.shape.capabilities.can_search, "clear_search", "can_search")?;
+        self.inner.clear_search()?;
+        self.searching.store(false, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn add_order(&mut self, field: &str, dir: vantage_vista::sort::SortDirection) -> Result<()> {
+        self.gate(self.shape.capabilities.can_order, "add_order", "can_order")?;
+        self.inner.add_order(field, dir)
+    }
+
+    fn clear_orders(&mut self) -> Result<()> {
+        self.gate(self.shape.capabilities.can_order, "clear_orders", "can_order")?;
+        self.inner.clear_orders()
+    }
+
+    fn set_page_size(&mut self, size: usize) -> Result<()> {
+        self.gate(
+            self.shape.capabilities.can_set_page_size,
+            "set_page_size",
+            "can_set_page_size",
+        )?;
+        self.page_size = size.max(1);
+        Ok(())
+    }
+
+    /// Same store and fault/jitter stream, fresh query state — the clone a
+    /// consumer narrows (`add_order` + `fetch_window`) without disturbing
+    /// this handle. Each clone tracks its own `searching`.
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        let inner = self.inner.clone_shell()?;
+        Some(Box::new(Self {
+            inner,
+            shape: self.shape.clone(),
+            rng: self.rng.clone(),
+            epoch: self.epoch,
+            page_size: self.page_size,
+            searching: Arc::new(AtomicBool::new(false)),
+        }))
+    }
+}

--- a/vantage-faker/src/value_gen.rs
+++ b/vantage-faker/src/value_gen.rs
@@ -4,6 +4,13 @@
 //! (an `email` column gets a real email, `city` a city, …), then fall back to
 //! the declared *type*. All values come from the third-party `fake` crate — we
 //! never hand-maintain name lists.
+//!
+//! The generator owns its rng. [`ValueGen::new`] seeds from the OS (the
+//! classic behavior); [`ValueGen::seeded`] makes every draw a pure function
+//! of the seed, so a scenario replays identically — the property the shaped
+//! backends and their tests depend on.
+
+use std::sync::{Arc, Mutex};
 
 use ciborium::Value as CborValue;
 use fake::Fake;
@@ -13,90 +20,160 @@ use fake::faker::internet::en::{SafeEmail, Username};
 use fake::faker::lorem::en::Word;
 use fake::faker::name::en::{FirstName, LastName, Name};
 use fake::faker::phone_number::en::PhoneNumber;
+use fake::rand::rngs::StdRng;
+use fake::rand::{RngExt as _, SeedableRng as _};
 use vantage_types::Record;
 
 use crate::FakerColumn;
 
-/// Stateless generator — every call draws fresh values from `fake`'s thread rng.
-#[derive(Clone, Default)]
-pub struct ValueGen;
+/// Rows this fraction of `record_for` calls draw a value from the anomaly
+/// pool instead of the realistic generator — see [`ValueGen::with_weirdness`].
+const ANOMALIES: [&str; 4] = ["long", "blank", "duplicate", "unicode"];
+
+/// A fresh rng seeded from the thread rng — the "no seed given" path.
+pub(crate) fn entropy_rng() -> StdRng {
+    StdRng::seed_from_u64(fake::rand::random())
+}
+
+/// Column-aware value generator with an owned, optionally-seeded rng.
+#[derive(Clone)]
+pub struct ValueGen {
+    /// Shared across clones so a table's seed produces ONE deterministic
+    /// stream regardless of how many handles draw from it.
+    rng: Arc<Mutex<StdRng>>,
+    /// Fraction of string cells drawn from the anomaly pool (0.0 = never).
+    weirdness: f64,
+}
+
+impl Default for ValueGen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl ValueGen {
+    /// Entropy-seeded: fresh values every run, like the thread-rng original.
     pub fn new() -> Self {
-        Self
+        Self {
+            rng: Arc::new(Mutex::new(entropy_rng())),
+            weirdness: 0.0,
+        }
+    }
+
+    /// Deterministic: every draw is a pure function of `seed`.
+    pub fn seeded(seed: u64) -> Self {
+        Self {
+            rng: Arc::new(Mutex::new(StdRng::seed_from_u64(seed))),
+            weirdness: 0.0,
+        }
+    }
+
+    /// Make this fraction of string cells anomalous: ~200-char labels, blank
+    /// titles, a fixed duplicate name, unicode/emoji. Rendering oddities then
+    /// appear *somewhere* in any big list without a dedicated fixture table.
+    pub fn with_weirdness(mut self, weirdness: f64) -> Self {
+        self.weirdness = weirdness.clamp(0.0, 1.0);
+        self
     }
 
     /// Generate a single value appropriate for `col`, name-pattern first.
     pub fn value_for(&self, col: &FakerColumn) -> CborValue {
+        let rng = &mut *self.rng.lock().unwrap();
+        Self::value_for_with(rng, col)
+    }
+
+    fn value_for_with(rng: &mut StdRng, col: &FakerColumn) -> CborValue {
         let name = col.name.to_lowercase();
 
         // --- name-aware ------------------------------------------------------
         if name.contains("email") {
-            return CborValue::Text(SafeEmail().fake());
+            return CborValue::Text(SafeEmail().fake_with_rng(rng));
         }
         if name.contains("first") && name.contains("name") {
-            return CborValue::Text(FirstName().fake());
+            return CborValue::Text(FirstName().fake_with_rng(rng));
         }
         if name.contains("last") && name.contains("name") || name.contains("surname") {
-            return CborValue::Text(LastName().fake());
+            return CborValue::Text(LastName().fake_with_rng(rng));
         }
         if name.contains("username") || name.contains("login") || name.contains("handle") {
-            return CborValue::Text(Username().fake());
+            return CborValue::Text(Username().fake_with_rng(rng));
         }
         if name.contains("name") {
-            return CborValue::Text(Name().fake());
+            return CborValue::Text(Name().fake_with_rng(rng));
         }
         if name.contains("phone") || name.contains("mobile") || name.contains("tel") {
-            return CborValue::Text(PhoneNumber().fake());
+            return CborValue::Text(PhoneNumber().fake_with_rng(rng));
         }
         if name.contains("city") {
-            return CborValue::Text(CityName().fake());
+            return CborValue::Text(CityName().fake_with_rng(rng));
         }
         if name.contains("country") {
-            return CborValue::Text(CountryName().fake());
+            return CborValue::Text(CountryName().fake_with_rng(rng));
         }
         if name.contains("street") || name.contains("address") {
-            return CborValue::Text(StreetName().fake());
+            return CborValue::Text(StreetName().fake_with_rng(rng));
         }
         if name.contains("company") || name.contains("employer") || name.contains("organization") {
-            return CborValue::Text(CompanyName().fake());
+            return CborValue::Text(CompanyName().fake_with_rng(rng));
         }
 
         // --- type fallback ---------------------------------------------------
-        self.value_by_type(&col.ty)
+        Self::value_by_type(rng, &col.ty)
     }
 
-    fn value_by_type(&self, ty: &str) -> CborValue {
+    fn value_by_type(rng: &mut StdRng, ty: &str) -> CborValue {
         match ty.trim().to_lowercase().as_str() {
             "int" | "integer" | "number" | "i64" | "bigint" => {
-                let n: i64 = (0..10_000).fake();
+                let n: i64 = (0..10_000).fake_with_rng(rng);
                 CborValue::Integer(n.into())
             }
             "decimal" | "float" | "double" | "money" | "amount" | "f64" => {
                 // two-decimal money-like value without a float-formatting dep
-                let cents: i64 = (0..1_000_000).fake();
+                let cents: i64 = (0..1_000_000).fake_with_rng(rng);
                 CborValue::Float(cents as f64 / 100.0)
             }
-            "bool" | "boolean" => CborValue::Bool(fake::Faker.fake()),
+            "bool" | "boolean" => CborValue::Bool(fake::Faker.fake_with_rng(rng)),
             "datetime" | "date" | "timestamp" => {
                 // avoid a wall-clock / chrono dependency — vary a plausible ISO string
-                let day: u8 = (1..=28).fake();
-                let hour: u8 = (0..24).fake();
+                let day: u8 = (1..=28).fake_with_rng(rng);
+                let hour: u8 = (0..24).fake_with_rng(rng);
                 CborValue::Text(format!("2026-01-{day:02}T{hour:02}:00:00Z"))
             }
             // string and anything unknown
-            _ => CborValue::Text(Word().fake()),
+            _ => CborValue::Text(Word().fake_with_rng(rng)),
         }
     }
 
+    /// One draw from the anomaly pool — always a string, because the pool
+    /// exists to stress *label rendering*.
+    fn anomaly(rng: &mut StdRng) -> CborValue {
+        let kind = ANOMALIES[rng.random_range(0..ANOMALIES.len())];
+        CborValue::Text(match kind {
+            "long" => {
+                let mut s = String::with_capacity(210);
+                while s.len() < 200 {
+                    let w: String = Word().fake_with_rng(rng);
+                    s.push_str(&w);
+                    s.push(' ');
+                }
+                s
+            }
+            "blank" => String::new(),
+            "duplicate" => "John Smith".to_string(),
+            _ => "Žofia 🌸 Ōkami".to_string(),
+        })
+    }
+
     /// Build a full record for `id`, filling every column. The id column is set
-    /// to `id` verbatim; all others are generated.
+    /// to `id` verbatim; all others are generated — each string cell standing a
+    /// `weirdness` chance of drawing from the anomaly pool instead.
     pub fn record_for(
         &self,
         columns: &[FakerColumn],
         id_column: &str,
         id: &str,
     ) -> Record<CborValue> {
+        let rng = &mut *self.rng.lock().unwrap();
         let mut rec = Record::new();
         let mut wrote_id = false;
         for col in columns {
@@ -104,7 +181,14 @@ impl ValueGen {
                 rec.insert(col.name.clone(), CborValue::Text(id.to_string()));
                 wrote_id = true;
             } else {
-                rec.insert(col.name.clone(), self.value_for(col));
+                let mut value = Self::value_for_with(rng, col);
+                if self.weirdness > 0.0
+                    && matches!(value, CborValue::Text(_))
+                    && rng.random_range(0.0..1.0) < self.weirdness
+                {
+                    value = Self::anomaly(rng);
+                }
+                rec.insert(col.name.clone(), value);
             }
         }
         if !wrote_id {
@@ -176,5 +260,50 @@ mod tests {
         assert_eq!(rec.get("id"), Some(&CborValue::Text("abc".into())));
         assert!(text(rec.get("email").unwrap()).contains('@'));
         assert!(matches!(rec.get("age"), Some(CborValue::Integer(_))));
+    }
+
+    #[test]
+    fn same_seed_replays_the_same_records() {
+        let cols = [col("id", "string"), col("name", "string"), col("age", "int")];
+        let a: Vec<_> = {
+            let g = ValueGen::seeded(42);
+            (0..5).map(|i| g.record_for(&cols, "id", &i.to_string())).collect()
+        };
+        let b: Vec<_> = {
+            let g = ValueGen::seeded(42);
+            (0..5).map(|i| g.record_for(&cols, "id", &i.to_string())).collect()
+        };
+        assert_eq!(a, b, "a seed is a promise");
+    }
+
+    #[test]
+    fn weirdness_one_makes_every_string_cell_anomalous() {
+        let g = ValueGen::seeded(7).with_weirdness(1.0);
+        let cols = [col("id", "string"), col("name", "string")];
+        let anomalies: Vec<String> = (0..40)
+            .map(|i| text(g.record_for(&cols, "id", &i.to_string()).get("name").unwrap()).to_string())
+            .collect();
+        // Every value came from the pool: blank, John Smith, unicode, or long.
+        for v in &anomalies {
+            let from_pool = v.is_empty()
+                || v == "John Smith"
+                || v.contains('Ž')
+                || v.len() >= 200;
+            assert!(from_pool, "unexpected non-anomalous value {v:?}");
+        }
+        // And the pool cycles — more than one kind appears over 40 draws.
+        assert!(anomalies.iter().any(|v| v.is_empty()));
+        assert!(anomalies.iter().any(|v| v.len() >= 200));
+    }
+
+    #[test]
+    fn weirdness_zero_never_draws_anomalies() {
+        let g = ValueGen::seeded(7);
+        let cols = [col("id", "string"), col("name", "string")];
+        for i in 0..40 {
+            let rec = g.record_for(&cols, "id", &i.to_string());
+            let v = text(rec.get("name").unwrap()).to_string();
+            assert!(!v.is_empty() && v != "John Smith" && v.len() < 200, "anomaly leaked: {v:?}");
+        }
     }
 }

--- a/vantage-faker/tests/shaped_backends.rs
+++ b/vantage-faker/tests/shaped_backends.rs
@@ -1,0 +1,321 @@
+//! The `ShapedShell` contract: a shape's capabilities are enforced, its
+//! pagination styles serve the same store, its faults fire on schedule, and
+//! a seed replays the whole personality deterministically.
+
+use std::time::Duration;
+
+use ciborium::Value as CborValue;
+use vantage_dataset::prelude::ReadableValueSet as _;
+use vantage_faker::{
+    BackendShape, ExtraFields, FakerColumn, FakerTable, FaultSchedule, Latency, LatencyModel,
+    Offline, StaticEffect,
+};
+use vantage_vista::VistaCapabilities;
+
+fn columns() -> Vec<FakerColumn> {
+    vec![
+        FakerColumn {
+            name: "id".into(),
+            ty: "string".into(),
+            flags: vec!["id".into()],
+        },
+        FakerColumn {
+            name: "name".into(),
+            ty: "string".into(),
+            flags: vec![],
+        },
+        FakerColumn {
+            name: "surname".into(),
+            ty: "string".into(),
+            flags: vec![],
+        },
+        FakerColumn {
+            name: "age".into(),
+            ty: "int".into(),
+            flags: vec![],
+        },
+        FakerColumn {
+            name: "balance".into(),
+            ty: "money".into(),
+            flags: vec![],
+        },
+    ]
+}
+
+fn windowed_caps() -> VistaCapabilities {
+    VistaCapabilities {
+        can_count: true,
+        can_fetch_window: true,
+        can_order: true,
+        ..VistaCapabilities::default()
+    }
+}
+
+fn shaped(count: usize, shape: BackendShape) -> FakerTable {
+    FakerTable::build_shaped(
+        "shaped",
+        columns(),
+        "id",
+        Box::new(StaticEffect { count }),
+        shape,
+    )
+}
+
+#[tokio::test]
+async fn advertised_window_serves_and_counts_with_total() {
+    let table = shaped(
+        30,
+        BackendShape {
+            capabilities: windowed_caps(),
+            seed: Some(1),
+            ..BackendShape::default()
+        },
+    );
+
+    let (rows, total) = table.vista.fetch_window_counted(5, 10).await.unwrap();
+    assert_eq!(rows.len(), 10);
+    assert_eq!(total, Some(30));
+
+    // Windows tile without overlap when no skew is configured.
+    let (next, _) = table.vista.fetch_window_counted(15, 10).await.unwrap();
+    assert!(rows.iter().all(|(id, _)| next.iter().all(|(n, _)| n != id)));
+}
+
+#[tokio::test]
+async fn unadvertised_operations_refuse_as_unsupported() {
+    let table = shaped(
+        10,
+        BackendShape {
+            capabilities: windowed_caps(), // no fetch_page, no fetch_next, no search
+            seed: Some(1),
+            ..BackendShape::default()
+        },
+    );
+
+    let page = table.vista.fetch_page(1).await;
+    assert!(page.is_err(), "fetch_page must refuse when not advertised");
+    let next = table.vista.fetch_next(None).await;
+    assert!(next.is_err(), "fetch_next must refuse when not advertised");
+
+    let caps = table.vista.capabilities();
+    assert!(!caps.can_search && !caps.can_fetch_page && !caps.can_fetch_next);
+}
+
+#[tokio::test]
+async fn cursor_pagination_walks_the_whole_set_in_fixed_pages() {
+    let table = shaped(
+        60,
+        BackendShape {
+            capabilities: VistaCapabilities {
+                can_fetch_next: true,
+                ..VistaCapabilities::default()
+            },
+            page_size: 25,
+            seed: Some(2),
+            ..BackendShape::default()
+        },
+    );
+
+    let mut token = None;
+    let mut seen = Vec::new();
+    loop {
+        let (rows, next) = table.vista.fetch_next(token).await.unwrap();
+        seen.extend(rows.into_iter().map(|(id, _)| id));
+        match next {
+            Some(t) => token = Some(t),
+            None => break,
+        }
+    }
+    assert_eq!(seen.len(), 60, "cursor walk covers every row exactly once");
+    let mut dedup = seen.clone();
+    dedup.sort();
+    dedup.dedup();
+    assert_eq!(dedup.len(), 60);
+}
+
+#[tokio::test(start_paused = true)]
+async fn expired_cursor_tokens_die() {
+    let table = shaped(
+        60,
+        BackendShape {
+            capabilities: VistaCapabilities {
+                can_fetch_next: true,
+                ..VistaCapabilities::default()
+            },
+            page_size: 25,
+            faults: FaultSchedule {
+                cursor_expiry: Some(Duration::from_secs(30)),
+                ..FaultSchedule::default()
+            },
+            seed: Some(2),
+            ..BackendShape::default()
+        },
+    );
+
+    let (_, token) = table.vista.fetch_next(None).await.unwrap();
+    let token = token.expect("more pages exist");
+
+    tokio::time::advance(Duration::from_secs(31)).await;
+    let err = table.vista.fetch_next(Some(token)).await.unwrap_err();
+    assert!(
+        err.to_string().contains("expired"),
+        "expected token expiry, got: {err}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn latency_is_paid_per_operation_class() {
+    let table = shaped(
+        10,
+        BackendShape {
+            capabilities: windowed_caps(),
+            latency: LatencyModel {
+                window: Some(Latency::fixed(Duration::from_millis(800))),
+                get: None, // instant get next to a slow window: the asymmetry
+                ..LatencyModel::default()
+            },
+            seed: Some(3),
+            ..BackendShape::default()
+        },
+    );
+
+    let started = tokio::time::Instant::now();
+    let fetched = table.vista.fetch_window(0, 5);
+    tokio::pin!(fetched);
+    // The paused clock only advances past the sleep when we let it.
+    let rows = fetched.await.unwrap();
+    assert_eq!(rows.len(), 5);
+    assert!(
+        started.elapsed() >= Duration::from_millis(800),
+        "window fetch must pay its latency toll"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn offline_windows_refuse_on_schedule() {
+    let table = shaped(
+        10,
+        BackendShape {
+            capabilities: windowed_caps(),
+            faults: FaultSchedule {
+                offline: Some(Offline {
+                    down: Duration::from_secs(10),
+                    period: Duration::from_secs(60),
+                }),
+                ..FaultSchedule::default()
+            },
+            seed: Some(4),
+            ..BackendShape::default()
+        },
+    );
+
+    // t=0: online (windows start online).
+    assert!(table.vista.fetch_window(0, 5).await.is_ok());
+
+    // t=55s: inside the final 10s of the period — down.
+    tokio::time::advance(Duration::from_secs(55)).await;
+    let err = table.vista.fetch_window(0, 5).await.unwrap_err();
+    assert!(err.to_string().contains("offline"), "got: {err}");
+
+    // t=65s: next period, online again.
+    tokio::time::advance(Duration::from_secs(10)).await;
+    assert!(table.vista.fetch_window(0, 5).await.is_ok());
+}
+
+#[tokio::test]
+async fn error_rate_one_fails_everything_and_totals_lie() {
+    let table = shaped(
+        20,
+        BackendShape {
+            capabilities: windowed_caps(),
+            faults: FaultSchedule {
+                error_rate: 1.0,
+                ..FaultSchedule::default()
+            },
+            seed: Some(5),
+            ..BackendShape::default()
+        },
+    );
+    assert!(table.vista.fetch_window(0, 5).await.is_err());
+    assert!(table.vista.list_values().await.is_err());
+
+    let honest_free = shaped(
+        20,
+        BackendShape {
+            capabilities: windowed_caps(),
+            faults: FaultSchedule {
+                total_lie: -13,
+                ..FaultSchedule::default()
+            },
+            seed: Some(5),
+            ..BackendShape::default()
+        },
+    );
+    assert_eq!(honest_free.vista.get_count().await.unwrap(), 7);
+}
+
+#[tokio::test]
+async fn extra_fields_ride_along_undeclared() {
+    let table = shaped(
+        3,
+        BackendShape {
+            extra_fields: Some(ExtraFields {
+                count: 50,
+                size: 1000,
+            }),
+            seed: Some(6),
+            ..BackendShape::default()
+        },
+    );
+    let rows = table.vista.list_values().await.unwrap();
+    let (_, rec) = rows.iter().next().unwrap();
+    // 5 declared columns + 50 riders.
+    assert_eq!(rec.len(), 55);
+    let CborValue::Text(payload) = rec.get("extra_0050").unwrap() else {
+        panic!("extra field should be text");
+    };
+    assert_eq!(payload.len(), 1000);
+}
+
+#[tokio::test]
+async fn a_seed_replays_the_same_backend() {
+    let shape = || BackendShape {
+        capabilities: windowed_caps(),
+        weirdness: 0.2,
+        seed: Some(42),
+        ..BackendShape::default()
+    };
+    let a = shaped(25, shape()).vista.list_values().await.unwrap();
+    let b = shaped(25, shape()).vista.list_values().await.unwrap();
+    assert_eq!(a, b, "same seed, same rows — a scenario replays identically");
+}
+
+#[tokio::test]
+async fn search_gates_and_narrows_when_advertised() {
+    let mut caps = windowed_caps();
+    caps.can_search = true;
+    let table = shaped(
+        40,
+        BackendShape {
+            capabilities: caps,
+            seed: Some(7),
+            ..BackendShape::default()
+        },
+    );
+
+    let all = table.vista.list_values().await.unwrap();
+    // Pick a needle from a real row so the search must hit at least once.
+    let needle = all
+        .values()
+        .find_map(|r| match r.get("name") {
+            Some(CborValue::Text(s)) if s.len() >= 3 => Some(s[..3].to_string()),
+            _ => None,
+        })
+        .expect("a generated name to search for");
+
+    let mut vista = table.vista;
+    vista.add_search(&needle).unwrap();
+    let narrowed = vista.list_values().await.unwrap();
+    assert!(!narrowed.is_empty());
+    assert!(narrowed.len() <= all.len());
+}

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.20 — 2026-07-30
+
+- `MockShell` serves windows and counts without copying the store. The obvious
+  implementations — list everything, slice; list everything, take a length —
+  copied every record per request, which on a 200k-row mock turned each "fast"
+  page into a near-second stall and drowned out the shaped faker's latency
+  knobs. Filtering and ordering now work over references; only the returned
+  window is cloned.
+- `MockShell::get_record` / `record_ids` — store-side snapshots for effects and
+  tests inspecting what they are about to mutate, bypassing conditions and the
+  `fail_reads` guard.
+
 ## 0.6.19 — 2026-07-28
 
 - Doc fix: an intra-doc link on `Vista::aggregate` spelled out a target the

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.19"
+version = "0.6.20"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -156,6 +156,20 @@ impl MockShell {
         self.len() == 0
     }
 
+    /// Snapshot one record by id, straight off the store — no conditions, no
+    /// `fail_reads` guard. Companion to the live-mutation helpers: an effect
+    /// or test reading what it is about to mutate is inspecting its own
+    /// store, not querying a source.
+    pub fn get_record(&self, id: &str) -> Option<Record<CborValue>> {
+        self.data.lock().unwrap().get(id).cloned()
+    }
+
+    /// Ids currently held, in store order. Same store-side view as
+    /// [`Self::get_record`].
+    pub fn record_ids(&self) -> Vec<String> {
+        self.data.lock().unwrap().keys().cloned().collect()
+    }
+
     /// Return `Err` while `fail_reads` is set — see [`Self::set_fail_reads`].
     fn guard_reads(&self) -> Result<()> {
         if self.fail_reads.load(Ordering::SeqCst) {

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -324,18 +324,50 @@ impl TableShell for MockShell {
     }
 
     /// Windowed read that honours the shell's current `add_order` — the mock's
-    /// analogue of a driver serving an ordered `[offset, limit)` page. Reuses
-    /// `list_vista_values` (filter + search + order) then slices, so a caller
-    /// that set an order via `add_order` gets it applied server-side. Gated by
+    /// analogue of a driver serving an ordered `[offset, limit)` page. Gated by
     /// `can_fetch_window` like every driver.
+    ///
+    /// Clones only the returned window. The obvious implementation — list
+    /// everything, then slice — copies the whole store per window, which on a
+    /// large mock (200k rows) turns every "fast" page into a near-second stall
+    /// and made the shaped-faker latency knobs meaningless. Filtering and
+    /// ordering work over references; records are cloned after the slice.
     async fn fetch_window(
         &self,
-        vista: &Vista,
+        _vista: &Vista,
         offset: usize,
         limit: usize,
     ) -> Result<Vec<(String, Record<CborValue>)>> {
-        let ordered = self.list_vista_values(vista).await?;
-        Ok(ordered.into_iter().skip(offset).take(limit).collect())
+        self.guard_reads()?;
+        let data = self.data.lock().unwrap();
+        let matches =
+            |record: &Record<CborValue>| self.matches_filters(record) && self.matches_search(record);
+        let order = self.order.lock().unwrap().clone();
+        Ok(match order {
+            Some((field, dir)) => {
+                let mut refs: Vec<(&String, &Record<CborValue>)> =
+                    data.iter().filter(|(_, r)| matches(r)).collect();
+                refs.sort_by(|a, b| {
+                    let ord = cbor_cmp(a.1.get(&field), b.1.get(&field));
+                    match dir {
+                        SortDirection::Ascending => ord,
+                        SortDirection::Descending => ord.reverse(),
+                    }
+                });
+                refs.into_iter()
+                    .skip(offset)
+                    .take(limit)
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            }
+            None => data
+                .iter()
+                .filter(|(_, r)| matches(r))
+                .skip(offset)
+                .take(limit)
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
+        })
     }
 
     /// Share the backing store, but give the copy its **own** query state
@@ -452,8 +484,18 @@ impl TableShell for MockShell {
         Ok(id)
     }
 
+    /// Count without materializing: `list_vista_values` clones every matching
+    /// record just to take a length, which turns each counted window fetch on
+    /// a large store into a full-store copy (1.8 s against a 200k-row mock).
+    /// Counting only needs the predicates.
     async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
-        Ok(self.list_vista_values(vista).await?.len() as i64)
+        let _ = vista;
+        self.guard_reads()?;
+        let data = self.data.lock().unwrap();
+        Ok(data
+            .values()
+            .filter(|record| self.matches_filters(record) && self.matches_search(record))
+            .count() as i64)
     }
 
     fn capabilities(&self) -> &VistaCapabilities {


### PR DESCRIPTION
Foundation for the backend-scenario test work (design: `vantage-ui/agents/specs/2026-07-29-faker-backend-scenarios-design.md`). The diorama debug stream (#374) stacks on this branch.

## vantage-faker

- `BackendShape` / `ShapedShell`: one struct is the whole backend personality — advertised `capabilities` (everything else refuses as unsupported), `page_size`, a per-operation-class `LatencyModel` (`list`/`get`/`window`/`count`, plus `search_extra` while a filter is active), a `FaultSchedule` (`error_rate`, scheduled `offline` windows, `cursor_expiry`, `total_lie`, `boundary_skew`), undeclared fat `extra_fields`, `weirdness` (anomaly pool for string cells), and a `seed` for deterministic replay. `FakerTable::build_shaped` reads the same store through the shaped shell.
- `RhaiEffect` (feature `rhai`): scripted mutation loop — seeds `count` rows, then runs a Rhai script per `interval` with verbs (`ids`, `get`, `set`, `patch`, `insert`, `delete`, `fake`, `rand_*`, `pick`); every mutation broadcasts its `ChangeEvent`.
- `ValueGen` gains `seeded(u64)` and `with_weirdness(f64)`; effect rng decorrelated from the value rng.
- `tracing::debug!` taps on every tolled op under `vantage_faker::shape` — the request-accounting hook.
- Tests: `tests/shaped_backends.rs` (10 paused-clock tests: window/count with totals, capability refusal, cursor walk + expiry, per-class latency, outage windows, error-rate/total lies, extra fields, seed replay, search gating).

## vantage-diorama groundwork

- `ChunkQuery` carries search through the chunk pipeline; `set_search` on sceneries (server pushdown when the master `can_search`, eager local predicate otherwise); paged search is stale-while-revalidate instead of collapsing per keystroke.
- Unknown-total windowed sources grow on scroll: viewport horizon probe for total-less paged sources, with grid-step-scroll regression test.
- Paged views seed from a warm cache and settle at once; stated grand totals persist in cache meta and restore at seed, so warm reopens get final geometry before any fetch.
- `MockShell::fetch_window`/`get_vista_count` stop cloning the whole store per window (a 200k-row mock cost ~1.8s per counted window, drowning the latency knobs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quicksearch support for table views, including filtering across text fields.
  * Added richer query handling combining search and sorting.
  * Warm cached tables now reopen with rows and totals available immediately.
  * Added configurable faker backends with latency, outages, errors, pagination, seeded data, and scripted mutations.
  * Added support for generating extra fields and controlled data anomalies.

* **Bug Fixes**
  * Improved pagination for sources without known totals, including reliable end-of-data detection.
  * Preserved search behavior through capped table views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->