### PR TITLE
Condition groups for or_/and_, and a search that keeps the conditions of the table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.6.17 — 2026-08-07
+
+- **Bug fix:** a search keeps the conditions of the table. The search
+  looks in each column, and `AND` binds more tightly than `OR`. Thus
+  `role = 'admin' AND <first branch> OR <second branch>` let each row
+  that matched a later branch ignore the role condition. The branches
+  are now one group with brackets.
+- `or_` and `and_` are also methods on the operation trait:
+  `price.gt(100).or_(featured.eq(true))`. The functions stay available.
+- **Behaviour change:** `or_` and `and_` give a `ConditionGroup`, which
+  writes one set of brackets around the chain and no brackets around
+  each operand. `or_(a, b)` gave `(a) OR (b)`, and it now gives
+  `(a OR b)`. A chain stays flat: `a.or_(b).or_(c)` gives
+  `(a OR b OR c)`, not a nest. To make a different group, nest the
+  calls: `a.or_(b.or_(c))`.
+
 ## 0.6.16 — 2026-07-26
 
 - **Behaviour change:** a Postgres vista no longer advertises `can_subscribe`

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -46,7 +46,10 @@ serde_yaml_ng = "0.10"
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
 sqlformat = "0.3"
 
+# The name must be unique across the workspace: cargo writes every
+# example to the same target/debug/examples directory, and two targets
+# with one name overwrite each other.
 [[example]]
