### PR TITLE
fmt: apply rustfmt across the shaped-faker files

### DIFF
--- a/vantage-diorama/src/lens/mod.rs
+++ b/vantage-diorama/src/lens/mod.rs
@@ -24,11 +24,11 @@ use crate::ops::{ChangeEvent, ChangeFlash, QueryDescriptor};
 pub use activity::{Activity, ActivitySignal};
 pub use cache_backend::{CacheBackend, CacheStatus, CacheTable};
 pub use callbacks::{
-    ChunkQuery,
-    DioCallback, DioEventCallback, DioFlashCallback, DioListPageCallback, DioLoadChunkCallback,
-    DioLoadDetailCallback, DioTotalProviderCallback, LensCallbacks, boxed_dio_callback,
-    boxed_dio_event_callback, boxed_dio_flash_callback, boxed_list_page_callback,
-    boxed_load_chunk_callback, boxed_load_detail_callback, boxed_total_provider_callback,
+    ChunkQuery, DioCallback, DioEventCallback, DioFlashCallback, DioListPageCallback,
+    DioLoadChunkCallback, DioLoadDetailCallback, DioTotalProviderCallback, LensCallbacks,
+    boxed_dio_callback, boxed_dio_event_callback, boxed_dio_flash_callback,
+    boxed_list_page_callback, boxed_load_chunk_callback, boxed_load_detail_callback,
+    boxed_total_provider_callback,
 };
 pub use chunk_sink::{ChunkRow, ChunkSink, SceneryChunkTarget};
 pub use defaults::LensDefaults;

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -452,7 +452,10 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 // Single-pass paged mode only: a two-pass view's list pass
                 // enumerated the whole set — its size is knowledge, not an
                 // inference to extend.
