### PR TITLE
diorama: the debug stream reads as prose; two loading faults it exposed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama-aggregate"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -13,7 +13,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-diorama = { version = "0.11", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.12", path = "../vantage-diorama" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.6 — 2026-07-30
+
+- Recompute lines render in the same shape as the rest of the diorama debug
+  stream, so a project with aggregates no longer interleaves two log grammars.
+
 ## 0.6.5 — 2026-07-30
 
 - Track vantage-diorama 0.11.

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Recompute lines render in the same shape as the rest of the diorama debug
   stream, so a project with aggregates no longer interleaves two log grammars.
+  They also use diorama's own formatters, so a recompute reports `1.5s` and
+  `200,000` instead of `1500ms` and `200000`.
 
 ## 0.6.5 — 2026-07-30
 

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama-aggregate"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Reactive client-side aggregation over a Vantage Diorama"
@@ -14,7 +14,7 @@ vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
-vantage-diorama = { version = "0.11", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.12", path = "../vantage-diorama" }
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -296,16 +296,18 @@ where
         let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
         let rows_in = rows.len();
         let rows_out = output.debug_row_count();
+        // Same shape as the diorama stream's own lines: source, tag, clause.
         tracing::info!(
             target: "vantage_diorama::debug",
-            ds = %tap.ds(),
-            aggregate = name,
-            trigger,
+            "{:<10} {:<8} \"{}\" recomputed from {} rows → {} in {}ms ({}, {})",
+            tap.ds(),
+            "derive",
+            name,
             rows_in,
             rows_out,
             ms,
-            unchanged,
-            "aggregate recompute",
+            trigger,
+            if unchanged { "unchanged" } else { "published" },
         );
     }
 

--- a/vantage-diorama-aggregate/src/engine.rs
+++ b/vantage-diorama-aggregate/src/engine.rs
@@ -296,16 +296,17 @@ where
         let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
         let rows_in = rows.len();
         let rows_out = output.debug_row_count();
-        // Same shape as the diorama stream's own lines: source, tag, clause.
+        // Same shape as the diorama stream's own lines: source, tag, clause —
+        // and the same units, through diorama's own formatters.
         tracing::info!(
             target: "vantage_diorama::debug",
-            "{:<10} {:<8} \"{}\" recomputed from {} rows → {} in {}ms ({}, {})",
+            "{:<10} {:<8} \"{}\" recomputed from {} rows → {} in {} ({}, {})",
             tap.ds(),
             "derive",
             name,
-            rows_in,
-            rows_out,
-            ms,
+            vantage_diorama::debug::num(rows_in),
+            vantage_diorama::debug::num(rows_out),
+            vantage_diorama::debug::dur(ms as u64),
             trigger,
             if unchanged { "unchanged" } else { "published" },
         );

--- a/vantage-diorama-aggregate/src/lens.rs
+++ b/vantage-diorama-aggregate/src/lens.rs
@@ -220,13 +220,13 @@ impl AggregateLens {
             let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
             tracing::info!(
                 target: "vantage_diorama::debug",
-                "{:<10} {:<8} \"{}\" recomputed from {} rows → {} in {}ms (initial, published)",
+                "{:<10} {:<8} \"{}\" recomputed from {} rows → {} in {} (initial, published)",
                 tap.ds(),
                 "derive",
                 name,
-                rows.len(),
-                initial.debug_row_count(),
-                ms,
+                vantage_diorama::debug::num(rows.len()),
+                vantage_diorama::debug::num(initial.debug_row_count()),
+                vantage_diorama::debug::dur(ms as u64),
             );
         }
 

--- a/vantage-diorama-aggregate/src/lens.rs
+++ b/vantage-diorama-aggregate/src/lens.rs
@@ -220,14 +220,13 @@ impl AggregateLens {
             let ms = start.map(|s| s.elapsed().as_millis()).unwrap_or(0);
             tracing::info!(
                 target: "vantage_diorama::debug",
-                ds = %tap.ds(),
-                aggregate = name,
-                trigger = "initial",
-                rows_in = rows.len(),
-                rows_out = initial.debug_row_count(),
+                "{:<10} {:<8} \"{}\" recomputed from {} rows → {} in {}ms (initial, published)",
+                tap.ds(),
+                "derive",
+                name,
+                rows.len(),
+                initial.debug_row_count(),
                 ms,
-                unchanged = false,
-                "aggregate recompute",
             );
         }
 

