### PR TITLE
SurrealDB cloud auth, record-id escaping, imported columns, and a local-search fix

### DIFF
--- a/.config/nextest.toml.example
+++ b/.config/nextest.toml.example
@@ -1,0 +1,25 @@
+# Copy to .config/nextest.toml and tune to your machine.
+#
+#   cargo nextest run --workspace --all-features -j 45
+#
+# Thread count is machine-specific. Default is one per core; the suite
+# waits on databases, so more threads than cores is quicker. Measured on
+# 15 cores: 15.1s at 15 threads, 13.7s at 30, 12.9s at 45, 15.1s at 60.
+
+[profile.default]
+# vantage-diorama's `bdd` target is `harness = false` (cucumber). It
+# rejects `--list`, which aborts the whole nextest run. Run it with
+# `cargo test -p vantage-diorama --test bdd`.
+default-filter = 'not binary(bdd)'
+failure-output = "immediate-final"
+slow-timeout = { period = "30s", terminate-after = 4 }
+
+# Parallel writes to the shared SurrealDB instance raise
+# "Transaction conflict". Serialise them; everything else stays parallel.
+[test-groups]
+surreal = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'package(vantage-surrealdb) or package(surreal-client) or package(bakery_model3)'
+test-group = 'surreal'
+retries = 2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ PR-REWRITE-LIST.md
 # Scratch project for the docs4 "Optimising Live Diorama Data" chapter — the
 # chapter tells the reader to generate their own, so this one is local only.
 /optimising/
+
+# nextest thread count is machine-specific; copy .config/nextest.toml.example.
+/.config/nextest.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,7 +4610,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surreal-client"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -5458,7 +5458,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vantage-api-adapters"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5832,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/agent/todo/vista-import-related-columns.md
+++ b/agent/todo/vista-import-related-columns.md
@@ -1,0 +1,42 @@
+# Vista: import columns from related models after creation
+
+**Today:** a Vista's projection is fixed when it is created. Dotted
+traversal columns (`batch.name`, `batch.golf_course.name`) must be
+declared table-side before the wrap: YAML tables list them in the spec's
+columns, typed tables call `Table::with_imported_column` before
+`from_table`. A consumer that discovers late that it needs a related
+column (a vantage-ui page whose `params.columns` names `batch.name`) has
+no way to ask the Vista for it — vantage-ui silently drops the column
+(`crates/app/src/screen/pages/columns.rs:18`).
+
+**Want:** a capability + a post-creation mutator on Vista:
+
+- `VistaCapabilities::can_import_columns` — the driver advertises that it
+  can extend the projection with columns reached through the table's
+  declared relations.
+- `Vista::import_column(&mut self, path: &str) -> Result<()>` — callable
+  AFTER the vista is created. The shell resolves `path` against the
+  table's relations, adds the join (SQL) or traversal projection
+  (SurrealDB idiom path), and registers the extra column in the vista's
+  metadata (read-only: `calculated` flag, not orderable where ordering by
+  the alias cannot work). Errors loudly when the first path segment is
+  not a declared relation or the driver lacks the capability.
+
+Implementation sketch:
+
+- SurrealDB shell: delegate to `Table::add_imported_column` (already
+  additive) on the shell's inner table, then append the metadata column —
+  the projection alias mechanism exists end to end.
+- SQL shells: add a LEFT JOIN through the relation's foreign key and
+  project `related.column AS "path"`.
+- Drivers without a join/traversal story keep the capability off; callers
+  fall back to declaring the column table-side.
+
+**First consumer:** vantage-ui page loading. When a page's
+`params.columns` names a dotted column the table does not project, the
+loader calls `import_column` on the freshly built Vista (YAML-spec and
+model-bundle paths converge here). That deletes the last UI-serving lines
+from bundle `build_vista` implementations (see
+`vantage-ui/crates/backend/src/bundles/chtags.rs`) and makes page YAML
+self-sufficient: name a related column, get a join. Companion vantage-ui
+notes: `chtags/agent/todo/vantage-ui-page-dotted-columns.md`.

--- a/surreal-client/CHANGELOG.md
+++ b/surreal-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.4 — unreleased
+
+- A DSN can select the authentication scope: `?auth=namespace` or `?auth=database`
+  signs in at that level instead of as a root user. Cloud instances have no root
+  user, so a connection string is now enough to reach one.
+- New `escape_record_id` for the id half of a record id. It follows the
+  `escape_identifier` rules, except that a numeric id stays bare: a numeric
+  field name has to be quoted to parse, but `t:1` and `t:⟨1⟩` address different
+  records (integer key vs string key).
+
 ## 0.6.3 — unreleased
 
 - The JSON convenience transcoding routes through the shared `vantage-types` walker

--- a/surreal-client/Cargo.toml
+++ b/surreal-client/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "surreal-client"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "CBOR-based SurrealDB client for the Vantage data framework"