-                if !state.two_pass && effective_len > 0 && horizon_reached && !state.total_ever_stated()
+                if !state.two_pass
+                    && effective_len > 0
+                    && horizon_reached
+                    && !state.total_ever_stated()
                 {
                     let extended = effective_range.end + effective_len;
                     tracing::debug!(

--- a/vantage-faker/src/rhai_effect.rs
+++ b/vantage-faker/src/rhai_effect.rs
@@ -127,7 +127,9 @@ fn register_verbs(engine: &mut Engine, ctx: &Arc<FakerCtx>) {
     });
 
     let c = ctx.clone();
-    engine.register_fn("rand_int", move |lo: i64, hi: i64| -> i64 { c.rand_int(lo, hi) });
+    engine.register_fn("rand_int", move |lo: i64, hi: i64| -> i64 {
+        c.rand_int(lo, hi)
+    });
 
     let c = ctx.clone();
     engine.register_fn("rand_float", move |lo: f64, hi: f64| -> f64 {
@@ -305,7 +307,10 @@ mod tests {
     fn a_broken_script_reports_not_panics() {
         let (ctx, _rx) = ctx();
         let err = run_tick(&ctx, "no_such_verb()", 0).unwrap_err();
-        assert!(err.contains("no_such_verb"), "error names the problem: {err}");
+        assert!(
+            err.contains("no_such_verb"),
+            "error names the problem: {err}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/vantage-faker/src/shape.rs
+++ b/vantage-faker/src/shape.rs
@@ -26,11 +26,11 @@ use indexmap::IndexMap;
 use tokio::time::Instant;
 use vantage_core::{Result, error};
 use vantage_types::Record;
+use vantage_vista::Vista;
 use vantage_vista::capabilities::VistaCapabilities;
 use vantage_vista::column::Column;
 use vantage_vista::reference::Reference;
 use vantage_vista::source::TableShell;
-use vantage_vista::Vista;
 
 /// A latency band: each request draws uniformly from `[min, max]`.
 #[derive(Clone, Copy, Debug)]
@@ -414,13 +414,20 @@ impl TableShell for ShapedShell {
             Some(t) => self.decode_cursor(t)?,
         };
         let offset = self.skewed_offset(offset);
-        let rows = self.inner.fetch_window(vista, offset, self.page_size).await?;
+        let rows = self
+            .inner
+            .fetch_window(vista, offset, self.page_size)
+            .await?;
         let next = (rows.len() == self.page_size).then(|| self.cursor_token(offset + rows.len()));
         Ok((rows, next))
     }
 
     async fn get_vista_count(&self, vista: &Vista) -> Result<i64> {
-        self.gate(self.shape.capabilities.can_count, "get_vista_count", "can_count")?;
+        self.gate(
+            self.shape.capabilities.can_count,
+            "get_vista_count",
+            "can_count",
+        )?;
         tracing::debug!(target: "vantage_faker::shape", op = "count", "request");
         self.toll(OpClass::Count).await?;
         self.lied_total(vista).await
@@ -435,7 +442,11 @@ impl TableShell for ShapedShell {
         id: &String,
         record: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
-        self.gate(self.shape.capabilities.can_insert, "insert_vista_value", "can_insert")?;
+        self.gate(
+            self.shape.capabilities.can_insert,
+            "insert_vista_value",
+            "can_insert",
+        )?;
         self.inner.insert_vista_value(vista, id, record).await
     }
 
@@ -445,7 +456,11 @@ impl TableShell for ShapedShell {
         id: &String,
         record: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
-        self.gate(self.shape.capabilities.can_update, "replace_vista_value", "can_update")?;
+        self.gate(
+            self.shape.capabilities.can_update,
+            "replace_vista_value",
+            "can_update",
+        )?;
         self.inner.replace_vista_value(vista, id, record).await
     }
 
@@ -455,12 +470,20 @@ impl TableShell for ShapedShell {
         id: &String,
         partial: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
-        self.gate(self.shape.capabilities.can_update, "patch_vista_value", "can_update")?;
+        self.gate(
+            self.shape.capabilities.can_update,
+            "patch_vista_value",
+            "can_update",
+        )?;
         self.inner.patch_vista_value(vista, id, partial).await
     }
 
     async fn delete_vista_value(&self, vista: &Vista, id: &String) -> Result<()> {
-        self.gate(self.shape.capabilities.can_delete, "delete_vista_value", "can_delete")?;
+        self.gate(
+            self.shape.capabilities.can_delete,
+            "delete_vista_value",
+            "can_delete",
+        )?;
         self.inner.delete_vista_value(vista, id).await
     }
 
@@ -495,14 +518,22 @@ impl TableShell for ShapedShell {
     }
 
     fn add_search(&mut self, text: &str) -> Result<()> {
-        self.gate(self.shape.capabilities.can_search, "add_search", "can_search")?;
+        self.gate(
+            self.shape.capabilities.can_search,
+            "add_search",
+            "can_search",
+        )?;
         self.inner.add_search(text)?;
         self.searching.store(true, Ordering::Relaxed);
         Ok(())
     }
 
     fn clear_search(&mut self) -> Result<()> {
-        self.gate(self.shape.capabilities.can_search, "clear_search", "can_search")?;
+        self.gate(
+            self.shape.capabilities.can_search,
+            "clear_search",
+            "can_search",
+        )?;
         self.inner.clear_search()?;
         self.searching.store(false, Ordering::Relaxed);
         Ok(())
@@ -514,7 +545,11 @@ impl TableShell for ShapedShell {
     }
 
     fn clear_orders(&mut self) -> Result<()> {
-        self.gate(self.shape.capabilities.can_order, "clear_orders", "can_order")?;
+        self.gate(
+            self.shape.capabilities.can_order,
+            "clear_orders",
+            "can_order",
+        )?;
         self.inner.clear_orders()
     }
 

--- a/vantage-faker/src/value_gen.rs
+++ b/vantage-faker/src/value_gen.rs
@@ -264,14 +264,22 @@ mod tests {
 
     #[test]
     fn same_seed_replays_the_same_records() {
-        let cols = [col("id", "string"), col("name", "string"), col("age", "int")];
+        let cols = [
+            col("id", "string"),
+            col("name", "string"),
+            col("age", "int"),
+        ];
         let a: Vec<_> = {
             let g = ValueGen::seeded(42);
-            (0..5).map(|i| g.record_for(&cols, "id", &i.to_string())).collect()
+            (0..5)
+                .map(|i| g.record_for(&cols, "id", &i.to_string()))
+                .collect()
         };
         let b: Vec<_> = {
             let g = ValueGen::seeded(42);
-            (0..5).map(|i| g.record_for(&cols, "id", &i.to_string())).collect()
+            (0..5)
+                .map(|i| g.record_for(&cols, "id", &i.to_string()))
+                .collect()
         };
         assert_eq!(a, b, "a seed is a promise");
     }
@@ -281,14 +289,18 @@ mod tests {
         let g = ValueGen::seeded(7).with_weirdness(1.0);
         let cols = [col("id", "string"), col("name", "string")];
         let anomalies: Vec<String> = (0..40)
-            .map(|i| text(g.record_for(&cols, "id", &i.to_string()).get("name").unwrap()).to_string())
+            .map(|i| {
+                text(
+                    g.record_for(&cols, "id", &i.to_string())
+                        .get("name")
+                        .unwrap(),
+                )
+                .to_string()
+            })
             .collect();
         // Every value came from the pool: blank, John Smith, unicode, or long.
         for v in &anomalies {
-            let from_pool = v.is_empty()
-                || v == "John Smith"
-                || v.contains('Ž')
-                || v.len() >= 200;
+            let from_pool = v.is_empty() || v == "John Smith" || v.contains('Ž') || v.len() >= 200;
             assert!(from_pool, "unexpected non-anomalous value {v:?}");
         }
         // And the pool cycles — more than one kind appears over 40 draws.
@@ -303,7 +315,10 @@ mod tests {
         for i in 0..40 {
             let rec = g.record_for(&cols, "id", &i.to_string());
             let v = text(rec.get("name").unwrap()).to_string();
-            assert!(!v.is_empty() && v != "John Smith" && v.len() < 200, "anomaly leaked: {v:?}");
+            assert!(
+                !v.is_empty() && v != "John Smith" && v.len() < 200,
+                "anomaly leaked: {v:?}"
+            );
         }
     }
 }

--- a/vantage-faker/tests/shaped_backends.rs
+++ b/vantage-faker/tests/shaped_backends.rs
@@ -287,7 +287,10 @@ async fn a_seed_replays_the_same_backend() {
     };
     let a = shaped(25, shape()).vista.list_values().await.unwrap();
     let b = shaped(25, shape()).vista.list_values().await.unwrap();
-    assert_eq!(a, b, "same seed, same rows — a scenario replays identically");
+    assert_eq!(
+        a, b,
+        "same seed, same rows — a scenario replays identically"
+    );
 }
 
 #[tokio::test]

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -340,8 +340,9 @@ impl TableShell for MockShell {
     ) -> Result<Vec<(String, Record<CborValue>)>> {
         self.guard_reads()?;
         let data = self.data.lock().unwrap();
-        let matches =
-            |record: &Record<CborValue>| self.matches_filters(record) && self.matches_search(record);
+        let matches = |record: &Record<CborValue>| {
+            self.matches_filters(record) && self.matches_search(record)
+        };
         let order = self.order.lock().unwrap().clone();
         Ok(match order {
             Some((field, dir)) => {


### PR DESCRIPTION
`cargo fmt --check` fails on main since #375: the shaped-faker work landed with rustfmt drift in seven files (import wrapping in diorama's lens re-exports, a multi-condition `if` in the chunk loader, and the new faker shape/rhai/value-gen modules plus the vista MockShell window fix).

No code changes — pure formatting, verified with `cargo fmt --all -- --check` clean in both the workspace and the standalone `vantage-faker` workspace.