-name = "rhai_test"
+name = "rhai_test_sql"
 path = "examples/rhai_test.rs"
 required-features = ["rhai"]

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/condition.rs
+++ b/vantage-sql/src/condition.rs
@@ -174,6 +174,43 @@ macro_rules! define_sql_operation {
         where
             T: Into<$any_type> + Send + Clone + 'static,
         {
+            /// `(self OR other)` — joins two conditions into a
+            /// `ConditionGroup`.
+            ///
+            /// Use this method to write alternatives. Do not write
+            /// `"a OR b"` as text. The group writes its own brackets,
+            /// and it keeps its meaning next to the other conditions.
+            /// Text has no brackets, and `AND` binds more tightly than
+            /// `OR`. Thus `role = 'admin' AND a OR b` means
+            /// `(role = 'admin' AND a) OR b`.
+            ///
+            /// A chain stays flat: `a.or_(b).or_(c)` gives
+            /// `(a OR b OR c)`.
+            fn or_(
+                &self,
+                other: impl $crate::vantage_expressions::Expressive<T>,
+            ) -> $crate::primitives::ConditionGroup<T>
+            where
+                Self: Sized,
+            {
+                $crate::primitives::or_(self.expr(), other.expr())
+            }
+
+            /// `(self AND other)` — joins two conditions into a
+            /// `ConditionGroup`.
+            ///
+            /// A table joins its conditions with `AND` already. Use this
+            /// method when you must make a group inside an `or_`.
+            fn and_(
+                &self,
+                other: impl $crate::vantage_expressions::Expressive<T>,
+            ) -> $crate::primitives::ConditionGroup<T>
+            where
+                Self: Sized,
+            {
+                $crate::primitives::and_(self.expr(), other.expr())
+            }
+
             /// `field = value`
             fn eq(&self, value: impl $crate::vantage_expressions::Expressive<T>) -> $condition
             where

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -152,10 +152,24 @@ impl TableSource for MysqlDB {
             })
             .collect();
 
-        if conditions.is_empty() {
+        // Add each branch with `or_`. The accumulator stays a group, and
+        // thus the branches stay flat: `(a OR b OR c)`, not
+        // `((a OR b) OR c)`. The brackets of the group keep the other
+        // conditions of the table when WHERE joins them with AND.
+        let mut branches = conditions.into_iter();
+        let Some(first) = branches.next() else {
+            // The table has no columns to search. Match no rows.
             return mysql_expr!("FALSE").into();
+        };
+        let Some(second) = branches.next() else {
+            // One branch needs no group.
+            return first.into();
+        };
+        let mut group = crate::primitives::or_(first, second);
+        for branch in branches {
+            group = group.or_(branch);
         }
-        Expression::from_vec(conditions, " OR ").into()
+        group.expr().into()
     }
 
     async fn list_table_values<E>(

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -170,10 +170,24 @@ impl TableSource for PostgresDB {
             })
             .collect();
 
-        if conditions.is_empty() {
+        // Add each branch with `or_`. The accumulator stays a group, and
+        // thus the branches stay flat: `(a OR b OR c)`, not
+        // `((a OR b) OR c)`. The brackets of the group keep the other
+        // conditions of the table when WHERE joins them with AND.
+        let mut branches = conditions.into_iter();
+        let Some(first) = branches.next() else {
+            // The table has no columns to search. Match no rows.
             return postgres_expr!("FALSE").into();
+        };
+        let Some(second) = branches.next() else {
+            // One branch needs no group.
+            return first.into();
+        };
+        let mut group = crate::primitives::or_(first, second);
+        for branch in branches {
+            group = group.or_(branch);
         }
-        Expression::from_vec(conditions, " OR ").into()
+        group.expr().into()
     }
 
     async fn list_table_values<E>(

--- a/vantage-sql/src/primitives/logical.rs
+++ b/vantage-sql/src/primitives/logical.rs
@@ -1,84 +1,117 @@
-//! Logical combinators for SQL conditions: `or_()` and `and_()`.
+//! Logical operators for SQL conditions: `or_()` and `and_()`, and the
+//! [`ConditionGroup`] that they make.
 //!
-//! These combine two expressions with `OR` / `AND`, wrapping each side
-//! in parentheses to preserve precedence.
+//! A group writes one set of brackets around the full chain. It writes
+//! no brackets around each operand: `(a OR b OR c)`. A chain stays flat
+//! while the operator does not change, and thus `a.or_(b).or_(c)` gives
+//! `(a OR b OR c)`. To make a different group, nest the calls.
+//! `a.or_(b.or_(c))` gives `(a OR (b OR c))`, because the inner group is
+//! an operand and it writes its own brackets.
+//!
+//! The group writes the brackets. The statement renderer does not.
+//! `WHERE` joins its conditions with a plain `AND`, and each group
+//! arrives complete. This keeps the conditions of a table when a search
+//! runs on top of them. The query says `role = 'admin' AND (a OR b)`. It
+//! does not say `role = 'admin' AND a OR b`, which means
+//! `(role = 'admin' AND a) OR b`, because `AND` binds more tightly than
+//! `OR`.
 
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
 
-/// Combines two conditions with `OR`: `(lhs) OR (rhs)`.
+/// Conditions that one logical operator joins, written as a single
+/// group in brackets. To make a group, call [`or_`] or [`and_`], or use
+/// the `or_` and `and_` methods on a column or an identifier.
+#[derive(Clone)]
+pub struct ConditionGroup<T> {
+    operator: &'static str,
+    operands: Vec<Expression<T>>,
+}
+
+impl<T> std::fmt::Debug for ConditionGroup<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConditionGroup")
+            .field("operator", &self.operator)
+            .field("operands", &self.operands.len())
+            .finish()
+    }
+}
+
+impl<T: Clone> ConditionGroup<T> {
+    pub(crate) fn new(operator: &'static str, operands: Vec<Expression<T>>) -> Self {
+        Self { operator, operands }
+    }
+
+    /// Adds a condition with `OR`. If this group is an `OR` chain, the
+    /// condition goes into the same group.
+    ///
+    /// This method is inherent. Rust selects it before the `or_` of the
+    /// operation trait, and this keeps a chain flat.
+    pub fn or_(self, other: impl Expressive<T>) -> Self {
+        self.extend("OR", other.expr())
+    }
+
+    /// Adds a condition with `AND`. If this group is an `AND` chain, the
+    /// condition goes into the same group.
+    pub fn and_(self, other: impl Expressive<T>) -> Self {
+        self.extend("AND", other.expr())
+    }
+
+    fn extend(mut self, operator: &'static str, other: Expression<T>) -> Self {
+        if self.operator == operator {
+            self.operands.push(other);
+            self
+        } else {
+            // The operator changes. The chain to this point becomes one
+            // operand of the new group. It keeps its brackets and its
+            // meaning.
+            Self::new(operator, vec![self.expr(), other])
+        }
+    }
+}
+
+impl<T: Clone> Expressive<T> for ConditionGroup<T> {
+    fn expr(&self) -> Expression<T> {
+        let separator = format!(" {} ", self.operator);
+        let template = std::iter::repeat_n("{}", self.operands.len())
+            .collect::<Vec<_>>()
+            .join(&separator);
+        Expression::new(
+            format!("({template})"),
+            self.operands
+                .iter()
+                .cloned()
+                .map(ExpressiveEnum::Nested)
+                .collect(),
+        )
+    }
+}
+
+/// Joins two conditions with `OR`: `(lhs OR rhs)`.
 ///
 /// ```ignore
 /// use vantage_sql::primitives::*;
 ///
 /// or_(ident("role").eq("admin"), ident("role").eq("superuser"))
-/// // => ("role" = 'admin') OR ("role" = 'superuser')
+/// // => ("role" = 'admin' OR "role" = 'superuser')
 /// ```