--- a/surreal-client/src/connection.rs
+++ b/surreal-client/src/connection.rs
@@ -374,8 +374,7 @@ mod tests {
             SurrealConnection::dsn("cbor://user:pw@cloud.example/ns/db?auth=namespace").unwrap();
         assert!(matches!(conn.auth, Some(AuthParams::Namespace { .. })));
 
-        let conn =
-            SurrealConnection::dsn("cbor://user:pw@cloud.example/ns/db?auth=db").unwrap();
+        let conn = SurrealConnection::dsn("cbor://user:pw@cloud.example/ns/db?auth=db").unwrap();
         assert!(matches!(conn.auth, Some(AuthParams::Database { .. })));
 
         assert!(SurrealConnection::dsn("cbor://user:pw@h/n/d?auth=nope").is_err());

--- a/surreal-client/src/connection.rs
+++ b/surreal-client/src/connection.rs
@@ -100,6 +100,29 @@ impl SurrealConnection {
                 "version_check" => {
                     conn.version_check = value.parse().unwrap_or(true);
                 }
+                // Signin level for the DSN credentials. Without it, DSN
+                // credentials sign in as root — a namespace- or
+                // database-defined user needs `?auth=namespace` /
+                // `?auth=database` (cloud instances have no root users).
+                "auth" | "auth_level" => {
+                    let (username, password) = match conn.auth.take() {
+                        Some(AuthParams::Root { username, password }) => (username, password),
+                        other => {
+                            conn.auth = other;
+                            continue;
+                        }
+                    };
+                    conn.auth = Some(match value.as_ref() {
+                        "namespace" | "ns" => AuthParams::Namespace { username, password },
+                        "database" | "db" => AuthParams::Database { username, password },
+                        "root" => AuthParams::Root { username, password },
+                        other => {
+                            return Err(SurrealError::Connection(format!(
+                                "Unknown auth level `{other}` — use root, namespace, or database"
+                            )));
+                        }
+                    });
+                }
                 _ => {}
             }
         }
@@ -343,6 +366,19 @@ mod tests {
         assert_eq!(conn.database, Some("test_db".to_string()));
         assert!(!conn.version_check);
         assert!(matches!(conn.auth, Some(AuthParams::Root { .. })));
+    }
+
+    #[test]
+    fn test_dsn_auth_level() {
+        let conn =
+            SurrealConnection::dsn("cbor://user:pw@cloud.example/ns/db?auth=namespace").unwrap();
+        assert!(matches!(conn.auth, Some(AuthParams::Namespace { .. })));
+
+        let conn =
+            SurrealConnection::dsn("cbor://user:pw@cloud.example/ns/db?auth=db").unwrap();
+        assert!(matches!(conn.auth, Some(AuthParams::Database { .. })));
+
+        assert!(SurrealConnection::dsn("cbor://user:pw@h/n/d?auth=nope").is_err());
     }
 
     #[test]

--- a/surreal-client/src/lib.rs
+++ b/surreal-client/src/lib.rs
@@ -26,5 +26,7 @@ pub use engines::{DebugEngine, WsCborEngine};
 pub use error::{Result, SurrealError};
 pub use live::{Action, LiveStream, Notification};
 pub use mocks::{MockSurrealEngine, SurrealMockBuilder};
-pub use record::{RecordId, RecordIdValue, RecordRange, Table, escape_identifier};
+pub use record::{
+    RecordId, RecordIdValue, RecordRange, Table, escape_identifier, escape_record_id,
+};
 pub use session::SessionState;

