### PR TITLE
vantage-api-adapters: an alias path names its own captures

### DIFF
--- a/vantage-api-adapters/CHANGELOG.md
+++ b/vantage-api-adapters/CHANGELOG.md
@@ -9,8 +9,10 @@
 - `axum_action::ActionRouter` mounts a model's `ModelAction` set as POST
   routes with no per-action code: `POST /{table}/{id}/actions/{name}` for a
   record action, `POST /{table}/actions/{name}` for a table action. `alias`
-  hands out a single handler for a legacy path, which may carry captures
-  besides the id.
+  hands out a single handler for a legacy path. An alias path names its own
+  captures, so a single capture is taken as the record id whatever it is
+  called (`/tag/{tag_id}/register`); `id` only has to be spelled out when the
+  path captures more than one value.
 - Actions are keyed by table and name together, so two models exposing the
   same action name both keep their routes; a genuine duplicate is an error at
   construction rather than a dropped route.

--- a/vantage-api-adapters/src/axum_action.rs
+++ b/vantage-api-adapters/src/axum_action.rs
@@ -66,6 +66,20 @@ fn error_response(e: VantageError) -> ApiError {
     }
 }
 
+/// The record key out of a path's captures.
+///
+/// A canonical route names it `{id}`, but an alias mounts onto a path
+/// somebody else already chose — `/tag/{tag_id}/register` in a contract
+/// that predates the action. So a single capture *is* the id whatever it
+/// is called, and `id` only has to be spelled out when the path captures
+/// more than one value and the choice would otherwise be arbitrary.
+fn record_id(params: &HashMap<String, String>) -> Option<String> {
+    if params.len() == 1 {
+        return params.values().next().cloned();
+    }
+    params.get("id").cloned()
+}
+
 async fn run(
     action: Arc<dyn ModelAction>,
     target: Target,
@@ -164,12 +178,13 @@ impl ActionRouter {
             ActionTarget::Record { .. } => post(
                 move |Path(params): Path<HashMap<String, String>>,
                       Json(body): Json<serde_json::Value>| async move {
-                    match params.get("id") {
-                        Some(id) => run(action, Target::Id(id.clone()), body).await,
+                    match record_id(&params) {
+                        Some(id) => run(action, Target::Id(id), body).await,
                         None => ApiError {
                             status: StatusCode::INTERNAL_SERVER_ERROR,
                             message: format!(
-                                "route for record action `{}` has no `{{id}}` segment",
+                                "route for record action `{}` has no id segment; name it \
+                                 `{{id}}` when the path captures more than one value",
                                 action.descriptor().name
                             ),
                         }

--- a/vantage-api-adapters/tests/axum_action.rs
+++ b/vantage-api-adapters/tests/axum_action.rs
@@ -174,6 +174,37 @@ async fn an_alias_path_may_carry_more_than_one_capture() {
     assert_eq!(body, r#"{"saw":"GH1"}"#);
 }
 
+/// An alias mounts onto a path somebody else already named. The legacy
+/// chtags contract spells it `/tag/{tag_id}/register`, so requiring the
+/// literal `{id}` would make every existing route unmountable.
+#[tokio::test]
+async fn a_single_capture_is_the_id_whatever_it_is_called() {
+    let actions = ActionRouter::new(vec![echo_record("tag", "register")]).unwrap();
+    let app: Router = Router::new().route(
+        "/tag/{tag_id}/register",
+        actions.alias("tag", "register").unwrap(),
+    );
+
+    let (status, body) = post(app, "/tag/GH1/register", "{}").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, r#"{"saw":"GH1"}"#);
+}
+
+/// With more than one capture the choice would be arbitrary, so the id
+/// has to be named. Saying so beats picking one at random.
+#[tokio::test]
+async fn several_captures_none_named_id_is_reported_not_guessed() {
+    let actions = ActionRouter::new(vec![echo_record("tag", "register")]).unwrap();
+    let app: Router = Router::new().route(
+        "/t/{tenant}/tag/{tag_id}/register",
+        actions.alias("tag", "register").unwrap(),
+    );
+
+    let (status, body) = post(app, "/t/acme/tag/GH1/register", "{}").await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(body.contains("has no id segment"), "{body}");
+}
+
 #[tokio::test]
 async fn alias_rejects_an_unknown_table_or_name() {
     let actions = ActionRouter::new(vec![echo_record("tag", "register")]).unwrap();


### PR DESCRIPTION
Follow-up to #382, found by the chtags API contract tests.

`ActionRouter::alias` mounts one action onto a path that somebody else already named. The legacy chtags contract spells that path `/tag/{tag_id}/register`, but the handler looked for a capture named literally `id`, so every existing route answered:

```
500  route for record action `register_tag` has no `{id}` segment
```

A single capture is now taken as the record id whatever it is called. `id` only has to be spelled out when the path captures more than one value and the choice would otherwise be arbitrary; that case reports the problem instead of guessing.

Two tests cover it: a lone `{tag_id}` resolves, and `/t/{tenant}/tag/{tag_id}/register` (two captures, neither named `id`) is reported rather than guessed.