-pub fn or_<T>(lhs: impl Expressive<T>, rhs: impl Expressive<T>) -> Expression<T> {
-    Expression::new(
-        "({}) OR ({})",
-        vec![
-            ExpressiveEnum::Nested(lhs.expr()),
-            ExpressiveEnum::Nested(rhs.expr()),
-        ],
-    )
+pub fn or_<T: Clone>(lhs: impl Expressive<T>, rhs: impl Expressive<T>) -> ConditionGroup<T> {
+    ConditionGroup::new("OR", vec![lhs.expr(), rhs.expr()])
 }
 
-/// Combines two conditions with `AND`: `(lhs) AND (rhs)`.
+/// Joins two conditions with `AND`: `(lhs AND rhs)`.
 ///
-/// Useful when you need explicit grouping — `with_condition()` already
-/// combines multiple conditions with `AND`, but `and_()` lets you nest
-/// it inside an `or_()`:
+/// `with_condition()` joins its conditions with `AND` already. Use
+/// `and_()` when you must make a group inside an `or_()`:
 ///
 /// ```ignore
 /// use vantage_sql::primitives::*;
 ///
-/// // (price > 100 AND in_stock = 1) OR (featured = 1)
+/// // ((price > 100 AND in_stock = 1) OR featured = 1)
 /// or_(
 ///     and_(ident("price").gt(100), ident("in_stock").eq(true)),
 ///     ident("featured").eq(true),
 /// )
 /// ```
-pub fn and_<T>(lhs: impl Expressive<T>, rhs: impl Expressive<T>) -> Expression<T> {
-    Expression::new(
-        "({}) AND ({})",
-        vec![
-            ExpressiveEnum::Nested(lhs.expr()),
-            ExpressiveEnum::Nested(rhs.expr()),
-        ],
-    )
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_or_preview() {
-        let expr: Expression<i32> = or_(
-            Expression::new("a = {}", vec![ExpressiveEnum::Scalar(1)]),
-            Expression::new("b = {}", vec![ExpressiveEnum::Scalar(2)]),
-        );
-        assert_eq!(expr.preview(), "(a = 1) OR (b = 2)");
-    }
-
-    #[test]
-    fn test_and_preview() {
-        let expr: Expression<i32> = and_(
-            Expression::new("a = {}", vec![ExpressiveEnum::Scalar(1)]),
-            Expression::new("b = {}", vec![ExpressiveEnum::Scalar(2)]),
-        );
-        assert_eq!(expr.preview(), "(a = 1) AND (b = 2)");
-    }
-
-    #[test]
-    fn test_nested_or_and() {
-        let expr: Expression<i32> = or_(
-            and_(
-                Expression::new("a = {}", vec![ExpressiveEnum::Scalar(1)]),
-                Expression::new("b = {}", vec![ExpressiveEnum::Scalar(2)]),
-            ),
-            Expression::new("c = {}", vec![ExpressiveEnum::Scalar(3)]),
-        );
-        assert_eq!(expr.preview(), "((a = 1) AND (b = 2)) OR (c = 3)");
-    }
+pub fn and_<T: Clone>(lhs: impl Expressive<T>, rhs: impl Expressive<T>) -> ConditionGroup<T> {
+    ConditionGroup::new("AND", vec![lhs.expr(), rhs.expr()])
 }

--- a/vantage-sql/src/primitives/mod.rs
+++ b/vantage-sql/src/primitives/mod.rs
@@ -24,5 +24,5 @@ pub use group_concat::GroupConcat;
 pub use identifier::{Identifier, ident};
 pub use iif::Iif;
 pub use interval::Interval;
-pub use logical::{and_, or_};
+pub use logical::{ConditionGroup, and_, or_};
 pub use ternary::ternary;

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -146,10 +146,24 @@ impl TableSource for SqliteDB {
             })
             .collect();
 
-        if conditions.is_empty() {
+        // Add each branch with `or_`. The accumulator stays a group, and
+        // thus the branches stay flat: `(a OR b OR c)`, not
+        // `((a OR b) OR c)`. The brackets of the group keep the other
+        // conditions of the table when WHERE joins them with AND.
+        let mut branches = conditions.into_iter();
+        let Some(first) = branches.next() else {
+            // The table has no columns to search. Match no rows.
             return sqlite_expr!("0").into();
+        };
+        let Some(second) = branches.next() else {
+            // One branch needs no group.
+            return first.into();
+        };
+        let mut group = crate::primitives::or_(first, second);
+        for branch in branches {
+            group = group.or_(branch);
         }
-        Expression::from_vec(conditions, " OR ").into()
+        group.expr().into()
     }
 
     async fn list_table_values<E>(

--- a/vantage-sql/tests/mysql/2_search.rs
+++ b/vantage-sql/tests/mysql/2_search.rs
@@ -4,6 +4,7 @@
 use vantage_dataset::ReadableDataSet;
 #[allow(unused_imports)]
 use vantage_sql::mysql::{AnyMysqlType, MysqlDB, MysqlType};
+use vantage_sql::mysql_expr;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::entity;
@@ -14,6 +15,13 @@ const MYSQL_URL: &str = "mysql://vantage:vantage@localhost:3306/vantage";
 #[derive(Debug, Clone, PartialEq, Default)]
 struct Item {
     name: String,
+}
+
+#[entity(MysqlType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Doc {
+    name: String,
+    status: String,
 }
 
 async fn setup(suffix: &str, rows: &[&str]) -> (MysqlDB, Table<MysqlDB, Item>) {
@@ -83,4 +91,52 @@ async fn test_search_backslash_literal() {
     let results = table.list().await.unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results.values().next().unwrap().name, "path\\to\\file");
+}
+
+/// A search must keep the conditions of the table. The search looks in
+/// each column and joins the branches with `OR`, and `AND` binds more
+/// tightly than `OR`. Without a group, the query reads as
+/// `(status = 'registered' AND <branch 1>) OR <branch 2> …`, and each
+/// row that matches a later branch ignores the status condition.
+#[tokio::test]
+async fn test_search_keeps_table_conditions() {
+    let db = MysqlDB::connect(MYSQL_URL).await.unwrap();
+    sqlx::query("DROP TABLE IF EXISTS `search_cond`")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE `search_cond` (id VARCHAR(255) PRIMARY KEY, name TEXT NOT NULL, status TEXT NOT NULL)",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    for (id, name, status) in [("1", "alpha", "registered"), ("2", "beta", "draft")] {
+        sqlx::query("INSERT INTO `search_cond` (id, name, status) VALUES (?, ?, ?)")
+            .bind(id)
+            .bind(name)
+            .bind(status)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    let table = Table::<MysqlDB, Doc>::new("search_cond", db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("status")
+        .with_condition(mysql_expr!("`status` = {}", "registered"));
+
+    // "draft" matches the status column of row 2 only. Row 2 fails the
+    // status condition, so the search finds no rows.
+    let mut filtered = table.clone();
+    filtered.add_condition(db.search_table_condition(&table, "draft"));
+    assert_eq!(filtered.list().await.unwrap().len(), 0);
+
+    // A search that matches a row which meets the condition finds it.
+    let mut filtered = table.clone();
+    filtered.add_condition(db.search_table_condition(&table, "alpha"));
+    let results = filtered.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "alpha");
 }

--- a/vantage-sql/tests/postgres/2_search.rs
+++ b/vantage-sql/tests/postgres/2_search.rs
@@ -4,6 +4,7 @@
 use vantage_dataset::ReadableDataSet;
 #[allow(unused_imports)]
 use vantage_sql::postgres::{AnyPostgresType, PostgresDB, PostgresType};
+use vantage_sql::postgres_expr;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::entity;
@@ -14,6 +15,13 @@ const PG_URL: &str = "postgres://vantage:vantage@localhost:5433/vantage";
 #[derive(Debug, Clone, PartialEq, Default)]
 struct Item {
     name: String,
+}
+
+#[entity(PostgresType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Doc {
+    name: String,
+    status: String,
 }
 
 async fn setup(suffix: &str, rows: &[&str]) -> (PostgresDB, Table<PostgresDB, Item>) {
@@ -82,4 +90,52 @@ async fn test_search_backslash_literal() {
     let results = table.list().await.unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results.values().next().unwrap().name, "path\\to\\file");
+}
+
+/// A search must keep the conditions of the table. The search looks in
+/// each column and joins the branches with `OR`, and `AND` binds more
+/// tightly than `OR`. Without a group, the query reads as
+/// `(status = 'registered' AND <branch 1>) OR <branch 2> …`, and each
+/// row that matches a later branch ignores the status condition.
+#[tokio::test]
+async fn test_search_keeps_table_conditions() {
+    let db = PostgresDB::connect(PG_URL).await.unwrap();
+    sqlx::query("DROP TABLE IF EXISTS \"search_cond\"")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TABLE \"search_cond\" (id TEXT PRIMARY KEY, name TEXT NOT NULL, status TEXT NOT NULL)",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+    for (id, name, status) in [("1", "alpha", "registered"), ("2", "beta", "draft")] {
+        sqlx::query("INSERT INTO \"search_cond\" (id, name, status) VALUES ($1, $2, $3)")
+            .bind(id)
+            .bind(name)
+            .bind(status)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    let table = Table::<PostgresDB, Doc>::new("search_cond", db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("status")
+        .with_condition(postgres_expr!("\"status\" = {}", "registered"));
+
+    // "draft" matches the status column of row 2 only. Row 2 fails the
+    // status condition, so the search finds no rows.
+    let mut filtered = table.clone();
+    filtered.add_condition(db.search_table_condition(&table, "draft"));
+    assert_eq!(filtered.list().await.unwrap().len(), 0);
+
+    // A search that matches a row which meets the condition finds it.
+    let mut filtered = table.clone();
+    filtered.add_condition(db.search_table_condition(&table, "alpha"));
+    let results = filtered.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "alpha");
 }

--- a/vantage-sql/tests/sqlite/2_primitives.rs
+++ b/vantage-sql/tests/sqlite/2_primitives.rs
@@ -179,31 +179,46 @@ fn test_ident_alias() {
 
 // ── or_ / and_ ─────────────────────────────────────────────────────
 
+/// How conditions make groups. `AND` binds more tightly than `OR`. Thus
+/// alternatives without brackets change the query: `role = 'admin' AND a
+/// OR b` means `(role = 'admin' AND a) OR b`, and each row that matches
+/// only `b` ignores the role condition. `or_` and `and_` write the
+/// brackets. The statement renderer does not.
 #[test]
-fn test_or_with_ident() {
-    let expr = or_(ident("role").eq("admin"), ident("role").eq("superuser"));
-    assert_eq!(
-        expr.preview(),
-        "(\"role\" = 'admin') OR (\"role\" = 'superuser')"
-    );
-}
-
-#[test]
-fn test_or_with_typed_columns() {
-    let price = Column::<i64>::new("price");
-    let featured = Column::<bool>::new("featured");
-    let expr = or_(price.gt(100i64), featured.eq(true));
-    assert_eq!(expr.preview(), "(price > 100) OR (featured = 1)");
-}
-
-#[test]
-fn test_nested_and_inside_or() {
+fn test_condition_grouping() {
     let price = Column::<i64>::new("price");
     let in_stock = Column::<bool>::new("in_stock");
     let featured = Column::<bool>::new("featured");
-    let expr = or_(and_(price.gt(100i64), in_stock.eq(true)), featured.eq(true));
+
+    // A chain is one flat group. It has one set of brackets around the
+    // full chain, and no brackets around each operand.
     assert_eq!(
-        expr.preview(),
-        "((price > 100) AND (in_stock = 1)) OR (featured = 1)"
+        price
+            .gt(100i64)
+            .or_(in_stock.eq(true))
+            .or_(featured.eq(true))
+            .preview(),
+        "(price > 100 OR in_stock = 1 OR featured = 1)"
+    );
+
+    // Nest the calls, and the inner group writes its own brackets.
+    assert_eq!(
+        price
+            .gt(100i64)
+            .or_(in_stock.eq(true).or_(featured.eq(true)))
+            .preview(),
+        "(price > 100 OR (in_stock = 1 OR featured = 1))"
+    );
+
+    // The operator changes. The chain to this point becomes one operand.
+    assert_eq!(
+        or_(and_(price.gt(100i64), in_stock.eq(true)), featured.eq(true)).preview(),
+        "((price > 100 AND in_stock = 1) OR featured = 1)"
+    );
+
+    // The function and the method give the same result.
+    assert_eq!(
+        or_(ident("role").eq("admin"), ident("role").eq("superuser")).preview(),
+        "(\"role\" = 'admin' OR \"role\" = 'superuser')"
     );
 }

--- a/vantage-sql/tests/sqlite/2_search.rs
+++ b/vantage-sql/tests/sqlite/2_search.rs
@@ -4,6 +4,7 @@
 use vantage_dataset::ReadableDataSet;
 #[allow(unused_imports)]
 use vantage_sql::sqlite::{AnySqliteType, SqliteDB, SqliteType};
+use vantage_sql::sqlite_expr;
 use vantage_table::table::Table;
 use vantage_table::traits::table_source::TableSource;
 use vantage_types::entity;
@@ -12,6 +13,13 @@ use vantage_types::entity;
 #[derive(Debug, Clone, PartialEq, Default)]
 struct Item {
     name: String,
+}
+
+#[entity(SqliteType)]
+#[derive(Debug, Clone, PartialEq, Default)]
+struct Doc {
+    name: String,
+    status: String,
 }
 
 async fn setup(rows: &[&str]) -> (SqliteDB, Table<SqliteDB, Item>) {
@@ -68,4 +76,46 @@ async fn test_search_backslash_literal() {
     let results = table.list().await.unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results.values().next().unwrap().name, "path\\to\\file");
+}
+
+/// A search must keep the conditions of the table. The search looks in
+/// each column and joins the branches with `OR`, and `AND` binds more
+/// tightly than `OR`. Without a group, the query reads as
+/// `(status = 'registered' AND <branch 1>) OR <branch 2> …`, and each
+/// row that matches a later branch ignores the status condition.
+#[tokio::test]
+async fn test_search_keeps_table_conditions() {
+    let db = SqliteDB::connect("sqlite::memory:").await.unwrap();
+    sqlx::query("CREATE TABLE doc (id TEXT PRIMARY KEY, name TEXT NOT NULL, status TEXT NOT NULL)")
+        .execute(db.pool())
+        .await
+        .unwrap();
+    for (id, name, status) in [("1", "alpha", "registered"), ("2", "beta", "draft")] {
+        sqlx::query("INSERT INTO doc (id, name, status) VALUES (?, ?, ?)")
+            .bind(id)
+            .bind(name)
+            .bind(status)
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    let table = Table::<SqliteDB, Doc>::new("doc", db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<String>("status")
+        .with_condition(sqlite_expr!("\"status\" = {}", "registered"));
+
+    // "draft" matches the status column of row 2 only. Row 2 fails the
+    // status condition, so the search finds no rows.
+    let mut filtered = table.clone();
+    filtered.add_condition(db.search_table_condition(&table, "draft"));
+    assert_eq!(filtered.list().await.unwrap().len(), 0);
+
+    // A search that matches a row which meets the condition finds it.
+    let mut filtered = table.clone();
+    filtered.add_condition(db.search_table_condition(&table, "alpha"));
+    let results = filtered.list().await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.values().next().unwrap().name, "alpha");
 }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.6.13 — 2026-08-07
+
+- **Bug fix:** a search keeps the conditions of the table. The search
+  looks in each column, and `AND` binds more tightly than `OR`. Thus
+  `status = 'registered' AND <first branch> OR <second branch>` let each
+  row that matched a later branch ignore the status condition. The
+  branches are now one group with brackets.
+- **Bug fix:** a search also looks in computed columns. The query writes
+  a column with an `expr:` script as `(<expr>) AS <name>`. The alias does
+  not exist where the `WHERE` clause runs, and thus a search on the alias
+  matched no rows. The search now uses the expression.
+- `or_` and `and_` on `SurrealOperation` make alternatives. Do not write
+  `"a OR b"` as text. These methods give a `ConditionGroup`, which writes
+  one set of brackets around the chain and no brackets around each
+  operand: `a.or_(b).or_(c)` gives `(a OR b OR c)`. A chain stays flat.
+  To make a different group, nest the calls: `a.or_(b.or_(c))`.
+
 ## 0.6.12 — 2026-07-28
 
 - `fetch_window` serves a row-indexed window as `LIMIT n START m`. The

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -99,7 +99,10 @@ vantage-vista = { version = "0.6", path = "../vantage-vista" }
 name = "expr"
 path = "examples/expr.rs"
 
+# The name must be unique across the workspace: cargo writes every
+# example to the same target/debug/examples directory, and two targets
+# with one name overwrite each other.
 [[example]]
-name = "rhai_test"
+name = "rhai_test_surreal"
 path = "examples/rhai_test.rs"
 required-features = ["rhai"]

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.12"
+version = "0.6.13"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/operation.rs
+++ b/vantage-surrealdb/src/operation.rs
@@ -1,7 +1,8 @@
 //! SurrealDB-specific operations for expressions.
 //!
 //! - `SurrealOperation` — common comparison methods (eq, ne, gt, gte, lt, lte,
-//!   in_) producing `Expression<AnySurrealType>`.
+//!   in_) that give an `Expression<AnySurrealType>`. It also has `or_` and
+//!   `and_`, which join conditions into a [`ConditionGroup`].
 //! - `RefOperation` — SurrealDB-specific graph traversal (rref/lref),
 //!   subtraction, CONTAINS, and parenthesis-free IN.
 
@@ -10,10 +11,109 @@ use vantage_expressions::{Expression, Expressive};
 
 use crate::{AnySurrealType, Expr, identifier::Identifier, surreal_expr};
 
+/// Conditions that one logical operator joins. The group writes one set
+/// of brackets around the full chain. It writes no brackets around each
+/// operand: `(a OR b OR c)`.
+///
+/// A chain stays flat while the operator does not change. `a.or_(b).or_(c)`
+/// gives `(a OR b OR c)`. To make a different group, nest the calls.
+/// `a.or_(b.or_(c))` gives `(a OR (b OR c))`, because the inner group is
+/// an operand and it writes its own brackets.
+///
+/// The group writes the brackets. The statement renderer does not.
+/// `WHERE` joins its conditions with a plain `AND`, and each group
+/// arrives complete. This keeps the conditions of a table when a search
+/// runs on top of them. The query says `status = 'x' AND (a OR b)`. It
+/// does not say `status = 'x' AND a OR b`, which means
+/// `(status = 'x' AND a) OR b`, because `AND` binds more tightly
+/// than `OR`.
+#[derive(Debug, Clone)]
+pub struct ConditionGroup {
+    operator: &'static str,
+    operands: Vec<Expr>,
+}
+
+impl ConditionGroup {
+    pub(crate) fn new(operator: &'static str, operands: Vec<Expr>) -> Self {
+        Self { operator, operands }
+    }
+
+    /// Adds a condition with `OR`. If this group is an `OR` chain, the
+    /// condition goes into the same group.
+    ///
+    /// This method is inherent. Rust selects it before the blanket
+    /// [`SurrealOperation::or_`], and this keeps a chain flat.
+    pub fn or_(self, other: impl Expressive<AnySurrealType>) -> Self {
+        self.extend("OR", other.expr())
+    }
+
+    /// Adds a condition with `AND`. If this group is an `AND` chain, the
+    /// condition goes into the same group.
+    pub fn and_(self, other: impl Expressive<AnySurrealType>) -> Self {
+        self.extend("AND", other.expr())
+    }
+
+    fn extend(mut self, operator: &'static str, other: Expr) -> Self {
+        if self.operator == operator {
+            self.operands.push(other);
+            self
+        } else {
+            // The operator changes. The chain to this point becomes one
+            // operand of the new group. It keeps its brackets and its
+            // meaning.
+            Self::new(operator, vec![self.expr(), other])
+        }
+    }
+}
+
+impl Expressive<AnySurrealType> for ConditionGroup {
+    fn expr(&self) -> Expr {
+        let separator = format!(" {} ", self.operator);
+        let template = std::iter::repeat_n("{}", self.operands.len())
+            .collect::<Vec<_>>()
+            .join(&separator);
+        Expression::new(
+            format!("({template})"),
+            self.operands
+                .iter()
+                .cloned()
+                .map(ExpressiveEnum::Nested)
+                .collect(),
+        )
+    }
+}
+
 /// Standard comparison operations for SurrealDB expressions.
 ///
 /// Blanket-implemented for all `Expressive<AnySurrealType>`.
 pub trait SurrealOperation: Expressive<AnySurrealType> {
+    /// `(self OR other)` — joins two conditions into a
+    /// [`ConditionGroup`].
+    ///
+    /// Use this method to write alternatives. Do not write `"a OR b"` as
+    /// text. The group writes its own brackets, and it keeps its meaning
+    /// next to the other conditions. Text has no brackets, and `AND`
+    /// binds more tightly than `OR`. Thus `status = 'x' AND a OR b`
+    /// means `(status = 'x' AND a) OR b`.
+    fn or_(&self, other: impl Expressive<AnySurrealType>) -> ConditionGroup
+    where
+        Self: Sized,
+    {
+        ConditionGroup::new("OR", vec![self.expr(), other.expr()])
+    }
+
+    /// `(self AND other)` — joins two conditions into a
+    /// [`ConditionGroup`].
+    ///
+    /// A table joins its conditions with `AND` already. Use this method
+    /// when you must make a group inside an [`Self::or_`].
+    fn and_(&self, other: impl Expressive<AnySurrealType>) -> ConditionGroup
+    where
+        Self: Sized,
+    {
+        ConditionGroup::new("AND", vec![self.expr(), other.expr()])
+    }
+
     /// `field = value`
     fn eq(&self, value: impl Expressive<AnySurrealType>) -> Expr
     where

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -164,18 +164,38 @@ impl TableSource for SurrealDB {
             .filter(|col| !table.is_imported_column(col.name()))
             .map(|col| {
                 let needle = search_value.to_lowercase();
+                // The query writes a computed column as `(<expr>) AS <name>`.
+                // The alias does not exist where the WHERE clause runs, so
+                // search the expression instead. For a usual column,
+                // `get_column_expr` gives the identifier.
+                let target = table
+                    .get_column_expr(col.name())
+                    .unwrap_or_else(|| crate::surreal_expr!("{}", (Identifier::new(col.name()))));
                 crate::surreal_expr!(
-                    "string::contains(string::lowercase(<string>{}), {})",
-                    (Identifier::new(col.name())),
+                    "string::contains(string::lowercase(<string>({})), {})",
+                    (target),
                     needle
                 )
             })
             .collect();
-        if parts.is_empty() {
-            crate::surreal_expr!("false")
-        } else {
-            Expression::from_vec(parts, " OR ")
+        // Add each branch with `or_`. The accumulator stays a group, and
+        // thus the branches stay flat: `(a OR b OR c)`, not
+        // `((a OR b) OR c)`. The brackets of the group keep the other
+        // conditions of the table when WHERE joins them with AND.
+        let mut branches = parts.into_iter();
+        let Some(first) = branches.next() else {
+            // The table has no columns to search. Match no rows.
+            return crate::surreal_expr!("false");
+        };
+        let Some(second) = branches.next() else {
+            // One branch does not need a group.
+            return first;
+        };
+        let mut group = first.or_(second);
+        for branch in branches {
+            group = group.or_(branch);
         }
+        group.expr()
     }
 
     async fn list_table_values<E>(

--- a/vantage-surrealdb/tests/search_expression.rs
+++ b/vantage-surrealdb/tests/search_expression.rs
@@ -1,4 +1,8 @@
 use surreal_client::{MockSurrealEngine, SurrealClient};
+use vantage_expressions::Expressive;
+use vantage_surrealdb::identifier::Identifier;
+use vantage_surrealdb::operation::SurrealOperation;
+use vantage_surrealdb::select::SurrealSelect;
 use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_table::prelude::*;
 use vantage_types::EmptyEntity;
@@ -12,54 +16,86 @@ fn make_db() -> SurrealDB {
     SurrealDB::new(client)
 }
 
+/// How conditions make groups. `AND` binds more tightly than `OR`. Thus
+/// alternatives without brackets change the query: `status = 'x' AND a
+/// OR b` means `(status = 'x' AND a) OR b`, and each row that matches
+/// only `b` ignores the status condition. `or_` and `and_` write the
+/// brackets. The renderer does not.
 #[test]
-fn test_search_expression_basic() {
-    let db = make_db();
+fn test_condition_grouping() {
+    let status = Identifier::new("status").eq("registered");
+    let a = Identifier::new("label").eq("a");
+    let b = Identifier::new("label").eq("b");
+    let c = Identifier::new("label").eq("c");
 
-    let table = Table::<SurrealDB, EmptyEntity>::new("users", db.clone())
-        .with_column(Column::<String>::new("id").with_flag(ColumnFlag::IdField))
-        .with_column(
-            Column::<String>::new("name")
-                .with_flags(&[ColumnFlag::TitleField, ColumnFlag::Searchable]),
-        )
-        .with_column(Column::<String>::new("email").with_flag(ColumnFlag::Searchable))
-        .with_column(Column::<String>::new("password").with_flag(ColumnFlag::Hidden))
-        .with_column(Column::<i64>::new("age"));
-
-    let search_expr = db.search_table_condition(&table, "john");
-    let preview = search_expr.preview();
-
-    assert!(
-        preview.contains("string::contains"),
-        "Should contain string::contains call, got: {}",
-        preview
+    // A chain is one flat group. It has one set of brackets around the
+    // full chain, and no brackets around each operand.
+    assert_eq!(
+        a.or_(b.clone()).or_(c.clone()).expr().preview(),
+        "(label = \"a\" OR label = \"b\" OR label = \"c\")"
     );
-    assert!(
-        preview.contains("john"),
-        "Should contain search value, got: {}",
-        preview
+
+    // Nest the calls, and the inner group writes its own brackets.
+    assert_eq!(
+        a.or_(b.clone().or_(c.clone())).expr().preview(),
+        "(label = \"a\" OR (label = \"b\" OR label = \"c\"))"
+    );
+
+    // The operator changes. The chain to this point becomes one operand.
+    assert_eq!(
+        a.or_(b.clone()).and_(c.clone()).expr().preview(),
+        "((label = \"a\" OR label = \"b\") AND label = \"c\")"
+    );
+
+    // Each condition that you add goes into the query with a plain AND.
+    // The query has no more brackets, because each condition is
+    // complete.
+    let select = SurrealSelect::new()
+        .from("tag")
+        .field("id")
+        .with_where(status.clone())
+        .with_where(a.or_(b).or_(c));
+    assert_eq!(
+        select.preview(),
+        "SELECT id FROM tag WHERE status = \"registered\" \
+         AND (label = \"a\" OR label = \"b\" OR label = \"c\")"
     );
 }
 
+/// A search looks in each column, and it obeys the same rule. The
+/// branches make one group, and thus the conditions of the table stay
+/// in effect.
 #[test]
-fn test_search_expression_special_characters() {
+fn test_search_across_columns() {
     let db = make_db();
 
-    let table = Table::<SurrealDB, EmptyEntity>::new("users", db.clone())
+    let table = Table::<SurrealDB, EmptyEntity>::new("tag", db.clone())
         .with_column(Column::<String>::new("id").with_flag(ColumnFlag::IdField))
-        .with_column(Column::<String>::new("name").with_flag(ColumnFlag::Searchable));
+        .with_column(Column::<String>::new("label"))
+        // The query writes a computed column as `(<expr>) AS <name>`.
+        // The alias does not exist where WHERE runs, and a search on the
+        // alias matches no rows. The search uses the expression.
+        .with_column(Column::<String>::new("owner_email"))
+        .with_expression("owner_email", |_| {
+            vantage_surrealdb::surreal_expr!("owner.email")
+        })
+        .with_condition(Identifier::new("status").eq("registered"));
 
-    let search_expr = db.search_table_condition(&table, "O'Brien");
-    let preview = search_expr.preview();
+    let query = table
+        .select()
+        .with_where(db.search_table_condition(&table, "PG9W"))
+        .preview();
 
-    assert!(
-        preview.contains("string::contains"),
-        "Should contain string::contains call, got: {}",
-        preview
+    assert_eq!(
+        query,
+        "SELECT id, label, (owner.email) AS owner_email FROM tag \
+         WHERE status = \"registered\" AND (\
+         string::contains(string::lowercase(<string>(id)), \"pg9w\") OR \
+         string::contains(string::lowercase(<string>(label)), \"pg9w\") OR \
+         string::contains(string::lowercase(<string>(owner.email)), \"pg9w\"))"
     );
-    assert!(
-        preview.contains("o'brien"),
-        "Should contain lowercased search value, got: {}",
-        preview
-    );
+
+    // A table with no columns to search matches no rows.
+    let empty = Table::<SurrealDB, EmptyEntity>::new("empty", db.clone());
+    assert_eq!(db.search_table_condition(&empty, "x").preview(), "false");
 }


### PR DESCRIPTION
## The problem

A search on a table with its own conditions returned the wrong rows. The search looks in each column and joins the branches with `OR`. `AND` binds more tightly than `OR`, so the query read:

```
WHERE status = 'registered' AND <branch 1> OR <branch 2> OR <branch 3>
```

This means `(status = 'registered' AND <branch 1>) OR <branch 2> OR <branch 3>`. Each row that matched a later branch ignored the status condition.

A second fault: a search on a computed column matched no rows. The query writes such a column as `(<expr>) AS <name>`. The alias does not exist where the `WHERE` clause runs.

## The change

`or_` and `and_` now give a `ConditionGroup`. The group writes one set of brackets around the full chain, and no brackets around each operand. The statement renderer does not change: `WHERE` joins its conditions with a plain `AND`, because each group arrives complete.

```rust
a.or_(b).or_(c)      // (a OR b OR c)      — a chain stays flat
a.or_(b.or_(c))      // (a OR (b OR c))    — nest to make a different group
a.or_(b).and_(c)     // ((a OR b) AND c)   — the operator changes
```

The drivers build the search with the same methods, and thus the search is one group. The search also uses the expression of a computed column, not the alias.

The methods are on `SurrealOperation` and on the SQL operation trait. `vantage-sql` keeps its `or_` and `and_` functions.

## Behaviour change

`or_(a, b)` in `vantage-sql` gave `(a) OR (b)`. It now gives `(a OR b)`.

## Tests

One test for the grouping rules and one for the search, in each crate. Removed 3 tests that repeated parts of the same rule.

- `vantage-sql`: 190 sqlite tests pass, and each one runs its query against the database. Postgres passes.
- `vantage-surrealdb`: all tests pass.
- MySQL: each SQL-text check passes. 27 tests fail because the `vantage` MySQL schema has no tables. This is not related to the change.

## Versions

Patch bumps: `vantage-sql` 0.6.17, `vantage-surrealdb` 0.6.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added grouped `AND`/`OR` condition support with consistent bracketed SQL and SurrealDB expressions.
  * Added flat chaining for consecutive logical operators while preserving nested grouping when operators change.

* **Bug Fixes**
  * Improved multi-column searches across SQL backends and SurrealDB.
  * Preserved existing table conditions and correctly searched computed columns.
  * Empty and single-column searches now produce appropriate conditions.

* **Documentation**
  * Updated changelogs and version information for the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->