--- a/surreal-client/src/record.rs
+++ b/surreal-client/src/record.rs
@@ -370,6 +370,22 @@ const RESERVED_KEYWORDS: &[&str] = &[
 /// emitted as `\u{27E9}` — `\⟩` is itself an invalid escape there, so the
 /// unicode escape is the only representation that survives. Plain identifiers
 /// pass through unchanged.
+/// Escape the id half of a record id (`table:<id>`).
+///
+/// The same rules as [`escape_identifier`], with one deliberate exception: a
+/// purely numeric id passes through unquoted. The two positions do not mean
+/// the same thing. A numeric *identifier* (a field name) has to be quoted to
+/// parse at all, but a numeric *record id* is an integer id — `t:1` and
+/// `t:⟨1⟩` address different records, the first keyed by the integer `1` and
+/// the second by the string `"1"`. Quoting here would silently repoint every
+/// lookup of an integer-keyed record.
+pub fn escape_record_id(id: &str) -> String {
+    if !id.is_empty() && id.parse::<i64>().is_ok() {
+        return id.to_string();
+    }
+    escape_identifier(id)
+}
+
 pub fn escape_identifier(ident: &str) -> String {
     if ident.is_empty() {
         return "⟨⟩".to_string();

--- a/vantage-api-adapters/CHANGELOG.md
+++ b/vantage-api-adapters/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.4 — unreleased
+
+- `DioRouter` gains `with_id_map`, `with_record_projection` and
+  `with_not_found_message`, so a route can match an existing API contract
+  exactly: rename the id field, replace the record body with a projection, and
+  choose the 404 text.
+
 ## 0.1.3 — 2026-07-27
 
 - Depend on vantage-diorama 0.9 (client-side search and the augmentation spec

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-api-adapters"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Web-framework adapters that expose Vantage Dio/Scenery over HTTP"

--- a/vantage-api-adapters/src/axum_dio.rs
+++ b/vantage-api-adapters/src/axum_dio.rs
@@ -84,12 +84,21 @@ pub type ApiResult<T> = Result<T, ApiError>;
 
 // ---- Router builder ---------------------------------------------------------
 
+/// Maps the id from the URL path to the Dio cache key.
+pub type IdMap = dyn Fn(&str) -> String + Send + Sync;
+/// Shapes a record into the JSON object served by the detail endpoint and
+/// carried in record-watch events.
+pub type RecordProjection = dyn Fn(&Record<CborValue>) -> serde_json::Value + Send + Sync;
+
 /// Builder for a kubernetes-style GET + watch router over one [`Dio`].
 pub struct DioRouter {
     dio: Dio,
     columns: Vec<(String, String)>,
     page_size: usize,
     key_field: Option<String>,
+    id_map: Option<Arc<IdMap>>,
+    record_projection: Option<Arc<RecordProjection>>,
+    not_found_message: Option<String>,
 }
 
 impl DioRouter {
@@ -99,7 +108,43 @@ impl DioRouter {
             columns: Vec::new(),
             page_size: 50,
             key_field: None,
+            id_map: None,
+            record_projection: None,
+            not_found_message: None,
         }
+    }
+
+    /// Map the `{id}` path segment to the Dio cache key before any lookup.
+    /// Use this when URLs carry a short form of the id — for example a
+    /// SurrealDB router that accepts `75KE-F3HG` while the cache keys rows
+    /// as `tag:75KE-F3HG`:
+    ///
+    /// ```ignore
+    /// .with_id_map(|id| format!("tag:{id}"))
+    /// ```
+    pub fn with_id_map(mut self, map: impl Fn(&str) -> String + Send + Sync + 'static) -> Self {
+        self.id_map = Some(Arc::new(map));
+        self
+    }
+
+    /// Shape the detail response and every record-watch `object` with a
+    /// closure instead of serving the whole record. Use this to serve an
+    /// exact API contract: pick fields, rename them, nest them, and keep
+    /// internal columns off the wire.
+    pub fn with_record_projection(
+        mut self,
+        projection: impl Fn(&Record<CborValue>) -> serde_json::Value + Send + Sync + 'static,
+    ) -> Self {
+        self.record_projection = Some(Arc::new(projection));
+        self
+    }
+
+    /// The message served with a detail 404. Without it, the response
+    /// carries `not found: <cache key>` — set this when clients show the
+    /// error text to end users.
+    pub fn with_not_found_message(mut self, message: impl Into<String>) -> Self {
+        self.not_found_message = Some(message.into());
+        self
     }
 
     /// Expose record field `field` as JSON key `name` in listing rows. The
@@ -137,6 +182,9 @@ impl DioRouter {
             columns: Arc::from(self.columns),
             page_size: self.page_size,
             key_field: self.key_field.map(Arc::from),
+            id_map: self.id_map,
+            record_projection: self.record_projection,
+            not_found_message: self.not_found_message.map(Arc::from),
         };
         Router::new()
             .route("/", get(listing))
@@ -151,6 +199,35 @@ struct ApiState {
     columns: Arc<[(String, String)]>,
     page_size: usize,
     key_field: Option<Arc<str>>,
+    id_map: Option<Arc<IdMap>>,
+    record_projection: Option<Arc<RecordProjection>>,
+    not_found_message: Option<Arc<str>>,
+}
+
+impl ApiState {
+    fn cache_key(&self, path_id: &str) -> String {
+        match &self.id_map {
+            Some(map) => map(path_id),
+            None => path_id.to_string(),
+        }
+    }
+
+    fn record_object(&self, record: &Record<CborValue>) -> serde_json::Value {
+        match &self.record_projection {
+            Some(projection) => projection(record),
+            None => record_json(record),
+        }
+    }
+
+    fn not_found(&self, cache_key: &str) -> ApiError {
+        match &self.not_found_message {
+            Some(message) => ApiError {
+                status: StatusCode::NOT_FOUND,
+                message: message.to_string(),
+            },
+            None => not_found(cache_key),
+        }
+    }
 }
 
 #[derive(serde::Deserialize, Default)]
@@ -303,33 +380,35 @@ async fn detail(
     }
     // Bounded facade read: hydrates this row (through the shared scheduler)
     // before returning, so the response always carries the augment columns.
+    let key = st.cache_key(&id);
     let row = st
         .dio
         .vista()
-        .get_value(id.clone())
+        .get_value(key.clone())
         .await?
-        .ok_or_else(|| not_found(&id))?;
-    Ok(Json(record_json(&row)).into_response())
+        .ok_or_else(|| st.not_found(&key))?;
+    Ok(Json(st.record_object(&row)).into_response())
 }
 
 async fn watch_detail(st: ApiState, id: String) -> ApiResult<Response> {
     // Hydrate first so the watch opens on a complete record instead of
     // sitting on an unfilled one.
+    let key = st.cache_key(&id);
     let row = st
         .dio
         .vista()
-        .get_value(id.clone())
+        .get_value(key.clone())
         .await?
-        .ok_or_else(|| not_found(&id))?;
-    let scenery = st.dio.record_scenery(id).await?;
+        .ok_or_else(|| st.not_found(&key))?;
+    let scenery = st.dio.record_scenery(key).await?;
     let mut generations = scenery.subscribe();
     // Open on the subscribed scenery's snapshot, not the pre-subscription
     // read: a change landing between the two would otherwise never produce
     // a MODIFIED line.
     let initial = scenery
         .record()
-        .map(|current| record_json(&current.record))
-        .unwrap_or_else(|| record_json(&row));
+        .map(|current| st.record_object(&current.record))
+        .unwrap_or_else(|| st.record_object(&row));
 
     let stream = async_stream::stream! {
         let mut last = initial;
@@ -339,7 +418,7 @@ async fn watch_detail(st: ApiState, id: String) -> ApiResult<Response> {
                 break;
             }
             let Some(current) = scenery.record() else { continue };
-            let object = record_json(&current.record);
+            let object = st.record_object(&current.record);
             if object != last {
                 last = object.clone();
                 yield event_line("MODIFIED", object);

--- a/vantage-api-adapters/tests/axum_dio.rs
+++ b/vantage-api-adapters/tests/axum_dio.rs
@@ -408,3 +408,35 @@ async fn watch_detail_streams_record_changes() {
     assert_eq!(modified["object"]["modified"], "t2");
     assert_eq!(modified["object"]["size"], "101");
 }
+
+#[tokio::test]
+async fn detail_honours_id_map_projection_and_not_found_message() {
+    let fx = fixture(1024).await;
+    // Rebuild the router with the contract-shaping hooks: URLs carry a bare
+    // suffix ("0"), the cache keys rows as "r0"; responses expose only a
+    // renamed id; a miss serves a user-safe message.
+    let router = DioRouter::new(fx.dio.clone())
+        .with_id_map(|id| format!("r{id}"))
+        .with_record_projection(|record| {
+            serde_json::json!({
+                "record_id": record.get("id").and_then(|v| v.as_text().map(str::to_string)),
+            })
+        })
+        .with_not_found_message("Tag not found")
+        .into_router();
+
+    let (status, body) = get_json(&router, "/0").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["record_id"], "r0");
+    assert!(body.get("modified").is_none(), "projection replaces the record");
+
+    let (status, body) = get_json(&router, "/9").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(body["error"], "Tag not found");
+
+    // The watch stream carries the same projected object.
+    let mut lines = get_stream(&router, "/0?watch=true").await;
+    let added = lines.next().await;
+    assert_eq!(added["type"], "ADDED");
+    assert_eq!(added["object"]["record_id"], "r0");
+}

--- a/vantage-api-adapters/tests/axum_dio.rs
+++ b/vantage-api-adapters/tests/axum_dio.rs
@@ -428,7 +428,10 @@ async fn detail_honours_id_map_projection_and_not_found_message() {
     let (status, body) = get_json(&router, "/0").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["record_id"], "r0");
-    assert!(body.get("modified").is_none(), "projection replaces the record");
+    assert!(
+        body.get("modified").is_none(),
+        "projection replaces the record"
+    );
 
     let (status, body) = get_json(&router, "/9").await;
     assert_eq!(status, StatusCode::NOT_FOUND);

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.12.1 — unreleased
+
+- **Bug fix:** a local quicksearch reads every kind of value, not only text.
+  A scenery that holds all of its rows filters them itself, and the predicate
+  compared `Text` alone — so a record id, a number, a boolean, and any field
+  inside a nested object or array never matched, while the same search run
+  against the data source found them. Numbers, booleans and record ids now
+  compare as text (the same shape a source-side `<string>` cast produces), and
+  the search descends into arrays and objects.
+
 ## 0.12.0 — 2026-07-30
 
 **The debug stream reads like a log, not a struct dump.**

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -27,9 +27,15 @@ pub(crate) fn record_get_path<'a>(rec: &'a Record<CborValue>, path: &str) -> Opt
     Some(current)
 }
 
-/// Local quicksearch predicate: case-insensitive substring over every text
-/// field of the record (the same semantics drivers use server-side, so a
-/// table behaves alike whichever side evaluates). `None`/blank matches all.
+/// Local quicksearch predicate: case-insensitive substring over every
+/// field of the record. `None`/blank matches all.
+///
+/// A driver searches server-side with a cast to text, and thus it also
+/// looks in a record id, a number and the fields of an embedded object.
+/// This predicate reads the same values, so a table behaves alike
+/// whichever side evaluates. It reads a container one level at a time:
+/// a record id is `Tag(8, [table, key])`, and an owner is a map of
+/// name, email and phone.
 pub(crate) fn matches_search(rec: &Record<CborValue>, query: Option<&str>) -> bool {
     let Some(query) = query else {
         return true;
@@ -38,10 +44,23 @@ pub(crate) fn matches_search(rec: &Record<CborValue>, query: Option<&str>) -> bo
     if needle.is_empty() {
         return true;
     }
-    rec.values().any(|v| match v {
-        CborValue::Text(s) => s.to_lowercase().contains(&needle),
+    rec.values().any(|v| cbor_contains(v, &needle))
+}
+
+/// True when `needle` (already lower case) is in the text of `value` or
+/// of anything the value holds.
+fn cbor_contains(value: &CborValue, needle: &str) -> bool {
+    match value {
+        CborValue::Text(s) => s.to_lowercase().contains(needle),
+        CborValue::Integer(i) => i128::from(*i).to_string().contains(needle),
+        CborValue::Float(f) => f.to_string().contains(needle),
+        CborValue::Bool(b) => b.to_string().contains(needle),
+        CborValue::Tag(_, inner) => cbor_contains(inner, needle),
+        CborValue::Array(items) => items.iter().any(|item| cbor_contains(item, needle)),
+        CborValue::Map(entries) => entries.iter().any(|(_, v)| cbor_contains(v, needle)),
+        // Null, Bytes and anything else carry no text to match.
         _ => false,
-    })
+    }
 }
 
 pub(crate) fn matches_conditions(rec: &Record<CborValue>, conds: &[(String, CborValue)]) -> bool {
@@ -122,6 +141,45 @@ mod tests {
         r.insert("status".to_string(), CborValue::Text(status.to_string()));
         r.insert("count".to_string(), CborValue::Integer(count.into()));
         r
+    }
+
+    /// Quicksearch reads a record id, an embedded object and a number,
+    /// and not only the plain text fields. A driver casts every column
+    /// to text server-side, and a grid that filters its cached rows must
+    /// find the same rows.
+    #[test]
+    fn search_reads_every_kind_of_value() {
+        let mut row = Record::new();
+        // A record id: Tag(8, [table, key]).
+        row.insert(
+            "id".to_string(),
+            CborValue::Tag(8, Box::new(text_array(&["tag", "4N35-BK8F"]))),
+        );
+        row.insert("label".to_string(), CborValue::Text("Wedge".to_string()));
+        // An embedded owner object.
+        row.insert(
+            "owner".to_string(),
+            CborValue::Map(vec![
+                (
+                    CborValue::Text("name".to_string()),
+                    CborValue::Text("Kennedy".to_string()),
+                ),
+                (
+                    CborValue::Text("email".to_string()),
+                    CborValue::Text("k@example.com".to_string()),
+                ),
+            ]),
+        );
+        row.insert("total".to_string(), CborValue::Integer(42.into()));
+
+        assert!(matches_search(&row, Some("4N35-BK8F")));
+        assert!(matches_search(&row, Some("4n35")), "search is case free");
+        assert!(matches_search(&row, Some("Kennedy")), "an owner field");
+        assert!(matches_search(&row, Some("42")), "a number");
+        assert!(matches_search(&row, Some("wedge")), "a plain text field");
+        assert!(!matches_search(&row, Some("nothing here")));
+        assert!(matches_search(&row, None), "no query matches all");
+        assert!(matches_search(&row, Some("")), "a blank query matches all");
     }
 
     fn text_array(items: &[&str]) -> CborValue {

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.14 — unreleased
+
+- **Bug fix:** `Thing::expr` escapes the table and the id through the
+  surreal-client authority. A record id with a dash (`tag:75KE-F3HG`) parsed
+  as a subtraction and matched no record; it now renders as `tag:⟨75KE-F3HG⟩`.
+- **Bug fix:** `insert` honours the idempotent `WritableDataSet` contract. A
+  duplicate `CREATE` returns the existing record instead of failing (SurrealDB
+  v3 rejects a duplicate `INSERT` too).
+- `SurrealType` is implemented for chrono `DateTime<Utc>`, reusing the tag-12
+  helpers from vantage-types.
+
 ## 0.6.13 — 2026-08-07
 
 - **Bug fix:** a search keeps the conditions of the table. The search

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.13"
+version = "0.6.14"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -388,7 +388,19 @@ impl TableSource for SurrealDB {
         for (key, value) in record.iter() {
             insert = insert.with_any_field(key, value.clone());
         }
-        let result = self.execute(&insert.expr()).await?;
+        let result = match self.execute(&insert.expr()).await {
+            Ok(result) => result,
+            Err(e) => {
+                // The `WritableDataSet::insert` contract is idempotent: when
+                // the record already exists, return it untouched instead of
+                // failing. SurrealDB's CREATE (and, since v3, INSERT too)
+                // rejects duplicates, so recover by reading the record back.
+                if let Some(existing) = self.get_table_value(table, id).await? {
+                    return Ok(existing);
+                }
+                return Err(e);
+            }
+        };
         let map = extract_first_map(result)?;
         let id_field = table
             .id_field()

--- a/vantage-surrealdb/src/thing.rs
+++ b/vantage-surrealdb/src/thing.rs
@@ -148,7 +148,7 @@ impl Expressive<AnySurrealType> for Thing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{identifier::Identifier, surrealdb::SurrealDB};
+    use crate::{identifier::Identifier, surreal_expr, surrealdb::SurrealDB};
     use indexmap::IndexMap;
     use surreal_client::{SurrealClient, SurrealConnection};
     use vantage_expressions::ExprDataSource;

--- a/vantage-surrealdb/src/thing.rs
+++ b/vantage-surrealdb/src/thing.rs
@@ -138,7 +138,7 @@ impl Expressive<AnySurrealType> for Thing {
             format!(
                 "{}:{}",
                 surreal_client::escape_identifier(&self.table),
-                surreal_client::escape_identifier(&self.id)
+                surreal_client::escape_record_id(&self.id)
             ),
             vec![],
         )
@@ -164,6 +164,9 @@ mod tests {
             Thing::new("batch", "batch5").expr().preview(),
             "batch:batch5"
         );
+        // A numeric id stays bare: `t:1` is keyed by the integer 1, and
+        // `t:⟨1⟩` by the string "1" — quoting would address another record.
+        assert_eq!(Thing::new("t", "1").expr().preview(), "t:1");
     }
 
     const DB_URL: &str = "cbor://localhost:8000/rpc";

--- a/vantage-surrealdb/src/thing.rs
+++ b/vantage-surrealdb/src/thing.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use vantage_expressions::{Expression, Expressive};
 
 use crate::{
-    AnySurrealType, surreal_expr,
+    AnySurrealType,
     types::{SurrealType, SurrealTypeThingMarker},
 };
 
@@ -131,7 +131,17 @@ impl SurrealType for Thing {
 
 impl Expressive<AnySurrealType> for Thing {
     fn expr(&self) -> Expression<AnySurrealType> {
-        surreal_expr!(format!("{}:{}", self.table, self.id))
+        // Escaping authority lives in `surreal-client`, same as `Identifier`.
+        // Ids like `75KE-F3HG` must render as `tag:⟨75KE-F3HG⟩` — bare, the
+        // dash parses as subtraction.
+        Expression::new(
+            format!(
+                "{}:{}",
+                surreal_client::escape_identifier(&self.table),
+                surreal_client::escape_identifier(&self.id)
+            ),
+            vec![],
+        )
     }
 }
 
@@ -143,6 +153,12 @@ mod tests {
     use surreal_client::{SurrealClient, SurrealConnection};
     use vantage_expressions::ExprDataSource;
     use vantage_types::{Record, TryFromRecord, entity};
+
+    #[test]
+    fn expr_escapes_non_identifier_ids() {
+        assert_eq!(Thing::new("tag", "75KE-F3HG").expr().preview(), "tag:⟨75KE-F3HG⟩");
+        assert_eq!(Thing::new("batch", "batch5").expr().preview(), "batch:batch5");
+    }
 
     const DB_URL: &str = "cbor://localhost:8000/rpc";
     const ROOT_USER: &str = "root";

--- a/vantage-surrealdb/src/thing.rs
+++ b/vantage-surrealdb/src/thing.rs
@@ -156,8 +156,14 @@ mod tests {
 
     #[test]
     fn expr_escapes_non_identifier_ids() {
-        assert_eq!(Thing::new("tag", "75KE-F3HG").expr().preview(), "tag:⟨75KE-F3HG⟩");
-        assert_eq!(Thing::new("batch", "batch5").expr().preview(), "batch:batch5");
+        assert_eq!(
+            Thing::new("tag", "75KE-F3HG").expr().preview(),
+            "tag:⟨75KE-F3HG⟩"
+        );
+        assert_eq!(
+            Thing::new("batch", "batch5").expr().preview(),
+            "batch:batch5"
+        );
     }
 
     const DB_URL: &str = "cbor://localhost:8000/rpc";

--- a/vantage-surrealdb/src/types/datetime.rs
+++ b/vantage-surrealdb/src/types/datetime.rs
@@ -1,0 +1,70 @@
+//! Datetime type implementation for SurrealDB
+//!
+//! Maps `chrono::DateTime<Utc>` to the SurrealDB compact datetime encoding
+//! (CBOR tag 12, `[seconds, nanos]`). The tag-12 conversion itself lives in
+//! `vantage_types::cbor_json` and is reused here. Decoding also accepts
+//! tag 0 (RFC 3339 text) and plain text, so records that store datetimes as
+//! strings still load while a dataset migrates to real datetime values.
+
+use crate::types::{SurrealType, SurrealTypeDateTimeMarker};
+use chrono::{DateTime, SecondsFormat, Utc};
+use ciborium::Value as CborValue;
+use vantage_types::cbor_json::{rfc3339_to_tag12, tag12_to_rfc3339};
+
+impl SurrealType for DateTime<Utc> {
+    type Target = SurrealTypeDateTimeMarker;
+
+    fn to_cbor(&self) -> CborValue {
+        rfc3339_to_tag12(&self.to_rfc3339_opts(SecondsFormat::Nanos, true))
+            .expect("RFC 3339 text from DateTime<Utc> always converts")
+    }
+
+    fn from_cbor(cbor: CborValue) -> Option<Self> {
+        match cbor {
+            CborValue::Tag(12, inner) => parse_rfc3339(&tag12_to_rfc3339(&inner)?),
+            CborValue::Tag(0, inner) => match *inner {
+                CborValue::Text(s) => parse_rfc3339(&s),
+                _ => None,
+            },
+            CborValue::Text(s) => parse_rfc3339(&s),
+            _ => None,
+        }
+    }
+}
+
+fn parse_rfc3339(s: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_compact() {
+        let dt = DateTime::from_timestamp(1_754_000_000, 123_456_789).unwrap();
+        let cbor = dt.to_cbor();
+        assert!(matches!(cbor, CborValue::Tag(12, _)));
+        assert_eq!(DateTime::<Utc>::from_cbor(cbor), Some(dt));
+    }
+
+    #[test]
+    fn decodes_rfc3339_text() {
+        let dt = DateTime::<Utc>::from_cbor(CborValue::Text(
+            "2026-03-19T20:25:38.870950016Z".to_string(),
+        ))
+        .unwrap();
+        assert_eq!(dt.timestamp_subsec_nanos(), 870_950_016);
+    }
+
+    #[test]
+    fn rejects_other_shapes() {
+        assert_eq!(DateTime::<Utc>::from_cbor(CborValue::Integer(5.into())), None);
+        assert_eq!(
+            DateTime::<Utc>::from_cbor(CborValue::Text("not a date".into())),
+            None
+        );
+    }
+}

--- a/vantage-surrealdb/src/types/datetime.rs
+++ b/vantage-surrealdb/src/types/datetime.rs
@@ -61,7 +61,10 @@ mod tests {
 
     #[test]
     fn rejects_other_shapes() {
-        assert_eq!(DateTime::<Utc>::from_cbor(CborValue::Integer(5.into())), None);
+        assert_eq!(
+            DateTime::<Utc>::from_cbor(CborValue::Integer(5.into())),
+            None
+        );
         assert_eq!(
             DateTime::<Utc>::from_cbor(CborValue::Text("not a date".into())),
             None

--- a/vantage-surrealdb/src/types/mod.rs
+++ b/vantage-surrealdb/src/types/mod.rs
@@ -143,6 +143,7 @@ impl SurrealTypeVariants {
 
 // Type implementations are organized in separate modules
 mod bool;
+mod datetime;
 mod decimal;
 mod generic;
 mod numbers;

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -485,8 +485,8 @@ pub(crate) fn column_for_type(name: &str, ty: &str) -> Result<TableColumn<AnySur
 
 pub(crate) fn metadata_from_table<T, E>(table: &Table<T, E>) -> VistaMetadata
 where
-    T: vantage_table::traits::table_source::TableSource,
-    E: Entity<T::Value>,
+    T: vantage_table::traits::table_source::TableSource + 'static,
+    E: Entity<T::Value> + 'static,
     T::Column<T::AnyType>: ColumnLike<T::AnyType>,
 {
     let mut metadata = VistaMetadata::new();
@@ -509,6 +509,12 @@ where
         if col.flags().contains(&ColumnFlag::Hidden) {
             vc = vc.with_flag(vista_flags::HIDDEN);
         }
+        if col.flags().contains(&ColumnFlag::Searchable) {
+            vc = vc.with_flag(vista_flags::SEARCHABLE);
+        }
+        if col.flags().contains(&ColumnFlag::Mandatory) {
+            vc = vc.with_flag(vista_flags::MANDATORY);
+        }
         metadata = metadata.with_column(vc);
     }
     if let Some(id_field) = table.id_field() {
@@ -518,6 +524,24 @@ where
         if let Some(col) = metadata.columns.get_mut(title) {
             col.flags.push(vista_flags::TITLE.to_string());
         }
+    }
+    // Surface the table's typed relations as schema references, so
+    // consumers that read the vista's metadata (not just traversal calls)
+    // see them — the target table name comes from building the bare
+    // target, which is offline (no I/O until a query runs).
+    for (name, kind) in table.ref_kinds() {
+        let Ok(foreign_key) = table.ref_foreign_key(&name) else {
+            continue;
+        };
+        let Ok(target) = table.get_ref_target_erased(&name) else {
+            continue;
+        };
+        metadata = metadata.with_reference(VistaReferenceMeta::new(
+            name,
+            target.table_name().to_string(),
+            kind,
+            foreign_key,
+        ));
     }
     for spec in table.vista_contained() {
         metadata = metadata.with_contained(spec);

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.15 — unreleased
+
+- `with_imported_column` / `add_imported_column` bring a column in over a
+  dotted traversal of a related record. Additive: the projection keeps every
+  column it already had, so importing one field no longer narrows the query.
+- `with_title_column` takes a pre-built column and marks it as the display
+  title, for callers that need flags (searchable, mandatory) on a title column
+  — `with_title_column_of` builds one by name as before.
+
 ## 0.6.14 — 2026-07-22
 
 - New `TableSource::coerce_reference_value` hook (default: identity). Reference

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/table/impls/columns.rs
+++ b/vantage-table/src/table/impls/columns.rs
@@ -111,6 +111,24 @@ impl<T: TableSource, E: Entity<T::Value>> Table<T, E> {
         self
     }
 
+    /// Add a pre-built column AND mark it as a display title — the
+    /// flag-carrying twin of [`Self::with_title_column_of`], for callers
+    /// that need flags (searchable, mandatory) on a title column.
+    pub fn with_title_column<NewColumnType>(mut self, column: T::Column<NewColumnType>) -> Self
+    where
+        NewColumnType: ColumnType,
+    {
+        let name = column.name().to_string();
+        if !self.title_fields.contains(&name) {
+            self.title_fields.push(name.clone());
+        }
+        if self.title_field.is_none() {
+            self.title_field = Some(name);
+        }
+        self.add_column(column);
+        self
+    }
+
     /// Add a typed column to the table (builder pattern)
     pub fn with_column_of<NewColumnType>(self, name: impl Into<String>) -> Self
     where

--- a/vantage-table/src/table/impls/selectable.rs
+++ b/vantage-table/src/table/impls/selectable.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use vantage_core::{Result, error};
 use vantage_expressions::traits::selectable::Selectable;
 use vantage_expressions::{Expression, Expressive, SelectableDataSource, expr_any};
@@ -214,48 +216,10 @@ where
             }
 
             if parts.len() >= 2 {
-                let column = parts[parts.len() - 1];
-                let hops = &parts[..parts.len() - 1];
-
-                if !self.data_source().supports_traversal() {
-                    return Err(error!(
-                        "backend does not support implicit-reference traversal in columns",
-                        column = col
-                    ));
-                }
-
-                // Validate the has_one chain and that the final column exists.
-                let (target, fk_hops) = self.resolve_has_one_target(hops)?;
-                if !target.columns().contains_key(column) {
-                    return Err(error!(
-                        "implicit reference target has no such column",
-                        column = column
-                    ));
-                }
-
-                // Lower to an expression: native path first, else the generic
-                // nested correlated-subquery chain. The native path receives
-                // the foreign-key/link *fields*, not the relation names — a
-                // SurrealDB idiom path traverses record-link fields, and a
-                // relation is free to be named differently from its FK
-                // (`with_one("owner", "client", …)` must lower to
-                // `client.name`, not the nonexistent `owner.name`).
-                let fk_refs: Vec<&str> = fk_hops.iter().map(String::as_str).collect();
-                let expr = match self.data_source().traversal_path_expr(&fk_refs, column) {
-                    Some(e) => e,
-                    None => self.traverse_rest_generic(hops, column)?,
-                };
-
-                let dotted = col.to_string();
-                if !self.columns.contains_key(&dotted) {
-                    let column_def = self.data_source.create_column::<T::AnyType>(&dotted);
-                    self.add_column(column_def);
-                }
-                self = self.with_expression(&dotted, move |_| expr.clone());
-                self.imported_columns.insert(dotted.clone());
+                self.import_dotted_column(col)?;
                 self.active_columns
                     .get_or_insert_with(Default::default)
-                    .insert(dotted);
+                    .insert(col.to_string());
             } else {
                 // Expression columns registered via `with_expression` alone
                 // (no column def) are projectable too — activating them must
@@ -269,6 +233,92 @@ where
             }
         }
         Ok(self)
+    }
+
+    /// Import a dotted implicit-reference column (`a.b…c`) **additively**:
+    /// the column joins the projection without restricting it, so the
+    /// declared columns keep flowing. Use this to give one consumer (an API
+    /// vista, a page) an extra traversal column that the shared table
+    /// definition does not carry.
+    pub fn with_imported_column(mut self, col: &str) -> Result<Self>
+    where
+        T: 'static,
+        E: 'static,
+        T::Column<T::AnyType>: Expressive<T::Value>,
+        T::Select: Expressive<T::Value>,
+    {
+        self.import_dotted_column(col)?;
+        Ok(self)
+    }
+
+    /// In-place form of [`with_imported_column`](Self::with_imported_column).
+    pub fn add_imported_column(&mut self, col: &str) -> Result<()>
+    where
+        T: 'static,
+        E: 'static,
+        T::Column<T::AnyType>: Expressive<T::Value>,
+        T::Select: Expressive<T::Value>,
+    {
+        self.import_dotted_column(col)
+    }
+
+    /// Shared body of the dotted branch: validate the `has_one` chain, lower
+    /// it to an expression (native idiom path or nested subqueries), register
+    /// the dotted alias as a column + expression and mark it imported. Does
+    /// NOT touch `active_columns` — the caller decides whether the projection
+    /// is restricted.
+    fn import_dotted_column(&mut self, col: &str) -> Result<()>
+    where
+        T: 'static,
+        E: 'static,
+        T::Column<T::AnyType>: Expressive<T::Value>,
+        T::Select: Expressive<T::Value>,
+    {
+        let parts: Vec<&str> = col.split('.').collect();
+        if parts.len() < 2 || parts.iter().any(|p| p.is_empty()) {
+            return Err(error!("invalid dotted column name", column = col));
+        }
+        let column = parts[parts.len() - 1];
+        let hops = &parts[..parts.len() - 1];
+
+        if !self.data_source().supports_traversal() {
+            return Err(error!(
+                "backend does not support implicit-reference traversal in columns",
+                column = col
+            ));
+        }
+
+        // Validate the has_one chain and that the final column exists.
+        let (target, fk_hops) = self.resolve_has_one_target(hops)?;
+        if !target.columns().contains_key(column) {
+            return Err(error!(
+                "implicit reference target has no such column",
+                column = column
+            ));
+        }
+
+        // Lower to an expression: native path first, else the generic
+        // nested correlated-subquery chain. The native path receives
+        // the foreign-key/link *fields*, not the relation names — a
+        // SurrealDB idiom path traverses record-link fields, and a
+        // relation is free to be named differently from its FK
+        // (`with_one("owner", "client", …)` must lower to
+        // `client.name`, not the nonexistent `owner.name`).
+        let fk_refs: Vec<&str> = fk_hops.iter().map(String::as_str).collect();
+        let expr = match self.data_source().traversal_path_expr(&fk_refs, column) {
+            Some(e) => e,
+            None => self.traverse_rest_generic(hops, column)?,
+        };
+
+        let dotted = col.to_string();
+        if !self.columns.contains_key(&dotted) {
+            let column_def = self.data_source.create_column::<T::AnyType>(&dotted);
+            self.add_column(column_def);
+        }
+        let wrapped: crate::table::base::ExpressionFn<T> = Arc::new(move |_| expr.clone());
+        self.expressions.insert(dotted.clone(), wrapped);
+        self.imported_columns.insert(dotted.clone());
+        Ok(())
     }
 
     /// Recursively lower a dotted implicit reference into nested correlated


### PR DESCRIPTION
Twelve commits off the long-running integration branch, now version-bumped and changelogged.

**surreal-client 0.6.4** — a DSN can pick the auth scope (`?auth=namespace` / `?auth=database`); cloud instances have no root user, so a connection string is now enough to reach one. New `escape_record_id` for the id half of a record id.

**vantage-surrealdb 0.6.14** — `Thing::expr` escapes the table and id, so a dashed record id (`tag:75KE-F3HG`) no longer parses as a subtraction and matches nothing. `insert` honours the idempotent `WritableDataSet` contract. `SurrealType` for chrono `DateTime<Utc>`.

**vantage-table 0.6.15** — `with_imported_column` / `add_imported_column` import a field over a dotted traversal without narrowing the projection; `with_title_column` takes a pre-built column so a title column can carry flags.

**vantage-api-adapters 0.1.4** — `DioRouter` gains `with_id_map`, `with_record_projection`, `with_not_found_message` for matching an existing API contract exactly.

**vantage-diorama 0.12.1** — a local quicksearch reads every kind of value. A scenery holding all its rows filtered them itself with a text-only predicate, so record ids, numbers, booleans and anything nested never matched, while the same search against the data source found them.

### Worth a reviewer's eye

Escaping the record id turned out to over-apply: `escape_identifier` quotes numeric identifiers, which is required for a field name but changes meaning for a record id — `t:1` is keyed by the integer 1 and `t:⟨1⟩` by the string "1". That silently repointed every integer-keyed lookup and broke `update_set_basic`. Numeric ids now stay bare via `escape_record_id`, with the reasoning recorded at the function.

Also included: nextest config shipped as an example (the custom bdd harness rejects `--list`, so it is filtered out; SurrealDB tests serialise and retry write conflicts).

`cargo nextest run --workspace --all-features`: 2085 passed. fmt and clippy clean.