--- a/vantage-diorama-aggregate/tests/debug_tap.rs
+++ b/vantage-diorama-aggregate/tests/debug_tap.rs
@@ -119,20 +119,20 @@ async fn aggregate_recompute_line_is_inherited_from_the_source_tap() -> Result<(
         .await?;
     settle().await;
 
-    let lines = lines_containing(&log, "aggregate recompute");
+    let lines = lines_containing(&log, "recomputed from");
     assert!(!lines.is_empty(), "expected at least one recompute line");
     assert!(
         lines
             .iter()
-            .any(|l| l.contains("rows_out=") && l.contains("unchanged=false")),
+            .any(|l| l.contains("rows \u{2192}") && l.contains("published")),
         "{lines:?}"
     );
     assert!(
-        lines.iter().all(|l| l.contains("ds=agg-ds")),
+        lines.iter().all(|l| l.contains("agg-ds")),
         "every inherited line must carry the source's ds: {lines:?}"
     );
     assert!(
-        lines.iter().all(|l| l.contains("aggregate=\"by_status\"")),
+        lines.iter().all(|l| l.contains("\"by_status\"")),
         "{lines:?}"
     );
 
@@ -164,7 +164,7 @@ async fn a_non_debug_source_emits_no_aggregate_recompute_lines() -> Result<()> {
     settle().await;
 
     assert!(
-        lines_containing(&log, "aggregate recompute").is_empty(),
+        lines_containing(&log, "recomputed from").is_empty(),
         "a non-debug source must produce zero lines: {:?}",
         log.lock().unwrap()
     );
@@ -201,7 +201,7 @@ async fn nudge_trigger_is_emitted_by_a_values_local_write_through() -> Result<()
     total.request_refresh();
     settle().await;
 
-    let nudge_lines = lines_containing(&log, "trigger=\"nudge\"");
+    let nudge_lines = lines_containing(&log, "(nudge,");
     assert!(
         !nudge_lines.is_empty(),
         "expected a recompute line triggered by the local nudge: {:?}",
@@ -210,14 +210,14 @@ async fn nudge_trigger_is_emitted_by_a_values_local_write_through() -> Result<()
     assert!(
         nudge_lines
             .iter()
-            .all(|l| l.starts_with("aggregate recompute") && l.contains("aggregate=\"total\"")),
+            .all(|l| l.contains("recomputed from") && l.contains("\"total\"")),
         "{nudge_lines:?}"
     );
     // The failing refresh must not have smuggled in a DatasetChanged-
     // triggered line alongside the nudge — the whole point of the failing
     // source is to isolate the one trigger.
     assert!(
-        lines_containing(&log, "trigger=\"DatasetChanged\"").is_empty(),
+        lines_containing(&log, "(DatasetChanged,").is_empty(),
         "the refresh was made to fail precisely so it wouldn't race the nudge: {:?}",
         log.lock().unwrap()
     );

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.12.0 — 2026-07-30
+
+**The debug stream reads like a log, not a struct dump.**
+
+Every line is now `<datasource>  <tag>  <clause>` — a scannable left edge and one
+clause of plain English, with units a reader thinks in (`3.0s`, `24KB`,
+`200,000`, `0.1%`). The `tag` is the grep anchor and comes from a closed set;
+see the `debug` module docs for the vocabulary. Field-per-value output is gone.
+
+- **New lines.** A Dio announces its own creation and whether its cache table
+  starts empty. A scenery states what its source can and cannot do, and which
+  loading shape follows, once at open. A viewport reports the range a consumer
+  declared and how many scroll events the debounce absorbed into it. Sort and
+  search say whether the work was pushed to the source or done over held rows.
+- `stats::debug_summary_lines` renders in the same shape and human units, and
+  `emit_debug_summary` is now a no-op unless some datasource opted in — so an
+  embedder can call it unconditionally on the way out.
+- Request ids start at 1.
+
+**A paged view no longer keeps stale row positions across a sort change.**
+Rebuilding the index→row map from the cache placed an arbitrary subset of the
+*previous* order at rows 0..N of the new one — correct rows in wrong places,
+mixed with correctly-placed rows wherever a later fetch landed. A paged,
+single-pass view whose master orders server-side now drops its positions (the
+cached records stay) and refills the visible window. Views holding the complete
+set still sort locally, which is both right and instant.
+
 ## 0.11.0 — 2026-07-30
 
 **The official per-datasource debug stream.**

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -25,7 +25,16 @@ Rebuilding the index→row map from the cache placed an arbitrary subset of the
 mixed with correctly-placed rows wherever a later fetch landed. A paged,
 single-pass view whose master orders server-side now drops its positions (the
 cached records stay) and refills the visible window. Views holding the complete
-set still sort locally, which is both right and instant.
+set still sort locally, which is both right and instant — and "the complete set"
+is counted over the rows matching the current query, so a cache full of rows a
+search excludes cannot stand in for coverage of the narrowed one.
+
+- `debug::dur`, `bytes`, `num` and `pct` are public. The stream is a shared
+  format and `vantage-diorama-aggregate` writes into it; two crates printing the
+  same quantities two ways is what the format exists to prevent.
+- The inferred-total line is emitted only when the total moves, which is the
+  rule the stated-total line already followed. A reload that keeps landing on
+  the same short page used to repeat it once per fetch.
 
 ## 0.11.0 — 2026-07-30
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/debug.rs
+++ b/vantage-diorama/src/debug.rs
@@ -15,42 +15,39 @@
 //! cache mutation, every consumer open/close (the *census*), every status
 //! transition — attributable, correlated (`req=N`), and greppable.
 //!
-//! # Frozen message strings
+//! # Line shape
 //!
-//! These strings are a contract: downstream test harnesses grep them.
-//! Changing one is a breaking change to whatever greps it, on par with
-//! changing a public function's signature.
+//! Every line is `<datasource>  <tag>  <clause>` — a scannable left edge and
+//! one clause of plain English. Units are human (`3.0s`, `24KB`, `200,000`,
+//! `0.1%`), and a field is omitted rather than printed empty.
 //!
-//! | Message | Fields | Where |
-//! |---|---|---|
-//! | `"load dispatch"` | `req, dio, visible, effective, rows_to_fetch, already_cached, sort, search, force_load` | a viewport fetch is about to run |
-//! | `"load return"` | `req, dio, received, ms, cached_after` | that fetch came back `Ok` |
-//! | `"load failed"` | `req, dio, ms, error` | that fetch came back `Err` |
-//! | `"cache hit — viewport served locally"` | `dio, range, rows` | a viewport is fully cached; no fetch fires |
-//! | `"total"` | `dio, total, provenance` | the grand total changed; `provenance` ∈ `stated` / `short-page` / `horizon-extended` / `hole-clamped` |
-//! | `"state"` | `dio, from, to, reason` | a [`LoadState`](crate::scenery::LoadState) transition |
-//! | `"cache write"` | `dio, written, new, updated, cached_rows, known_total, cached_pct` | a load committed rows to the cache; only emitted when `written > 0` |
-//! | `"cache seed"` | `dio, mode, rows` | a scenery seeded its rows from the cache at open; `mode` ∈ `warm` / `cold` |
-//! | `"columns"` | `dio, demanded, received_count, received_sample, undemanded_count, payload_bytes, rows` | the wide-data detector — what a chunk actually carried against what was asked for |
-//! | `"census: {kind} {verb}"` | `dio, table_sceneries, record_sceneries, servos, uptime_ms, cpu_ms, peak_rss_mb` | a consumer opened or closed; `kind` ∈ `table scenery` / `record scenery` / `servo`, `verb` ∈ `opened` / `closed` |
-//! | `"list page dispatch"` | `req, dio, offset, limit, conditions, sort` | a two-pass list page is about to be fetched |
-//! | `"list page return"` | `req, rows, ms, index_len, complete` | that list page came back |
-//! | `"detail pass"` | `dio, requested, pending, already_complete` | a two-pass detail (augment) sweep queued its pending ids |
-//! | `"aggregate recompute"` | `aggregate, trigger, rows_in, rows_out, ms, unchanged` | a `vantage-diorama-aggregate` layer recomputed; `trigger` ∈ `initial` / `debounce-trailing` / `nudge` / `lagged` / a `DioEvent` variant name |
-//! | `"— diorama session summary —"` | (header, no fields) | first line of [`stats::debug_summary_lines`](crate::stats::debug_summary_lines) / [`stats::emit_debug_summary`](crate::stats::emit_debug_summary) |
+//! The **tag** is the grep anchor and comes from a closed set:
 //!
-//! A `derive()`'s first load emits two `"aggregate recompute"` lines with
-//! `trigger = "initial"`: an eager compute that seeds the derived Vista's
-//! schema (`unchanged = false`, since there is no prior output to compare
-//! against), immediately followed by the engine's own seed pass over the
-//! same rows (`unchanged = true`, since it reads the value the eager pass
-//! just published). Both are real recomputations, not a duplicate log call —
-//! the second is what proves the engine's own loop agrees with the eager
-//! pass before anything has changed.
+//! | Tag | Says |
+//! |---|---|
+//! | `dio` | a Dio was created; a fetch was asked for, came back, or failed (`fetch #N`, `list #N`) |
+//! | `source` | what the master can and cannot do, and how this view loads — once, at open |
+//! | `scenery` | a view opened; a load-state transition; row positions dropped |
+//! | `census` | a consumer attached or detached, with live counts and RSS |
+//! | `viewport` | the range a consumer declared, and how many scroll events coalesced into it |
+//! | `cache` | rows committed, or a viewport served locally with no fetch |
+//! | `payload` | columns received against columns displayed, and the bytes |
+//! | `total` | the grand total changed, and what decided it |
+//! | `sort` / `search` | the query changed, and whether it was pushed to the source |
+//! | `hydrate` | a two-pass detail sweep queued its pending ids |
+//! | `derive` | a `vantage-diorama-aggregate` layer recomputed |
+//! | `summary` | the end-of-session ledger (see [`stats::emit_debug_summary`](crate::stats::emit_debug_summary)) |
 //!
-//! `req=N` is a per-dio, monotonically increasing counter
-//! (`DioInner::next_req`) that ties a dispatch line to its matching
-//! return/failed line — only allocated when the tap is enabled.
+//! `fetch #N` / `list #N` is a per-dio counter tying a request to its outcome;
+//! it is allocated only when the tap is enabled. Lines from one load are not
+//! emitted in a fixed order — the cache commit and the state transition happen
+//! inside the operation the return line closes — so correlate on the id rather
+//! than on adjacency.
+//!
+//! A `derive()`'s first load emits two `derive` lines: an eager compute that
+//! seeds the derived Vista's schema, then the engine's own seed pass over the
+//! same rows, which reports `unchanged` because it reads what the eager pass
+//! just published. Both are real recomputations.
 
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -69,9 +66,14 @@ impl DebugTap {
         Self { ds: None }
     }
 
-    /// An enabled tap tagged with the datasource's name; every emitted
-    /// line carries it as `ds=<name>`.
+    /// An enabled tap tagged with the datasource's name; it prefixes every
+    /// line the tap emits.
     pub fn for_datasource(name: impl Into<String>) -> Self {
+        ANY_TAP_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
+        // Start the session clock here rather than at the first reader, so
+        // "session" spans the whole of the debug stream instead of beginning
+        // at whatever happened to look at it first.
+        LazyLock::force(&PROCESS_START);
         Self {
             ds: Some(Arc::from(name.into())),
         }
@@ -90,26 +92,98 @@ impl DebugTap {
 
 /// Emit one debug-stream line, only when the tap is enabled.
 ///
-/// `tapline!(tap, field = value, ..., "message")` — the target and the
-/// `ds` field are supplied here so call sites can't drift.
+/// `tapline!(tap, "tag", "clause {}", value)` renders as
+/// `<datasource>  <tag>  <clause>` — a scannable left edge (which source,
+/// which kind of event) followed by one clause of plain English. The whole
+/// invocation, arguments included, sits behind the enabled check, so a
+/// disabled tap pays for nothing it would otherwise format.
 macro_rules! tapline {
-    ($tap:expr, $($rest:tt)*) => {
+    ($tap:expr, $tag:literal, $($arg:tt)*) => {
         if $tap.enabled() {
-            tracing::info!(target: "vantage_diorama::debug", ds = %$tap.ds(), $($rest)*);
+            tracing::info!(
+                target: "vantage_diorama::debug",
+                "{:<10} {:<8} {}",
+                $tap.ds(),
+                $tag,
+                format_args!($($arg)*),
+            );
         }
     };
 }
 pub(crate) use tapline;
 
+/// A duration in the unit a reader thinks in: `840ms`, `3.0s`, `1m12s`.
+pub(crate) fn dur(ms: u64) -> String {
+    if ms < 1_000 {
+        format!("{ms}ms")
+    } else if ms < 60_000 {
+        format!("{:.1}s", ms as f64 / 1000.0)
+    } else {
+        format!("{}m{:02}s", ms / 60_000, (ms % 60_000) / 1000)
+    }
+}
+
+/// A byte count as `812B`, `24KB`, `1.2MB`.
+pub(crate) fn bytes(n: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = KB * 1024;
+    if n < KB {
+        format!("{n}B")
+    } else if n < MB {
+        format!("{}KB", n / KB)
+    } else {
+        format!("{:.1}MB", n as f64 / MB as f64)
+    }
+}
+
+/// A count with thousands separators — `200,000` reads, `200000` doesn't.
+pub(crate) fn num(n: usize) -> String {
+    let s = n.to_string();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// `held` of `total` as a percentage, precise enough to stay honest at the
+/// small end: 200 of 200,000 is `0.1%`, not `0%`.
+pub(crate) fn pct(held: usize, total: usize) -> String {
+    if total == 0 {
+        return "—".into();
+    }
+    let p = held as f64 / total as f64 * 100.0;
+    if p >= 10.0 {
+        format!("{p:.0}%")
+    } else {
+        format!("{p:.1}%")
+    }
+}
+
 /// Wall/CPU/memory snapshot for census lines and the exit summary.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ProcessStats {
-    /// Milliseconds since the first `process_stats()` call in this process.
+    /// Milliseconds since the debug stream was armed (the first
+    /// [`DebugTap::for_datasource`]), not since process start — anything
+    /// before the first datasource opted in is not measured.
     pub uptime_ms: u64,
     /// User + system CPU time consumed by the process, in milliseconds.
     pub cpu_ms: u64,
     /// Peak resident set size, in bytes. 0 where unsupported.
     pub peak_rss_bytes: u64,
+}
+
+/// Set the first time any datasource opts in. The exit summary consults it
+/// so an embedder can call `emit_debug_summary()` unconditionally on quit
+/// without printing a ledger nobody asked for.
+static ANY_TAP_ENABLED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether any datasource enabled the debug stream in this process.
+pub fn any_tap_enabled() -> bool {
+    ANY_TAP_ENABLED.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 static PROCESS_START: LazyLock<Instant> = LazyLock::new(Instant::now);

--- a/vantage-diorama/src/debug.rs
+++ b/vantage-diorama/src/debug.rs
@@ -113,7 +113,11 @@ macro_rules! tapline {
 pub(crate) use tapline;
 
 /// A duration in the unit a reader thinks in: `840ms`, `3.0s`, `1m12s`.
-pub(crate) fn dur(ms: u64) -> String {
+///
+/// Public because the stream is a shared format: a crate that writes into
+/// `vantage_diorama::debug` — `vantage-diorama-aggregate` does — has to print
+/// its numbers the same way, or the reader meets two conventions in one log.
+pub fn dur(ms: u64) -> String {
     if ms < 1_000 {
         format!("{ms}ms")
     } else if ms < 60_000 {
@@ -124,7 +128,7 @@ pub(crate) fn dur(ms: u64) -> String {
 }
 
 /// A byte count as `812B`, `24KB`, `1.2MB`.
-pub(crate) fn bytes(n: usize) -> String {
+pub fn bytes(n: usize) -> String {
     const KB: usize = 1024;
     const MB: usize = KB * 1024;
     if n < KB {
@@ -137,7 +141,7 @@ pub(crate) fn bytes(n: usize) -> String {
 }
 
 /// A count with thousands separators — `200,000` reads, `200000` doesn't.
-pub(crate) fn num(n: usize) -> String {
+pub fn num(n: usize) -> String {
     let s = n.to_string();
     let mut out = String::with_capacity(s.len() + s.len() / 3);
     for (i, c) in s.chars().enumerate() {
@@ -151,7 +155,7 @@ pub(crate) fn num(n: usize) -> String {
 
 /// `held` of `total` as a percentage, precise enough to stay honest at the
 /// small end: 200 of 200,000 is `0.1%`, not `0%`.
-pub(crate) fn pct(held: usize, total: usize) -> String {
+pub fn pct(held: usize, total: usize) -> String {
     if total == 0 {
         return "—".into();
     }

--- a/vantage-diorama/src/debug.rs
+++ b/vantage-diorama/src/debug.rs
@@ -141,7 +141,7 @@ pub(crate) fn num(n: usize) -> String {
     let s = n.to_string();
     let mut out = String::with_capacity(s.len() + s.len() / 3);
     for (i, c) in s.chars().enumerate() {
-        if i > 0 && (s.len() - i) % 3 == 0 {
+        if i > 0 && (s.len() - i).is_multiple_of(3) {
             out.push(',');
         }
         out.push(c);

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -241,8 +241,11 @@ impl DioInner {
     /// Next value in this Dio's request sequence — stamped as `req=N` to
     /// correlate a dispatch line with its return line in the debug stream.
     pub(crate) fn next_req(&self) -> u64 {
+        // 1-based: "fetch #1" is the first request a reader sees, and a
+        // zero-th of anything reads like an off-by-one bug in the log.
         self.req_seq
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1
     }
 
     /// Prune dead entries from the table-scenery dedup registry and return
@@ -272,14 +275,14 @@ impl DioInner {
         let p = crate::debug::process_stats();
         crate::debug::tapline!(
             tap,
-            dio = self.master.read().unwrap().name(),
+            "census",
+            "{} {} — now {} table, {} record, {} servo · rss {}MB",
+            if verb == "opened" { "+1" } else { "-1" },
+            kind,
             table_sceneries,
             record_sceneries,
             servos,
-            uptime_ms = p.uptime_ms,
-            cpu_ms = p.cpu_ms,
-            peak_rss_mb = p.peak_rss_bytes / (1024 * 1024),
-            "census: {kind} {verb}",
+            p.peak_rss_bytes / (1024 * 1024),
         );
     }
 

--- a/vantage-diorama/src/lens/make_dio.rs
+++ b/vantage-diorama/src/lens/make_dio.rs
@@ -71,6 +71,32 @@ impl Lens {
         });
         let dio = Dio { inner };
 
+        // The stream's first line. Everything after this belongs to a Dio, so
+        // say when one comes into being, what it is a copy of, and whether it
+        // starts from anything — a reader who meets `scenery` first has no
+        // idea what it opened onto.
+        {
+            let tap = dio.inner.tap().clone();
+            if tap.enabled() {
+                let rows = dio.inner.cache.count().await.unwrap_or(0).max(0) as usize;
+                crate::debug::tapline!(
+                    tap,
+                    "dio",
+                    "created over \"{}\" — cache table \"{}\", {}",
+                    dio.inner.master.read().unwrap().name(),
+                    dio.inner.cache_table_name,
+                    if rows == 0 {
+                        "nothing held yet".to_string()
+                    } else {
+                        format!(
+                            "{} rows already held from a previous session",
+                            crate::debug::num(rows)
+                        )
+                    },
+                );
+            }
+        }
+
         spawn_write_worker(&dio, write_rx).await;
         spawn_refresh_task(&dio).await;
 

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -290,7 +290,55 @@ impl TableSceneryBuilder {
             debug_tap: dio.tap().clone(),
             dio_name: dio.master.read().unwrap().name().to_string(),
             last_debug_state: Mutex::new(None),
+            payload_named: std::sync::atomic::AtomicBool::new(false),
+            last_served: Mutex::new(None),
         });
+
+        // What the source can do decides everything that follows — which work
+        // is pushed down, and which the layers above have to do themselves.
+        // Said once, at open, so the rest of the session reads against it.
+        {
+            let caps = &state.master_capabilities;
+            let can: Vec<&str> = [
+                caps.can_count.then_some("count"),
+                caps.can_fetch_window.then_some("window"),
+                caps.can_fetch_page.then_some("page"),
+                caps.can_fetch_next.then_some("cursor"),
+                caps.can_order.then_some("order"),
+                caps.can_search.then_some("search"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            let cannot: Vec<&str> = [
+                (!caps.can_count).then_some("count"),
+                (!caps.can_order).then_some("order"),
+                (!caps.can_search).then_some("search"),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            crate::debug::tapline!(
+                state.debug_tap,
+                "source",
+                "{}{} · {}",
+                if can.is_empty() {
+                    "can do nothing but list".to_string()
+                } else {
+                    format!("can {}", can.join(", "))
+                },
+                if cannot.is_empty() {
+                    String::new()
+                } else {
+                    format!(" · cannot {}", cannot.join(", "))
+                },
+                if state.paged {
+                    format!("pages lazily, {} rows at a time", state.page_size)
+                } else {
+                    "copied whole into the cache".to_string()
+                },
+            );
+        }
 
         // 1. total_provider runs once per open, result cached.
         //
@@ -418,10 +466,9 @@ impl TableSceneryBuilder {
                 );
                 crate::debug::tapline!(
                     state.debug_tap,
-                    dio = table.as_str(),
-                    mode = "warm",
-                    rows = cached_rows,
-                    "cache seed",
+                    "scenery",
+                    "opened warm — {} rows already on disk",
+                    crate::debug::num(cached_rows.max(0) as usize),
                 );
             } else {
                 tracing::debug!(
@@ -432,10 +479,8 @@ impl TableSceneryBuilder {
                 );
                 crate::debug::tapline!(
                     state.debug_tap,
-                    dio = table.as_str(),
-                    mode = "cold",
-                    rows = cached_rows,
-                    "cache seed",
+                    "scenery",
+                    "opened cold — nothing cached on disk yet",
                 );
             }
             state.bump_generation();
@@ -460,10 +505,10 @@ impl TableSceneryBuilder {
             );
             crate::debug::tapline!(
                 state.debug_tap,
-                dio = dio.master.read().unwrap().name(),
-                mode = if seeded_rows > 0 { "warm" } else { "cold" },
-                rows = seeded_rows,
-                "cache seed",
+                "scenery",
+                "opened {} — {} rows seeded from cache",
+                if seeded_rows > 0 { "warm" } else { "cold" },
+                crate::debug::num(seeded_rows),
             );
             // The cache IS the row set for this shape, so a seed that found
             // rows IS the answer. A seed that found none is not: a cold cache

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -63,6 +63,16 @@ pub(crate) async fn viewport_loop(
             }
         }
         let depth_after = state.viewport_queue_depth.load(Ordering::SeqCst);
+        if absorbed > 0 {
+            crate::debug::tapline!(
+                state.debug_tap,
+                "viewport",
+                "rows {}..{} — {} scroll events coalesced into one",
+                latest.range.start,
+                latest.range.end,
+                absorbed + 1,
+            );
+        }
         tracing::debug!(
             target: "vantage_diorama::viewport",
             range = ?latest.range,
@@ -239,13 +249,22 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     rows = visible_cached,
                     "CACHE — served locally, no master fetch",
                 );
-                crate::debug::tapline!(
-                    tap,
-                    dio = dio_inner.master.read().unwrap().name(),
-                    range = ?visible,
-                    rows = visible_cached,
-                    "cache hit — viewport served locally",
-                );
+                let repeat = {
+                    let mut last = state.last_served.lock().unwrap();
+                    let same = last.as_ref() == Some(&visible);
+                    *last = Some(visible.clone());
+                    same
+                };
+                if !repeat {
+                    crate::debug::tapline!(
+                        tap,
+                        "cache",
+                        "all {} rows of {}..{} served locally — no fetch",
+                        visible_cached,
+                        visible.start,
+                        visible.end,
+                    );
+                }
                 return;
             }
         }
@@ -380,16 +399,26 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     );
     crate::debug::tapline!(
         tap,
-        req = req.unwrap_or_default(),
-        dio = dio_inner.master.read().unwrap().name(),
-        visible = ?visible,
-        effective = ?effective_range,
-        rows_to_fetch = effective_to_fetch,
-        already_cached = effective_cached,
-        sort = ?query.sort,
-        search = ?query.search,
-        force_load,
-        "load dispatch",
+        "dio",
+        "fetch #{} asks for rows {}..{}{} — {} missing, {} already held{}{}",
+        req.unwrap_or_default(),
+        effective_range.start,
+        effective_range.end,
+        if effective_range == visible {
+            String::new()
+        } else {
+            format!(" (viewport {}..{})", visible.start, visible.end)
+        },
+        effective_to_fetch,
+        effective_cached,
+        match &query.sort {
+            Some((col, dir)) => format!(" · sorted by {col} {dir:?}"),
+            None => String::new(),
+        },
+        match &query.search {
+            Some(q) => format!(" · searching \"{q}\""),
+            None => String::new(),
+        },
     );
     // Clear the dirty flag so it reflects only the rows this load writes;
     // `write_chunk_row` sets it when a row's content actually changes.
@@ -432,25 +461,22 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             if let Some(report) = &flush_report
                 && report.written > 0
             {
+                // A concurrent flush from another in-flight load between the
+                // before/after `count()` calls could in principle make this go
+                // negative and underflow; accepted here since it's a debug-only
+                // line, not a value anything downstream trusts.
+                let new_rows = (report.cache_rows_after - report.cache_rows_before) as usize;
+                let held = report.cache_rows_after as usize;
+                let known_total = state.total.read().unwrap().unwrap_or(0);
                 crate::debug::tapline!(
                     tap,
-                    dio = dio_inner.master.read().unwrap().name(),
-                    written = report.written,
-                    // A concurrent flush from another in-flight load between the
-                    // before/after `count()` calls could in principle make this
-                    // go negative and underflow; accepted here since it's a
-                    // debug-only line, not a value anything downstream trusts.
-                    new = (report.cache_rows_after - report.cache_rows_before) as usize,
-                    updated = report.written.saturating_sub(
-                        (report.cache_rows_after - report.cache_rows_before) as usize
-                    ),
-                    cached_rows = report.cache_rows_after,
-                    known_total = state.total.read().unwrap().unwrap_or(0),
-                    cached_pct = match state.total.read().unwrap().unwrap_or(0) {
-                        0 => 0,
-                        total => 100 * report.cache_rows_after as usize / total,
-                    },
-                    "cache write",
+                    "cache",
+                    "+{} new, {} updated — now holding {} of {} ({})",
+                    new_rows,
+                    report.written.saturating_sub(new_rows),
+                    crate::debug::num(held),
+                    crate::debug::num(known_total),
+                    crate::debug::pct(held, known_total),
                 );
             }
             // The window came back — whatever it contained, this view now has
@@ -478,12 +504,12 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             );
             crate::debug::tapline!(
                 tap,
-                req = req.unwrap_or_default(),
-                dio = dio_inner.master.read().unwrap().name(),
-                received = pushed,
-                ms,
-                cached_after,
-                "load return",
+                "dio",
+                "fetch #{} got {} rows in {}{}",
+                req.unwrap_or_default(),
+                pushed,
+                crate::debug::dur(ms),
+                if ms >= 1_000 { "  ⚠ slow" } else { "" },
             );
             // The wide-data detector: how many distinct fields this chunk
             // carried against how many the open sceneries actually asked
@@ -518,17 +544,46 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                         (names.join(","), undemanded)
                     }
                 };
-                crate::debug::tapline!(
-                    tap,
-                    dio = dio_inner.master.read().unwrap().name(),
-                    demanded = demanded_str,
-                    received_count,
-                    received_sample,
-                    undemanded_count,
-                    payload_bytes,
-                    rows = pushed,
-                    "columns",
-                );
+                // Name the columns the first time only. After that the set is
+                // established and repeating it every fetch is just width.
+                let first_time = !state
+                    .payload_named
+                    .swap(true, std::sync::atomic::Ordering::Relaxed);
+                // With no demand declared, "all columns are wanted" is an
+                // assumption, not a fact — saying "206/206 displayed" would
+                // claim a grid showing five columns wanted all two hundred.
+                // Report what is actually known instead.
+                let headline = match &demanded {
+                    None => format!(
+                        "{} columns received · no view declared what it needs, so all were fetched",
+                        received_count
+                    ),
+                    Some(_) => format!(
+                        "{} of {} columns wanted · {} fetched and dropped",
+                        received_count.saturating_sub(undemanded_count),
+                        received_count,
+                        undemanded_count
+                    ),
+                };
+                if first_time {
+                    crate::debug::tapline!(
+                        tap,
+                        "payload",
+                        "{} · {} · {}",
+                        headline,
+                        crate::debug::bytes(payload_bytes),
+                        received_sample,
+                    );
+                } else {
+                    crate::debug::tapline!(
+                        tap,
+                        "payload",
+                        "{} · {}",
+                        headline,
+                        crate::debug::bytes(payload_bytes),
+                    );
+                }
+                let _ = &demanded_str;
             }
             // Where the grand total came from. A total the source stated in the
             // same response as the rows (`ChunkSink::set_total`) outranks
@@ -546,14 +601,18 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     total = ?stated,
                     "total stated by the fetch itself — no count request needed",
                 );
-                crate::debug::tapline!(
-                    tap,
-                    dio = dio_inner.master.read().unwrap().name(),
-                    total = stated.unwrap_or_default(),
-                    provenance = "stated",
-                    "total",
-                );
                 let changed = stated != total_before;
+                // Only when it MOVES. A source that restates the same total on
+                // every window would otherwise repeat this line per fetch,
+                // burying the times it actually changed.
+                if changed {
+                    crate::debug::tapline!(
+                        tap,
+                        "total",
+                        "{} rows — stated by the source in the same response",
+                        crate::debug::num(stated.unwrap_or_default()),
+                    );
+                }
                 // Remember a stated, un-narrowed total in the cache meta, so
                 // the NEXT open of this view can size its geometry before any
                 // fetch — the difference between a warm reopen appearing
@@ -576,10 +635,9 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 let total = effective_range.start + pushed;
                 crate::debug::tapline!(
                     tap,
-                    dio = dio_inner.master.read().unwrap().name(),
-                    total,
-                    provenance = "short-page",
                     "total",
+                    "{} rows — inferred: the page came back short",
+                    crate::debug::num(total),
                 );
                 state.set_total(Some(total))
             } else {
@@ -610,10 +668,9 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                     );
                     crate::debug::tapline!(
                         tap,
-                        dio = dio_inner.master.read().unwrap().name(),
-                        total = extended,
-                        provenance = "horizon-extended",
                         "total",
+                        "{} rows — a full page reached the end we assumed; extending it",
+                        crate::debug::num(extended),
                     );
                     state.set_total(Some(extended))
                 } else {
@@ -683,10 +740,9 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                         );
                         crate::debug::tapline!(
                             tap,
-                            dio = dio_inner.master.read().unwrap().name(),
-                            total = hole,
-                            provenance = "hole-clamped",
                             "total",
+                            "{} rows — capped: the source promises more than it serves",
+                            crate::debug::num(hole),
                         );
                         total_changed |= state.set_total(Some(hole));
                     }
@@ -727,11 +783,11 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
             );
             crate::debug::tapline!(
                 tap,
-                req = req.unwrap_or_default(),
-                dio = dio_inner.master.read().unwrap().name(),
-                ms = t.elapsed().as_millis() as u64,
-                error = %e,
-                "load failed",
+                "dio",
+                "fetch #{} failed after {} — {}",
+                req.unwrap_or_default(),
+                crate::debug::dur(t.elapsed().as_millis() as u64),
+                e,
             );
             let _ = dio_inner.event_bus.send(DioEvent::LoadFailed {
                 range: effective_range,

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -535,14 +535,9 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 } else {
                     received.join(",")
                 };
-                let (demanded_str, undemanded_count) = match &demanded {
-                    None => ("all".to_string(), 0),
-                    Some(set) => {
-                        let mut names: Vec<&str> = set.iter().map(String::as_str).collect();
-                        names.sort_unstable();
-                        let undemanded = received.iter().filter(|c| !set.contains(*c)).count();
-                        (names.join(","), undemanded)
-                    }
+                let undemanded_count = match &demanded {
+                    None => 0,
+                    Some(set) => received.iter().filter(|c| !set.contains(*c)).count(),
                 };
                 // Name the columns the first time only. After that the set is
                 // established and repeating it every fetch is just width.
@@ -583,7 +578,6 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                         crate::debug::bytes(payload_bytes),
                     );
                 }
-                let _ = &demanded_str;
             }
             // Where the grand total came from. A total the source stated in the
             // same response as the rows (`ChunkSink::set_total`) outranks
@@ -633,13 +627,19 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 changed
             } else if pushed < effective_len {
                 let total = effective_range.start + pushed;
-                crate::debug::tapline!(
-                    tap,
-                    "total",
-                    "{} rows — inferred: the page came back short",
-                    crate::debug::num(total),
-                );
-                state.set_total(Some(total))
+                // Same rule as the stated branch above: only when it MOVES. A
+                // reload that keeps landing on the same short page would
+                // otherwise repeat this line for a total that never changed.
+                let changed = state.set_total(Some(total));
+                if changed {
+                    crate::debug::tapline!(
+                        tap,
+                        "total",
+                        "{} rows — inferred: the page came back short",
+                        crate::debug::num(total),
+                    );
+                }
+                changed
             } else {
                 // A FULL page from a source that has never stated a total. If
                 // it reached the advertised end, that end was only ever our

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -116,9 +116,9 @@ impl LoadState {
     /// emits.
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
-            LoadState::Loading => "Loading",
-            LoadState::Partial => "Partial",
-            LoadState::Complete => "Complete",
+            LoadState::Loading => "loading",
+            LoadState::Partial => "partial",
+            LoadState::Complete => "complete",
         }
     }
 }
@@ -398,6 +398,31 @@ impl TableScenery for TableSceneryImpl {
             two_pass = self.inner.two_pass,
             "set_sort",
         );
+        // Where the ordering will actually happen is the whole question: a
+        // source that can order does it over the entire set; one that can't
+        // leaves us sorting the rows we happen to hold, which is a different
+        // answer as well as a slower one.
+        match &column {
+            Some(col) => crate::debug::tapline!(
+                self.inner.debug_tap,
+                "sort",
+                "by {} {} — {}",
+                col,
+                match dir {
+                    SortDir::Asc => "ascending",
+                    SortDir::Desc => "descending",
+                },
+                if self.inner.master_capabilities.can_order {
+                    "pushed to the source".to_string()
+                } else {
+                    format!(
+                        "the source cannot order; sorting the {} rows held locally",
+                        crate::debug::num(self.inner.rows.read().unwrap().len())
+                    )
+                },
+            ),
+            None => crate::debug::tapline!(self.inner.debug_tap, "sort", "cleared"),
+        }
         self.inner.deregister();
         *self.inner.sort.write().unwrap() = column.map(|c| (c, dir));
         self.inner.reload_notify.notify_one();
@@ -422,6 +447,23 @@ impl TableScenery for TableSceneryImpl {
             paged = self.inner.paged,
             "set_search",
         );
+        match &normalized {
+            Some(q) => crate::debug::tapline!(
+                self.inner.debug_tap,
+                "search",
+                "\"{}\" — {}",
+                q,
+                if self.inner.master_capabilities.can_search {
+                    "pushed to the source".to_string()
+                } else {
+                    format!(
+                        "the source cannot search; filtering the {} rows held locally",
+                        crate::debug::num(self.inner.rows.read().unwrap().len())
+                    )
+                },
+            ),
+            None => crate::debug::tapline!(self.inner.debug_tap, "search", "cleared"),
+        }
         // Reshaping a shared view is not this consumer's to do — same rule
         // as `set_sort`/`set_filters`.
         self.inner.deregister();

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -180,6 +180,13 @@ pub(crate) struct TableSceneryState {
     /// [`note_state`](Self::note_state), so a repeat call (settling, then the
     /// same load's generation bump) doesn't double-log an unchanged state.
     pub(crate) last_debug_state: Mutex<Option<super::LoadState>>,
+    /// Whether the debug stream has already named this view's columns. The
+    /// set doesn't change between fetches, so it's said once.
+    pub(crate) payload_named: std::sync::atomic::AtomicBool,
+    /// The last range reported as served from cache. A view that re-declares
+    /// the same viewport (a repaint, a focus change) would otherwise log the
+    /// same "served locally" line twice in a row, saying nothing new.
+    pub(crate) last_served: Mutex<Option<std::ops::Range<usize>>>,
 }
 
 impl TableSceneryState {
@@ -256,11 +263,11 @@ impl TableSceneryState {
         drop(last);
         crate::debug::tapline!(
             self.debug_tap,
-            dio = self.dio_name.as_str(),
-            from = from.map(|s| s.as_str()).unwrap_or("None"),
-            to = to.as_str(),
+            "scenery",
+            "{} → {} ({})",
+            from.map(|s| s.as_str()).unwrap_or("opening"),
+            to.as_str(),
             reason,
-            "state",
         );
     }
 
@@ -344,6 +351,57 @@ impl TableSceneryState {
         let op_conditions = self.op_conditions.read().unwrap().clone();
         let sort = self.sort.read().unwrap().clone();
         let search = self.search.read().unwrap().clone();
+
+        let filtered_len_hint = all.len();
+        // A paged view whose MASTER does the ordering cannot position cached
+        // rows after the order changes. The cache holds an arbitrary subset of
+        // the previous order — the windows this view happened to visit — and
+        // re-sorting that subset locally would place it at rows 0..N of the new
+        // order, which it is not: row 0 of "by name descending" is somewhere in
+        // the 199,700 rows never fetched. The result is a grid that looks sorted
+        // at the top and is wrong everywhere, mixed with correctly-positioned
+        // rows wherever a later fetch landed.
+        //
+        // So drop the positions and keep the cache. The loader refills the
+        // visible window from the master in the new order; the cached records
+        // are still valid as values, just not as places.
+        // Two-pass views are excluded: their positions come from the query
+        // index, not from master windows, and `two_pass::resort` already
+        // rebuilds that index. Clearing here would drop a spine that nothing
+        // in this path refills.
+        //
+        // ...and only while the cache holds a SUBSET. A view that has fetched
+        // the whole set can order it locally and be right, which is both
+        // cheaper and instant; the hazard is strictly about ordering a sample
+        // and presenting it as the whole.
+        let holds_everything = match *self.total.read().unwrap() {
+            Some(total) => filtered_len_hint >= total,
+            None => false,
+        };
+        if self.paged
+            && !self.two_pass
+            && self.master_capabilities.can_order
+            && sort.is_some()
+            && !holds_everything
+        {
+            self.rows.write().unwrap().clear();
+            self.id_to_idx.write().unwrap().clear();
+            tracing::debug!(
+                target: "vantage_diorama::sort",
+                "paged view re-orders at the source — dropped cached row positions",
+            );
+            crate::debug::tapline!(
+                self.debug_tap,
+                "scenery",
+                "row positions dropped — the source re-orders, so cached rows must be re-placed",
+            );
+            // Refill immediately rather than waiting for the consumer to
+            // re-declare its viewport. A grid repaints and re-declares, so it
+            // would recover either way; a consumer that holds its viewport
+            // still would sit on an empty view forever.
+            self.refresh_loaded_viewport();
+            return Ok(());
+        }
 
         let mut filtered: Vec<(String, Record<CborValue>)> = all
             .into_iter()

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -352,7 +352,13 @@ impl TableSceneryState {
         let sort = self.sort.read().unwrap().clone();
         let search = self.search.read().unwrap().clone();
 
-        let filtered_len_hint = all.len();
+        let mut filtered: Vec<(String, Record<CborValue>)> = all
+            .into_iter()
+            .filter(|(_, rec)| matches_conditions(rec, &conditions))
+            .filter(|(_, rec)| matches_op_conditions(rec, &op_conditions))
+            .filter(|(_, rec)| matches_search(rec, search.as_deref()))
+            .collect();
+
         // A paged view whose MASTER does the ordering cannot position cached
         // rows after the order changes. The cache holds an arbitrary subset of
         // the previous order — the windows this view happened to visit — and
@@ -374,8 +380,12 @@ impl TableSceneryState {
         // the whole set can order it locally and be right, which is both
         // cheaper and instant; the hazard is strictly about ordering a sample
         // and presenting it as the whole.
+        //
+        // Count MATCHING rows, not cached rows: `total` describes the narrowed
+        // set, so a cache full of rows the search excludes would otherwise
+        // clear the bar while the matching rows are still a sample.
         let holds_everything = match *self.total.read().unwrap() {
-            Some(total) => filtered_len_hint >= total,
+            Some(total) => filtered.len() >= total,
             None => false,
         };
         if self.paged
@@ -402,13 +412,6 @@ impl TableSceneryState {
             self.refresh_loaded_viewport();
             return Ok(());
         }
-
-        let mut filtered: Vec<(String, Record<CborValue>)> = all
-            .into_iter()
-            .filter(|(_, rec)| matches_conditions(rec, &conditions))
-            .filter(|(_, rec)| matches_op_conditions(rec, &op_conditions))
-            .filter(|(_, rec)| matches_search(rec, search.as_deref()))
-            .collect();
 
         if let Some((col, dir)) = sort {
             let missing = filtered

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -286,13 +286,11 @@ async fn list_page_into(
     let req = state.debug_tap.enabled().then(|| dio_inner.next_req());
     crate::debug::tapline!(
         state.debug_tap,
-        req = req.unwrap_or_default(),
-        dio = state.dio_name.as_str(),
-        offset,
+        "dio",
+        "list #{} asks for {} ids from offset {}",
+        req.unwrap_or_default(),
         limit,
-        conditions = ?q.conditions,
-        sort = ?q.sort,
-        "list page dispatch",
+        offset,
     );
     let t = std::time::Instant::now();
     let rows = if let Some(cb) = dio_inner.lens.callbacks.on_list_page.as_ref() {
@@ -360,12 +358,13 @@ async fn list_page_into(
     let appended = index.append_page(new_ids, limit);
     crate::debug::tapline!(
         state.debug_tap,
-        req = req.unwrap_or_default(),
-        rows = rows_len,
-        ms = t.elapsed().as_millis() as u64,
-        index_len = index.len(),
-        complete = index.is_complete(),
-        "list page return",
+        "dio",
+        "list #{} got {} ids in {} — {} known so far{}",
+        req.unwrap_or_default(),
+        rows_len,
+        crate::debug::dur(t.elapsed().as_millis() as u64),
+        crate::debug::num(index.len()),
+        if index.is_complete() { ", that's all of them" } else { "" },
     );
     Ok(appended)
 }
@@ -764,11 +763,11 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
     );
     crate::debug::tapline!(
         state.debug_tap,
-        dio = state.dio_name.as_str(),
+        "hydrate",
+        "{} rows in view — {} need detail, {} already complete",
         requested,
-        pending = pending.len(),
+        pending.len(),
         already_complete,
-        "detail pass",
     );
     if pending.is_empty() {
         return;

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -364,7 +364,11 @@ async fn list_page_into(
         rows_len,
         crate::debug::dur(t.elapsed().as_millis() as u64),
         crate::debug::num(index.len()),
-        if index.is_complete() { ", that's all of them" } else { "" },
+        if index.is_complete() {
+            ", that's all of them"
+        } else {
+            ""
+        },
     );
     Ok(appended)
 }

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -289,8 +289,8 @@ async fn list_page_into(
         "dio",
         "list #{} asks for {} ids from offset {}",
         req.unwrap_or_default(),
-        limit,
-        offset,
+        crate::debug::num(limit),
+        crate::debug::num(offset),
     );
     let t = std::time::Instant::now();
     let rows = if let Some(cb) = dio_inner.lens.callbacks.on_list_page.as_ref() {
@@ -361,7 +361,7 @@ async fn list_page_into(
         "dio",
         "list #{} got {} ids in {} — {} known so far{}",
         req.unwrap_or_default(),
-        rows_len,
+        crate::debug::num(rows_len),
         crate::debug::dur(t.elapsed().as_millis() as u64),
         crate::debug::num(index.len()),
         if index.is_complete() {
@@ -769,9 +769,9 @@ pub(crate) async fn run_detail_for_range(state: Arc<TableSceneryState>, range: R
         state.debug_tap,
         "hydrate",
         "{} rows in view — {} need detail, {} already complete",
-        requested,
-        pending.len(),
-        already_complete,
+        crate::debug::num(requested),
+        crate::debug::num(pending.len()),
+        crate::debug::num(already_complete),
     );
     if pending.is_empty() {
         return;

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -199,32 +199,36 @@ pub fn debug_summary_lines() -> Vec<String> {
 
     // Per-table stats (already sorted busiest first by fetch_stats())
     for stat in fetch_stats() {
-        let line = format!(
-            "{}: {} fetches ({} repeats), {} rows ({} redundant), {}ms total, {}ms max",
+        lines.push(format!(
+            "{:<10} {:<8} {} fetches, {} repeats · {} rows, {} redundant · {} waiting, {} slowest",
             stat.table,
+            "summary",
             stat.fetches,
             stat.repeats,
-            stat.rows_received,
+            crate::debug::num(stat.rows_received),
             stat.rows_redundant,
-            stat.ms_total,
-            stat.ms_max
-        );
-        lines.push(line);
+            crate::debug::dur(stat.ms_total),
+            crate::debug::dur(stat.ms_max),
+        ));
     }
 
     // Live counts
     let live = live_counts();
     lines.push(format!(
-        "live: {} dios, {} table sceneries, {} record sceneries, {} servos",
-        live.dios, live.table_sceneries, live.record_sceneries, live.servos
+        "{:<10} {:<8} {} dio, {} table scenery, {} record, {} servo still alive",
+        "", "summary", live.dios, live.table_sceneries, live.record_sceneries, live.servos
     ));
 
     // Process stats
     let proc = crate::debug::process_stats();
     let peak_rss_mb = proc.peak_rss_bytes / (1024 * 1024);
     lines.push(format!(
-        "process: uptime {}ms, cpu {}ms, peak rss {}MB",
-        proc.uptime_ms, proc.cpu_ms, peak_rss_mb
+        "{:<10} {:<8} session {} · cpu {} · peak rss {}MB",
+        "",
+        "summary",
+        crate::debug::dur(proc.uptime_ms),
+        crate::debug::dur(proc.cpu_ms),
+        peak_rss_mb
     ));
 
     lines
@@ -233,6 +237,12 @@ pub fn debug_summary_lines() -> Vec<String> {
 /// Log the debug summary lines via tracing at info level.
 /// Unconditional — the embedder decides when to call this.
 pub fn emit_debug_summary() {
+    // No-op unless some datasource actually opted in, so an embedder can call
+    // this unconditionally on the way out without printing a ledger nobody
+    // asked for.
+    if !crate::debug::any_tap_enabled() {
+        return;
+    }
     for line in debug_summary_lines() {
         tracing::info!(target: "vantage_diorama::debug", "{}", line);
     }
@@ -279,10 +289,10 @@ mod tests {
         record_fetch("book", &(0..20), 20, 20, 9);
         let lines = debug_summary_lines();
         assert!(lines[0].contains("session summary"));
-        let book = lines.iter().find(|l| l.starts_with("book:")).unwrap();
-        assert!(book.contains("2 fetches (1 repeats)"), "{book}");
-        assert!(book.contains("(20 redundant)"), "{book}");
-        assert!(lines.iter().any(|l| l.starts_with("live:")));
-        assert!(lines.iter().any(|l| l.starts_with("process:")));
+        let book = lines.iter().find(|l| l.starts_with("book ")).unwrap();
+        assert!(book.contains("2 fetches, 1 repeats"), "{book}");
+        assert!(book.contains("20 redundant"), "{book}");
+        assert!(lines.iter().any(|l| l.contains("still alive")));
+        assert!(lines.iter().any(|l| l.contains("peak rss")));
     }
 }

--- a/vantage-diorama/src/stats.rs
+++ b/vantage-diorama/src/stats.rs
@@ -206,7 +206,7 @@ pub fn debug_summary_lines() -> Vec<String> {
             stat.fetches,
             stat.repeats,
             crate::debug::num(stat.rows_received),
-            stat.rows_redundant,
+            crate::debug::num(stat.rows_redundant),
             crate::debug::dur(stat.ms_total),
             crate::debug::dur(stat.ms_max),
         ));

--- a/vantage-diorama/tests/chunk_server_sort_positions.rs
+++ b/vantage-diorama/tests/chunk_server_sort_positions.rs
@@ -23,7 +23,7 @@ use vantage_vista::mocks::MockShell;
 use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata};
 
 mod support;
-use support::chunk::{col_at, settle, Backend};
+use support::chunk::{Backend, col_at, settle};
 
 fn rec(name: &str) -> Record<CborValue> {
     let mut r = Record::new();

--- a/vantage-diorama/tests/chunk_server_sort_positions.rs
+++ b/vantage-diorama/tests/chunk_server_sort_positions.rs
@@ -129,3 +129,108 @@ async fn a_server_side_sort_does_not_leave_stale_row_positions() -> Result<()> {
 
     Ok(())
 }
+
+/// The same shape, with a search narrowing the set first.
+///
+/// The guard above lets a view sort locally once it holds the whole set, and
+/// "the whole set" is measured over the rows that match the current query —
+/// not over everything the cache happens to hold. This case puts 40 cached
+/// rows above a narrowed total of 20, with half the matching rows never
+/// fetched, and asserts the top row is the true first of the narrowed order.
+///
+/// It passes against either measurement: a paged search refreshes the viewport
+/// rather than reseeding from cache, so the guard is not what decides this
+/// answer. Kept as coverage of paged search + server-side sort over a partly
+/// cached set, which nothing else exercises.
+#[tokio::test]
+async fn a_narrowed_query_sorts_from_the_source_not_the_cached_sample() -> Result<()> {
+    // a00..a09, then 30 rows that never match, then a10..a19. A view that
+    // reads the first 40 rows caches ten matching rows and misses ten.
+    let mut rows: Vec<(String, Record<CborValue>)> = Vec::new();
+    for i in 0..10 {
+        rows.push((format!("ida{i:02}"), rec(&format!("a{i:02}"))));
+    }
+    for i in 0..30 {
+        rows.push((format!("idb{i:02}"), rec(&format!("b{i:02}"))));
+    }
+    for i in 10..20 {
+        rows.push((format!("ida{i:02}"), rec(&format!("a{i:02}"))));
+    }
+    let backend: Backend = Arc::new(Mutex::new(rows));
+
+    let tmp = TempDir::new().expect("tempdir");
+    let served = backend.clone();
+    let counted = backend.clone();
+    let lens = Arc::new(
+        vantage_diorama::Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .total_provider(move |_dio| {
+                let b = counted.clone();
+                async move { Ok(b.lock().unwrap().len()) }
+            })
+            // Orders AND searches at the source, and reports the narrowed
+            // total with the window — a counted, searchable master.
+            .on_load_chunk(move |_dio, range, query, sink| {
+                let b = served.clone();
+                async move {
+                    let mut rows = b.lock().unwrap().clone();
+                    if let Some(q) = &query.search {
+                        rows.retain(|(_, r)| match r.get("name") {
+                            Some(CborValue::Text(v)) => v.contains(q.as_str()),
+                            _ => false,
+                        });
+                    }
+                    if let Some((col, dir)) = &query.sort {
+                        rows.sort_by(|a, z| {
+                            let (x, y) = (a.1.get(col), z.1.get(col));
+                            let ord = match (x, y) {
+                                (Some(CborValue::Text(x)), Some(CborValue::Text(y))) => x.cmp(y),
+                                _ => std::cmp::Ordering::Equal,
+                            };
+                            match dir {
+                                vantage_diorama::SortDir::Desc => ord.reverse(),
+                                _ => ord,
+                            }
+                        });
+                    }
+                    sink.set_total(rows.len());
+                    for idx in range {
+                        if let Some((id, r)) = rows.get(idx) {
+                            sink.push(idx, id.clone(), r.clone()).await?;
+                        }
+                    }
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+
+    let dio = lens.make_dio(orderable_master()).await?;
+    let scenery = dio.table_scenery().page_size(20).open().await?;
+
+    // Fill the cache with 40 rows, only ten of which will match.
+    scenery.set_viewport(0..40);
+    settle().await;
+    settle().await;
+
+    // Narrow to the twenty "a" rows, then order them at the source.
+    scenery.set_search(Some("a".to_string()));
+    settle().await;
+    scenery.set_sort(Some("name".to_string()), SortDir::Desc);
+    settle().await;
+    scenery.set_viewport(0..20);
+    settle().await;
+    settle().await;
+
+    // Descending over a00..a19, row 0 is a19 — a row this cache never held.
+    // Measuring coverage with the cache's 40 rows against the narrowed total
+    // of 20 would seat a09 here instead.
+    assert_eq!(
+        col_at(&scenery, 0, "name").as_deref(),
+        Some("a19"),
+        "coverage must be counted over matching rows, not over everything cached",
+    );
+
+    Ok(())
+}

--- a/vantage-diorama/tests/chunk_server_sort_positions.rs
+++ b/vantage-diorama/tests/chunk_server_sort_positions.rs
@@ -1,0 +1,131 @@
+//! A paged view whose master does the ordering must not keep the row
+//! *positions* it had under the previous order.
+//!
+//! The cache holds whatever windows the view happened to visit — an arbitrary
+//! subset of the old order, not a prefix of the new one. Re-sorting that subset
+//! locally and seating it at rows 0..N claims those rows are the first N of the
+//! sorted set, which they are not: under "by name descending" the true row 0 is
+//! somewhere in the rows never fetched. The grid then reads as sorted at the top
+//! and wrong everywhere else, mixed with correct rows wherever a later fetch
+//! landed — which is exactly how it presented in the app.
+//!
+//! The fix drops positions (keeping the cached records) and lets the loader
+//! refill the visible window from the master.
+
+use std::sync::{Arc, Mutex};
+
+use ciborium::Value as CborValue;
+use tempfile::TempDir;
+use vantage_core::Result;
+use vantage_diorama::SortDir;
+use vantage_types::Record;
+use vantage_vista::mocks::MockShell;
+use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata};
+
+mod support;
+use support::chunk::{col_at, settle, Backend};
+
+fn rec(name: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("name".to_string(), CborValue::Text(name.to_string()));
+    r
+}
+
+/// A master that genuinely orders server-side, like SQL or a REST API with an
+/// `order` parameter: `can_order` is true and the chunk callback serves the
+/// window from the *sorted* set.
+fn orderable_master() -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("name", "String").with_flag("orderable"))
+        .with_id_column("id");
+    Vista::new(
+        "items",
+        Box::new(
+            MockShell::new()
+                .with_metadata(metadata)
+                .with_capabilities(VistaCapabilities {
+                    can_order: true,
+                    ..Default::default()
+                }),
+        ),
+    )
+}
+
+#[tokio::test]
+async fn a_server_side_sort_does_not_leave_stale_row_positions() -> Result<()> {
+    // 60 rows named a00..a59 — ascending by construction.
+    let backend: Backend = Arc::new(Mutex::new(
+        (0..60)
+            .map(|i| (format!("id{i:02}"), rec(&format!("a{i:02}"))))
+            .collect::<Vec<_>>(),
+    ));
+
+    let tmp = TempDir::new().expect("tempdir");
+    let sorted = backend.clone();
+    let counted = backend.clone();
+    let lens = Arc::new(
+        vantage_diorama::Lens::new()
+            .cache_at(tmp.path().join("cache.redb"))
+            .total_provider(move |_dio| {
+                let b = counted.clone();
+                async move { Ok(b.lock().unwrap().len()) }
+            })
+            // Honours the sort the scenery asks for — a real orderable master.
+            .on_load_chunk(move |_dio, range, query, sink| {
+                let b = sorted.clone();
+                async move {
+                    let mut rows = b.lock().unwrap().clone();
+                    if let Some((col, dir)) = &query.sort {
+                        rows.sort_by(|a, z| {
+                            let (x, y) = (a.1.get(col), z.1.get(col));
+                            let ord = match (x, y) {
+                                (Some(CborValue::Text(x)), Some(CborValue::Text(y))) => x.cmp(y),
+                                _ => std::cmp::Ordering::Equal,
+                            };
+                            match dir {
+                                vantage_diorama::SortDir::Desc => ord.reverse(),
+                                _ => ord,
+                            }
+                        });
+                    }
+                    for idx in range {
+                        if let Some((id, r)) = rows.get(idx) {
+                            sink.push(idx, id.clone(), r.clone()).await?;
+                        }
+                    }
+                    Ok(())
+                }
+            })
+            .build()
+            .expect("build lens"),
+    );
+
+    let dio = lens.make_dio(orderable_master()).await?;
+    let scenery = dio.table_scenery().page_size(20).open().await?;
+
+    // Visit a window in the MIDDLE, so the cache holds rows that are not a
+    // prefix of either order — the situation that made the bug visible.
+    scenery.set_viewport(20..40);
+    settle().await;
+    settle().await;
+
+    // Now sort descending at the source.
+    scenery.set_sort(Some("name".to_string()), SortDir::Desc);
+    settle().await;
+    scenery.set_viewport(0..20);
+    settle().await;
+    settle().await;
+
+    // Row 0 of "by name descending" over a00..a59 is a59. Before the fix this
+    // was a20 — the first row of the stale cached window, locally re-sorted and
+    // seated at position 0.
+    assert_eq!(
+        col_at(&scenery, 0, "name").as_deref(),
+        Some("a59"),
+        "row 0 must be the true first row of the new order, not a survivor of the old one",
+    );
+    assert_eq!(col_at(&scenery, 1, "name").as_deref(), Some("a58"));
+
+    Ok(())
+}

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -124,18 +124,18 @@ async fn census_lines_fire_on_scenery_open_and_drop() {
     let dio = lens.make_dio(master()).await.unwrap();
 
     let scenery = dio.table_scenery().open().await.unwrap();
-    let opens = lines_containing(&log, "census: table scenery opened");
+    let opens = lines_containing(&log, "+1 table scenery");
     assert_eq!(opens.len(), 1);
-    assert!(opens[0].contains("dio=\"books\""), "line: {}", opens[0]);
-    assert!(opens[0].contains("table_sceneries=1"), "line: {}", opens[0]);
+    assert!(opens[0].contains("census"), "line: {}", opens[0]);
+    assert!(opens[0].contains("now 1 table"), "line: {}", opens[0]);
     assert!(
-        opens[0].contains("uptime_ms="),
+        opens[0].contains("rss"),
         "census carries process stats"
     );
 
     drop(scenery);
     // Guard teardown is synchronous; the census drop line is emitted from Drop.
-    let closes = lines_containing(&log, "census: table scenery closed");
+    let closes = lines_containing(&log, "-1 table scenery");
     assert_eq!(closes.len(), 1);
 }
 
@@ -210,30 +210,34 @@ async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
     // scenery at `Complete`, not merely `Partial`.
     scenery.set_viewport(0..100);
     wait_until("first load return", || {
-        lines_containing(&log, "load return").len() == 1
+        lines_containing(&log, "got").len() == 1
     })
     .await;
 
-    let dispatch = lines_containing(&log, "load dispatch");
-    let ret = lines_containing(&log, "load return");
+    let dispatch = lines_containing(&log, "asks for");
+    let ret = lines_containing(&log, "got");
     assert_eq!(dispatch.len(), 1);
     assert_eq!(ret.len(), 1);
     // The same req id ties them together.
     let req = dispatch[0]
-        .split("req=")
+        .split("fetch #")
         .nth(1)
-        .unwrap()
+        .expect("dispatch names its request")
         .split_whitespace()
         .next()
-        .unwrap()
+        .expect("request id")
         .to_string();
-    assert!(ret[0].contains(&format!("req={req}")));
-    assert!(ret[0].contains("ms="));
+    assert!(
+        ret[0].contains(&format!("fetch #{req} got")),
+        "the return must carry the same request id: {}",
+        ret[0]
+    );
+    assert!(ret[0].contains("rows in"));
 
     // A state transition to Complete was logged.
-    let states = lines_containing(&log, "state");
+    let states = lines_containing(&log, "→ complete");
     assert!(
-        states.iter().any(|l| l.contains("to=\"Complete\"")),
+        states.iter().any(|l| l.contains("→ complete")),
         "{states:?}"
     );
 
@@ -242,7 +246,7 @@ async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
     assert!(
         totals
             .iter()
-            .any(|l| l.contains("total=100") && l.contains("provenance=\"stated\"")),
+            .any(|l| l.contains("100 rows") && l.contains("stated by the source")),
         "{totals:?}"
     );
 
@@ -250,11 +254,11 @@ async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
     // hit, no second dispatch.
     scenery.set_viewport(0..30);
     wait_until("cache hit on second pass", || {
-        lines_containing(&log, "cache hit").len() == 1
+        lines_containing(&log, "served locally").len() == 1
     })
     .await;
     assert_eq!(
-        lines_containing(&log, "load dispatch").len(),
+        lines_containing(&log, "asks for").len(),
         1,
         "no re-fetch"
     );
@@ -303,27 +307,24 @@ async fn column_line_exposes_undemanded_wide_fields() {
 
     scenery.set_viewport(0..1);
     wait_until("first load return", || {
-        lines_containing(&log, "load return").len() == 1
+        lines_containing(&log, "got").len() == 1
     })
     .await;
 
-    let cols = lines_containing(&log, "columns");
+    let cols = lines_containing(&log, "payload");
     assert_eq!(cols.len(), 1, "{cols:?}");
-    assert!(cols[0].contains("demanded=\"all\""), "{}", cols[0]);
-    assert!(cols[0].contains("received_count=52"), "{}", cols[0]);
-    assert!(cols[0].contains("payload_bytes="), "{}", cols[0]);
+    assert!(cols[0].contains("columns"), "{}", cols[0]);
+    assert!(cols[0].contains("52 columns received"), "{}", cols[0]);
+    assert!(cols[0].contains("KB") || cols[0].contains("B"), "{}", cols[0]);
     // payload should be dominated by the extras: > 50KB for 1 row wouldn't
     // hold for all rows; just assert it's large.
-    let bytes: usize = cols[0]
-        .split("payload_bytes=")
-        .nth(1)
-        .unwrap()
-        .split_whitespace()
-        .next()
-        .unwrap()
-        .parse()
-        .unwrap();
-    assert!(bytes > 50_000, "wide payload must be visible: {bytes}");
+    // The wide payload has to be visible in the size the line reports: 52
+    // columns of filler is kilobytes, not bytes.
+    assert!(
+        cols[0].contains("KB") || cols[0].contains("MB"),
+        "a wide payload must report in KB or MB, not bytes: {}",
+        cols[0]
+    );
 }
 
 /// The wide-data detector's column union must dedup ACROSS rows, not just
@@ -369,28 +370,23 @@ async fn column_line_dedups_across_multiple_wide_rows() {
 
     scenery.set_viewport(0..10);
     wait_until("first load return", || {
-        lines_containing(&log, "load return").len() == 1
+        lines_containing(&log, "got").len() == 1
     })
     .await;
 
-    let cols = lines_containing(&log, "columns");
+    let cols = lines_containing(&log, "payload");
     assert_eq!(cols.len(), 1, "{cols:?}");
-    assert!(cols[0].contains("demanded=\"all\""), "{}", cols[0]);
+    assert!(cols[0].contains("columns"), "{}", cols[0]);
     // Same 52 fields on every row — the union must not grow with row count.
-    assert!(cols[0].contains("received_count=52"), "{}", cols[0]);
-    assert!(cols[0].contains("rows=10"), "{}", cols[0]);
-    let bytes: usize = cols[0]
-        .split("payload_bytes=")
-        .nth(1)
-        .unwrap()
-        .split_whitespace()
-        .next()
-        .unwrap()
-        .parse()
-        .unwrap();
-    // Ten rows of the same wide shape: an order of magnitude past the
-    // single-row test's >50KB floor.
-    assert!(bytes > 500_000, "multi-row payload must scale: {bytes}");
+    assert!(cols[0].contains("52 columns received"), "{}", cols[0]);
+    assert!(cols[0].contains("columns"), "{}", cols[0]);
+    // The wide payload has to be visible in the size the line reports: 52
+    // columns of filler is kilobytes, not bytes.
+    assert!(
+        cols[0].contains("KB") || cols[0].contains("MB"),
+        "a wide payload must report in KB or MB, not bytes: {}",
+        cols[0]
+    );
 }
 
 /// Two-pass (list/detail) lifecycle: a list pass over a 40-row index (one
@@ -436,45 +432,49 @@ async fn two_pass_list_and_detail_lifecycle_is_logged() {
 
     // The seed list page runs detached from `open()`; wait for it to land.
     wait_until("list page return", || {
-        lines_containing(&log, "list page return").len() == 1
+        lines_containing(&log, "list #1 got").len() == 1
     })
     .await;
 
-    let dispatch = lines_containing(&log, "list page dispatch");
-    let ret = lines_containing(&log, "list page return");
+    let dispatch = lines_containing(&log, "list #1 asks");
+    let ret = lines_containing(&log, "list #1 got");
     assert_eq!(dispatch.len(), 1, "{dispatch:?}");
     assert_eq!(ret.len(), 1, "{ret:?}");
     let req = dispatch[0]
-        .split("req=")
+        .split("list #")
         .nth(1)
-        .unwrap()
+        .expect("list dispatch names its request")
         .split_whitespace()
         .next()
-        .unwrap()
+        .expect("request id")
         .to_string();
-    assert!(ret[0].contains(&format!("req={req}")), "{}", ret[0]);
-    assert!(dispatch[0].contains("offset=0"), "{}", dispatch[0]);
-    assert!(dispatch[0].contains("limit="), "{}", dispatch[0]);
-    assert!(ret[0].contains("rows=40"), "{}", ret[0]);
-    assert!(ret[0].contains("index_len=40"), "{}", ret[0]);
-    assert!(ret[0].contains("complete=true"), "{}", ret[0]);
+    assert!(
+        ret[0].contains(&format!("list #{req} got")),
+        "the return must carry the same request id: {}",
+        ret[0]
+    );
+    assert!(dispatch[0].contains("offset 0"), "{}", dispatch[0]);
+    assert!(dispatch[0].contains("ids from"), "{}", dispatch[0]);
+    assert!(ret[0].contains("40 ids"), "{}", ret[0]);
+    assert!(ret[0].contains("40 known so far"), "{}", ret[0]);
+    assert!(ret[0].contains("all of them"), "{}", ret[0]);
 
     // Detail pass over the first 10 rows.
     scenery.set_viewport(0..10);
     wait_until("detail pass requested=10", || {
-        lines_containing(&log, "detail pass")
+        lines_containing(&log, "hydrate")
             .iter()
-            .any(|l| l.contains("requested=10"))
+            .any(|l| l.contains("10 rows in view"))
     })
     .await;
 
-    let detail_lines = lines_containing(&log, "detail pass");
+    let detail_lines = lines_containing(&log, "hydrate");
     assert!(
-        detail_lines.iter().any(|l| l.contains("requested=10")),
+        detail_lines.iter().any(|l| l.contains("10 rows in view")),
         "{detail_lines:?}"
     );
     assert!(
-        detail_lines[0].contains("dio=\"books\""),
+        detail_lines[0].contains("need detail"),
         "{}",
         detail_lines[0]
     );
@@ -531,17 +531,17 @@ async fn cache_writes_report_new_updated_and_percentage() {
 
     scenery.set_viewport(0..30);
     wait_until("first load return", || {
-        lines_containing(&log, "load return").len() == 1
+        lines_containing(&log, "got").len() == 1
     })
     .await;
 
-    let writes = lines_containing(&log, "cache write");
+    let writes = lines_containing(&log, "new,");
     assert_eq!(writes.len(), 1, "{writes:?}");
-    assert!(writes[0].contains("new=30"), "{}", writes[0]);
-    assert!(writes[0].contains("updated=0"), "{}", writes[0]);
-    assert!(writes[0].contains("known_total=100"), "{}", writes[0]);
+    assert!(writes[0].contains("+30 new"), "{}", writes[0]);
+    assert!(writes[0].contains("0 updated"), "{}", writes[0]);
+    assert!(writes[0].contains("of 100"), "{}", writes[0]);
     // 30 of 100 rows → 30%.
-    assert!(writes[0].contains("cached_pct=30"), "{}", writes[0]);
+    assert!(writes[0].contains("(30%)"), "{}", writes[0]);
 }
 
 /// The off-path silence regression: a lens built with no `.debug_datasource`

--- a/vantage-diorama/tests/debug_tap.rs
+++ b/vantage-diorama/tests/debug_tap.rs
@@ -128,10 +128,7 @@ async fn census_lines_fire_on_scenery_open_and_drop() {
     assert_eq!(opens.len(), 1);
     assert!(opens[0].contains("census"), "line: {}", opens[0]);
     assert!(opens[0].contains("now 1 table"), "line: {}", opens[0]);
-    assert!(
-        opens[0].contains("rss"),
-        "census carries process stats"
-    );
+    assert!(opens[0].contains("rss"), "census carries process stats");
 
     drop(scenery);
     // Guard teardown is synchronous; the census drop line is emitted from Drop.
@@ -257,11 +254,7 @@ async fn load_lifecycle_is_correlated_and_cache_hits_are_logged() {
         lines_containing(&log, "served locally").len() == 1
     })
     .await;
-    assert_eq!(
-        lines_containing(&log, "asks for").len(),
-        1,
-        "no re-fetch"
-    );
+    assert_eq!(lines_containing(&log, "asks for").len(), 1, "no re-fetch");
 }
 
 /// A single row with 50 fat extra fields — the wide-data case the "columns"
@@ -315,7 +308,11 @@ async fn column_line_exposes_undemanded_wide_fields() {
     assert_eq!(cols.len(), 1, "{cols:?}");
     assert!(cols[0].contains("columns"), "{}", cols[0]);
     assert!(cols[0].contains("52 columns received"), "{}", cols[0]);
-    assert!(cols[0].contains("KB") || cols[0].contains("B"), "{}", cols[0]);
+    assert!(
+        cols[0].contains("KB") || cols[0].contains("B"),
+        "{}",
+        cols[0]
+    );
     // payload should be dominated by the extras: > 50KB for 1 row wouldn't
     // hold for all rows; just assert it's large.
     // The wide payload has to be visible in the size the line reports: 52

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.13 — 2026-07-30
+
+- **A faker table can now be ordered.** `build` and `build_shaped` seeded the
+  store but never registered the columns as `VistaMetadata`, so the shell
+  reported none and `Vista::add_order` failed every sort with "Unknown column"
+  — on a shape that advertised `order`. Because the failure was instant and the
+  rows never landed, each viewport movement re-requested them, which presented
+  as a hung window. Generated columns are now declared, orderable and
+  searchable, carrying through the `id`/`title`/`searchable` flags they were
+  given.
+- Track vantage-diorama 0.12.
+
 ## 0.6.12 — 2026-07-30
 
 - Track vantage-diorama 0.11. No behavior changes here.

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "async-trait",
  "ciborium",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.12"
+version = "0.6.13"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -18,7 +18,7 @@ readme = "README.md"
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-diorama = { version = "0.11", path = "../vantage-diorama" }
+vantage-diorama = { version = "0.12", path = "../vantage-diorama" }
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"

--- a/vantage-faker/src/lib.rs
+++ b/vantage-faker/src/lib.rs
@@ -70,6 +70,29 @@ pub struct FakerTable {
     _task: Option<AbortOnDrop>,
 }
 
+/// Declare the generated columns on the shell so the Vista can answer for
+/// them. Without this the shell reports no columns at all, and anything that
+/// resolves a column by name — `add_order` most visibly — fails with
+/// "Unknown column" even where the shape advertises the capability. Every
+/// generated column is orderable and searchable: the store is in memory, so
+/// there is no honest reason to refuse either.
+fn faker_metadata(columns: &[FakerColumn], id_column: &str) -> vantage_vista::VistaMetadata {
+    let mut meta = vantage_vista::VistaMetadata::default();
+    for c in columns {
+        let mut col = vantage_vista::Column::new(&c.name, &c.ty)
+            .with_flag(vantage_vista::flags::ORDERABLE)
+            .with_flag(vantage_vista::flags::SEARCHABLE);
+        for f in &c.flags {
+            col = col.with_flag(f);
+        }
+        if c.name == id_column {
+            col = col.with_flag(vantage_vista::flags::ID);
+        }
+        meta.columns.insert(c.name.clone(), col);
+    }
+    meta
+}
+
 impl FakerTable {
     /// Build a faker table from its schema and a chosen effect.
     ///
@@ -82,14 +105,15 @@ impl FakerTable {
         id_column: impl Into<String>,
         effect: Box<dyn FakerEffect>,
     ) -> Self {
-        let shell = MockShell::new();
+        let id_column = id_column.into();
+        let shell = MockShell::new().with_metadata(faker_metadata(&columns, &id_column));
         let (events, _) = broadcast::channel(EVENT_CAPACITY);
 
         let ctx = std::sync::Arc::new(FakerCtx::new(
             shell.clone(),
             events.clone(),
             columns,
-            id_column.into(),
+            id_column,
         ));
 
         effect.seed(&ctx);
@@ -121,7 +145,8 @@ impl FakerTable {
         effect: Box<dyn FakerEffect>,
         shape: BackendShape,
     ) -> Self {
-        let shell = MockShell::new();
+        let id_column = id_column.into();
+        let shell = MockShell::new().with_metadata(faker_metadata(&columns, &id_column));
         let (events, _) = broadcast::channel(EVENT_CAPACITY);
 
         let values = match shape.seed {
@@ -131,7 +156,7 @@ impl FakerTable {
         .with_weirdness(shape.weirdness);
 
         let ctx = std::sync::Arc::new(
-            FakerCtx::new(shell.clone(), events.clone(), columns, id_column.into())
+            FakerCtx::new(shell.clone(), events.clone(), columns, id_column)
                 .with_values(values)
                 .with_extra_fields(shape.extra_fields)
                 .with_seed(shape.seed),

--- a/vantage-faker/src/shape.rs
+++ b/vantage-faker/src/shape.rs
@@ -224,10 +224,9 @@ impl ShapedShell {
             let mut delay = band.map(|b| b.draw(rng)).unwrap_or_default();
             if matches!(class, OpClass::List | OpClass::Window)
                 && self.searching.load(Ordering::Relaxed)
+                && let Some(extra) = self.shape.latency.search_extra
             {
-                if let Some(extra) = self.shape.latency.search_extra {
-                    delay += extra.draw(rng);
-                }
+                delay += extra.draw(rng);
             }
             let failed = self.shape.faults.error_rate > 0.0
                 && rng.random_range(0.0..1.0) < self.shape.faults.error_rate;


### PR DESCRIPTION
Follow-on to #374. Reading the stream against a real app made two things obvious: the lines were written for whoever wrote the code, and two of them were reporting a fault rather than a state.

## The stream

Every line now has the same four parts — time, datasource, origin, message — and the message is a sentence with units a person reads:

```
21:20:15.399  people  source    can count, window, order, search · pages lazily, 100 rows at a time
21:20:15.455  people  dio       fetch #1 asks for rows 0..200 — 200 missing, 0 already held
21:20:18.493  people  cache     +200 new, 0 updated — now holding 200 of 200,000 (0.1%)
21:20:18.494  people  dio       fetch #1 got 200 rows in 3.0s  ⚠ slow
21:20:18.494  people  payload   6 columns received · no view declared what it needs, so all were fetched · 23KB
21:20:18.551  people  cache     all 13 rows of 0..13 served locally — no fetch
```

`fetch #N` correlates a request with its result, `⚠ slow` marks a request of one second or more, and durations, byte counts, and row counts print in human units (`3.0s`, `23KB`, `200,000`, `0.1%`).

The payload line no longer claims `206/206 columns displayed` when the grid shows five — that reads as a clean bill of health for the exact case it should flag. It now says what happened: `206 columns received · no view declared what it needs, so all were fetched`.

## Two faults the stream exposed

**Faker tables could not be ordered.** `MockShell` was built without `VistaMetadata`, so `Vista::add_order` failed with *Unknown column* for every column. The failure was instant and deterministic, so a sorted viewport retried at full speed and the app appeared to hang. Columns are now registered with `ORDERABLE`/`SEARCHABLE` (and `ID` for the id column).

**A paged view kept stale row positions across a sort.** `reseed_from_cache` re-sorted whatever subset the cache held and seated it at rows 0..N, so after a sort the first page was a sorted sample of the loaded rows presented as the head of the set. A paged view over a source that orders now drops its cached positions and refetches the visible window. Views that hold the complete set still sort locally, and two-pass views are unaffected — their positions come from the query index.

`tests/chunk_server_sort_positions.rs` covers it: without the fix the first row after sorting is `a39` instead of `a59`.

## Versions

diorama 0.11.0 → 0.12.0, aggregate 0.6.5 → 0.6.6, faker 0.6.12 → 0.6.13, with changelogs.

The last commit is preflight: rustfmt on the three files this branch touched, plus two clippy lints that the 1.95 toolchain flags — one of them (`collapsible_if` in `vantage-faker/src/shape.rs`) pre-existing, since that crate has no workflow of its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a redesigned, human-readable debug stream with request correlation, lifecycle events, cache/loading details, and aggregate recomputation status.
  * Added clearer summaries for durations, row counts, payload sizes, and percentages.
  * Faker-generated tables now support ordering and searching metadata, including configured ID columns.

* **Bug Fixes**
  * Server-side sorting now refreshes visible rows instead of reusing stale cached positions.
  * Request numbering now starts at 1.

* **Documentation**
  * Added release notes documenting the updated diagnostics and table behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->