### PR TITLE
vantage-bundle: the contract a compiled-in model implements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5642,9 +5642,9 @@ version = "0.6.0"
 dependencies = [
  "async-trait",
  "serde_json",
+ "tokio",
  "vantage-action",
  "vantage-core",
- "vantage-surrealdb",
  "vantage-vista",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5637,6 +5637,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vantage-bundle"
+version = "0.6.0"
+dependencies = [
+ "async-trait",
+ "serde_json",
+ "vantage-action",
+ "vantage-core",
+ "vantage-surrealdb",
+ "vantage-vista",
+]
+
+[[package]]
 name = "vantage-cli-util"
 version = "0.6.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "vantage-diorama",
     "vantage-diorama-aggregate",
     "vantage-action",
+    "vantage-bundle",
     "vantage-api-adapters",
     "vantage-log-writer",
     "vantage-sql",

--- a/vantage-bundle/CHANGELOG.md
+++ b/vantage-bundle/CHANGELOG.md
@@ -20,3 +20,11 @@ and any application can compile it in.
   so the model crate cannot drift from a description of itself.
 - `BuiltinAction` — the older untyped action body, JSON in and JSON out,
   for screens that declare their own fields.
+
+The database is the bundle's own `Connection` associated type rather
+than a fixed handle in the signatures. The traits came from a codebase
+where every bundle was a SurrealDB one, and writing that in would have
+made the first bundle over another database a breaking change for
+everyone who had implemented against it. An application pins the type it
+holds connections for — `dyn ModelBundle<Connection = SurrealDB>` — so
+nothing is lost today, and this crate depends on no datasource at all.

--- a/vantage-bundle/CHANGELOG.md
+++ b/vantage-bundle/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.6.0 — 2026-08-09
+
+Initial release. The contract a compiled-in model crate implements to
+serve its tables and actions to an application.
+
+These traits already existed inside the Vantage UI application. Living
+there, they could only be implemented by code inside that application,
+so shipping a customer's model meant carrying a branch of the
+application itself: a Cargo feature, an optional path dependency to the
+customer's repository, and a hand-written shim, all re-merged on every
+release. Published here, a model crate implements the traits directly
+and any application can compile it in.
+
+- `ModelBundle` — the tables a bundle provides, the `Vista` behind each
+  one, and the operations that go with them.
+- `BundleTable` — a table's catalog key, its datasource, and a title.
+  No schema: the application introspects the real shape from the Vista,
+  so the model crate cannot drift from a description of itself.
+- `BuiltinAction` — the older untyped action body, JSON in and JSON out,
+  for screens that declare their own fields.

--- a/vantage-bundle/Cargo.toml
+++ b/vantage-bundle/Cargo.toml
@@ -10,10 +10,16 @@ repository = "https://github.com/romaninsh/vantage"
 doctest = false
 
 [dependencies]
+# No datasource crate: the connection is the bundle's associated type,
+# so nothing here needs to know which database is behind it.
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-vista = { version = "0.6", path = "../vantage-vista" }
-vantage-surrealdb = { version = "0.6", path = "../vantage-surrealdb" }
 vantage-action = { version = "0.6", path = "../vantage-action" }
 
 async-trait = "0.1"
 serde_json = "1"
+
+[dev-dependencies]
+# `tests/object_safe.rs` builds a bundle and holds it the way an
+# application does.
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/vantage-bundle/Cargo.toml
+++ b/vantage-bundle/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "vantage-bundle"
+version = "0.6.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "The contract a compiled-in model crate implements to serve its tables and actions to an application"
+repository = "https://github.com/romaninsh/vantage"
+
+[lib]
+doctest = false
+
+[dependencies]
+vantage-core = { version = "0.6", path = "../vantage-core" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-surrealdb = { version = "0.6", path = "../vantage-surrealdb" }
+vantage-action = { version = "0.6", path = "../vantage-action" }
+
+async-trait = "0.1"
+serde_json = "1"

--- a/vantage-bundle/src/lib.rs
+++ b/vantage-bundle/src/lib.rs
@@ -1,0 +1,128 @@
+//! The contract a compiled-in model crate implements to serve its
+//! tables and actions to an application.
+//!
+//! A Vantage application reads its screens from YAML, and its tables
+//! from whatever the YAML declares. A *bundle* is the other source: a
+//! Rust crate, compiled into the binary, that hands the application
+//! typed tables and the operations that go with them. The application
+//! resolves a bundle table exactly like a declared one — pages, menus,
+//! relations and scripting cannot tell them apart.
+//!
+//! # Why this is its own crate
+//!
+//! The traits are small, but which side of the dependency they sit on
+//! decides how a client model ships. Keeping them inside the
+//! application means the model crate must depend on the application to
+//! implement them, which it cannot: the application is a binary, and a
+//! model belongs to whoever owns the data. So the application's build
+//! grows a branch per client — a Cargo feature, an optional path
+//! dependency, and a hand-written shim — and every release has to be
+//! merged onto each one.
+//!
+//! Published here instead, the arrow turns around. A model crate
+//! depends on this, implements [`ModelBundle`], and any application can
+//! compile it in with no knowledge of that model beyond its name.
+//!
+//! # What a bundle provides
+//!
+//! - [`ModelBundle::tables`] — the tables, by catalog key and the
+//!   datasource whose live connection they use. Note there is no schema
+//!   here: the application builds each table's [`Vista`] against an
+//!   offline connection and reads the columns, flags and references off
+//!   it, so the model crate stays the single source of truth and cannot
+//!   drift from a copy.
+//! - [`ModelBundle::model_actions`] — typed operations carrying their
+//!   own input and output schemas ([`vantage_action::ModelAction`]).
+//!   The application synthesizes a form from the input schema, so the
+//!   screen declaring the action does not restate its fields.
+//! - [`ModelBundle::actions`] — the older, untyped [`BuiltinAction`]:
+//!   JSON in, JSON out, with the fields declared by the screen. Kept
+//!   for bodies that predate model actions; prefer `model_actions` for
+//!   anything new.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use vantage_surrealdb::surrealdb::SurrealDB;
+use vantage_vista::Vista;
+
+/// One table a bundle provides.
+///
+/// There is deliberately no schema: see the note on
+/// [`ModelBundle::tables`].
+pub struct BundleTable {
+    /// Catalog key the table is reachable under (`tag`, `batch`, …).
+    pub key: String,
+    /// Datasource key (e.g. `golf`) whose live connection this table
+    /// uses. Named, not held — the application owns connections and
+    /// hands the right one to [`ModelBundle::build_vista`].
+    pub datasource: String,
+    /// Display title for the synthesized config.
+    pub title: Option<String>,
+}
+
+/// A compiled-in model crate that provides tables and operations to an
+/// application.
+pub trait ModelBundle: Send + Sync {
+    /// Bundle name, for logs.
+    fn name(&self) -> &str;
+
+    /// The tables this bundle provides.
+    ///
+    /// Only keys and datasources — the application introspects each
+    /// table's real shape from the [`Vista`] that
+    /// [`ModelBundle::build_vista`] returns, rather than from anything
+    /// restated here. A description that could disagree with the model
+    /// eventually does.
+    fn tables(&self) -> Vec<BundleTable>;
+
+    /// Build the typed Vista for one table, given the live connection
+    /// of the datasource its [`BundleTable`] named.
+    fn build_vista(&self, table_key: &str, db: &SurrealDB) -> vantage_core::Result<Vista>;
+
+    /// Typed operations this bundle provides, built against the live
+    /// connections of an open project.
+    ///
+    /// Called on every (re)connect, so a bundle sees the connections as
+    /// they are now. Return an empty vec when a datasource an operation
+    /// needs is absent — the application reports the operation as
+    /// unavailable rather than offering one that cannot run.
+    fn model_actions(
+        &self,
+        surreal: &HashMap<String, SurrealDB>,
+    ) -> Vec<Arc<dyn vantage_action::ModelAction>> {
+        let _ = surreal;
+        Vec::new()
+    }
+
+    /// Untyped builtin actions. Prefer [`ModelBundle::model_actions`].
+    fn actions(&self) -> Vec<Arc<dyn BuiltinAction>> {
+        Vec::new()
+    }
+}
+
+/// A compiled-in action body with no schema of its own.
+///
+/// The screen declaring it owns the contract — dialog, form fields,
+/// placement — and this is only what runs when the user confirms.
+/// [`vantage_action::ModelAction`] supersedes it: an action that
+/// describes its own input can be rendered, called over HTTP and
+/// scripted from one definition, where this one can only be rendered
+/// from a screen that already knows its fields.
+#[async_trait::async_trait]
+pub trait BuiltinAction: Send + Sync {
+    /// The name a screen references.
+    fn name(&self) -> &str;
+
+    /// Datasource key whose live connection this action writes through.
+    fn datasource(&self) -> &str;
+
+    /// Run the action. `args` is a JSON object of the confirmed form
+    /// values keyed by field name; the JSON result becomes the record
+    /// the calling script receives.
+    async fn run(
+        &self,
+        db: &SurrealDB,
+        args: serde_json::Value,
+    ) -> vantage_core::Result<serde_json::Value>;
+}

--- a/vantage-bundle/src/lib.rs
+++ b/vantage-bundle/src/lib.rs
@@ -11,26 +11,41 @@
 //! # Why this is its own crate
 //!
 //! The traits are small, but which side of the dependency they sit on
-//! decides how a client model ships. Keeping them inside the
-//! application means the model crate must depend on the application to
-//! implement them, which it cannot: the application is a binary, and a
-//! model belongs to whoever owns the data. So the application's build
-//! grows a branch per client — a Cargo feature, an optional path
-//! dependency, and a hand-written shim — and every release has to be
-//! merged onto each one.
+//! decides how a model ships. Keeping them inside the application means
+//! a model crate must depend on the application to implement them,
+//! which it cannot: the application is a binary, and a model belongs to
+//! whoever owns the data. So the application's build grows a branch per
+//! model — a Cargo feature, an optional path dependency, and a
+//! hand-written shim — and every release is merged onto each one.
 //!
-//! Published here instead, the arrow turns around. A model crate
-//! depends on this, implements [`ModelBundle`], and any application can
-//! compile it in with no knowledge of that model beyond its name.
+//! Published here, the arrow turns around. A model crate depends on
+//! this, implements [`ModelBundle`], and any application can compile it
+//! in knowing nothing about that model beyond its name.
+//!
+//! It cannot live in `vantage-core` or `vantage-types` for a duller
+//! reason: [`Vista`] and [`vantage_action::ModelAction`] both sit above
+//! those, so the traits have to sit above them in turn.
+//!
+//! # The connection is the bundle's to name
+//!
+//! [`ModelBundle::Connection`] is an associated type, not a concrete
+//! database handle. A bundle over SurrealDB sets it to `SurrealDB`; one
+//! over Postgres sets it to whatever it connects with. The application
+//! holds the connections and hands the right one back — it just has to
+//! agree with the bundle on the type, which it does by naming it:
+//! `dyn ModelBundle<Connection = SurrealDB>`.
+//!
+//! Writing the database into the trait itself would have been shorter
+//! and would have made the second kind of bundle a breaking change to
+//! everyone who had implemented the first.
 //!
 //! # What a bundle provides
 //!
 //! - [`ModelBundle::tables`] — the tables, by catalog key and the
-//!   datasource whose live connection they use. Note there is no schema
-//!   here: the application builds each table's [`Vista`] against an
-//!   offline connection and reads the columns, flags and references off
-//!   it, so the model crate stays the single source of truth and cannot
-//!   drift from a copy.
+//!   datasource whose connection they use. Note there is no schema
+//!   here: the application builds each table's [`Vista`] and reads the
+//!   columns, flags and references off it, so the model crate stays the
+//!   single source of truth and cannot drift from a copy of itself.
 //! - [`ModelBundle::model_actions`] — typed operations carrying their
 //!   own input and output schemas ([`vantage_action::ModelAction`]).
 //!   The application synthesizes a form from the input schema, so the
@@ -43,7 +58,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use vantage_surrealdb::surrealdb::SurrealDB;
 use vantage_vista::Vista;
 
 /// One table a bundle provides.
@@ -53,9 +67,9 @@ use vantage_vista::Vista;
 pub struct BundleTable {
     /// Catalog key the table is reachable under (`tag`, `batch`, …).
     pub key: String,
-    /// Datasource key (e.g. `golf`) whose live connection this table
-    /// uses. Named, not held — the application owns connections and
-    /// hands the right one to [`ModelBundle::build_vista`].
+    /// Datasource key (e.g. `golf`) whose connection this table uses.
+    /// Named, not held — the application owns connections and hands the
+    /// right one to [`ModelBundle::build_vista`].
     pub datasource: String,
     /// Display title for the synthesized config.
     pub title: Option<String>,
@@ -64,6 +78,11 @@ pub struct BundleTable {
 /// A compiled-in model crate that provides tables and operations to an
 /// application.
 pub trait ModelBundle: Send + Sync {
+    /// The database handle this bundle's tables are built against. The
+    /// application must hold connections of this type to serve the
+    /// bundle — see the module docs.
+    type Connection;
+
     /// Bundle name, for logs.
     fn name(&self) -> &str;
 
@@ -78,10 +97,10 @@ pub trait ModelBundle: Send + Sync {
 
     /// Build the typed Vista for one table, given the live connection
     /// of the datasource its [`BundleTable`] named.
-    fn build_vista(&self, table_key: &str, db: &SurrealDB) -> vantage_core::Result<Vista>;
+    fn build_vista(&self, table_key: &str, db: &Self::Connection) -> vantage_core::Result<Vista>;
 
     /// Typed operations this bundle provides, built against the live
-    /// connections of an open project.
+    /// connections of an open project, keyed by datasource.
     ///
     /// Called on every (re)connect, so a bundle sees the connections as
     /// they are now. Return an empty vec when a datasource an operation
@@ -89,14 +108,14 @@ pub trait ModelBundle: Send + Sync {
     /// unavailable rather than offering one that cannot run.
     fn model_actions(
         &self,
-        surreal: &HashMap<String, SurrealDB>,
+        connections: &HashMap<String, Self::Connection>,
     ) -> Vec<Arc<dyn vantage_action::ModelAction>> {
-        let _ = surreal;
+        let _ = connections;
         Vec::new()
     }
 
     /// Untyped builtin actions. Prefer [`ModelBundle::model_actions`].
-    fn actions(&self) -> Vec<Arc<dyn BuiltinAction>> {
+    fn actions(&self) -> Vec<Arc<dyn BuiltinAction<Connection = Self::Connection>>> {
         Vec::new()
     }
 }
@@ -111,10 +130,14 @@ pub trait ModelBundle: Send + Sync {
 /// from a screen that already knows its fields.
 #[async_trait::async_trait]
 pub trait BuiltinAction: Send + Sync {
+    /// The database handle this action writes through. Matches the
+    /// bundle's [`ModelBundle::Connection`].
+    type Connection;
+
     /// The name a screen references.
     fn name(&self) -> &str;
 
-    /// Datasource key whose live connection this action writes through.
+    /// Datasource key whose connection this action writes through.
     fn datasource(&self) -> &str;
 
     /// Run the action. `args` is a JSON object of the confirmed form
@@ -122,7 +145,7 @@ pub trait BuiltinAction: Send + Sync {
     /// the calling script receives.
     async fn run(
         &self,
-        db: &SurrealDB,
+        db: &Self::Connection,
         args: serde_json::Value,
     ) -> vantage_core::Result<serde_json::Value>;
 }

--- a/vantage-bundle/tests/object_safe.rs
+++ b/vantage-bundle/tests/object_safe.rs
@@ -1,0 +1,97 @@
+//! The application holds bundles as trait objects with the connection
+//! pinned. If that stops compiling, every consumer's registry breaks —
+//! and the associated type exists precisely to make it work, so it is
+//! worth a test rather than an assumption.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use vantage_bundle::{BuiltinAction, BundleTable, ModelBundle};
+
+/// Stands in for a real database handle.
+struct FakeDb;
+
+struct Demo;
+
+impl ModelBundle for Demo {
+    type Connection = FakeDb;
+
+    fn name(&self) -> &str {
+        "demo"
+    }
+
+    fn tables(&self) -> Vec<BundleTable> {
+        vec![BundleTable {
+            key: "widget".into(),
+            datasource: "shop".into(),
+            title: Some("Widget".into()),
+        }]
+    }
+
+    fn build_vista(
+        &self,
+        table_key: &str,
+        _db: &FakeDb,
+    ) -> vantage_core::Result<vantage_vista::Vista> {
+        Err(vantage_core::error!(
+            "no vista in a test",
+            table = table_key
+        ))
+    }
+
+    fn actions(&self) -> Vec<Arc<dyn BuiltinAction<Connection = FakeDb>>> {
+        vec![Arc::new(Noop)]
+    }
+}
+
+struct Noop;
+
+#[async_trait::async_trait]
+impl BuiltinAction for Noop {
+    type Connection = FakeDb;
+
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    fn datasource(&self) -> &str {
+        "shop"
+    }
+
+    async fn run(
+        &self,
+        _db: &FakeDb,
+        args: serde_json::Value,
+    ) -> vantage_core::Result<serde_json::Value> {
+        Ok(args)
+    }
+}
+
+/// The shape an application's registry uses.
+type Registry = Vec<Arc<dyn ModelBundle<Connection = FakeDb>>>;
+
+#[test]
+fn a_bundle_is_usable_as_a_trait_object_with_its_connection_pinned() {
+    let registry: Registry = vec![Arc::new(Demo)];
+    let bundle = &registry[0];
+
+    assert_eq!(bundle.name(), "demo");
+    assert_eq!(bundle.tables()[0].key, "widget");
+    // The default `model_actions` body has to stay callable through the
+    // object too — it mentions `Self::Connection` in its signature.
+    assert!(bundle.model_actions(&HashMap::new()).is_empty());
+
+    let action = &bundle.actions()[0];
+    assert_eq!(action.name(), "noop");
+    assert_eq!(action.datasource(), "shop");
+}
+
+#[tokio::test]
+async fn an_action_runs_through_the_object() {
+    let action: Arc<dyn BuiltinAction<Connection = FakeDb>> = Arc::new(Noop);
+    let out = action
+        .run(&FakeDb, serde_json::json!({ "n": 1 }))
+        .await
+        .expect("noop");
+    assert_eq!(out, serde_json::json!({ "n": 1 }));
+}


### PR DESCRIPTION
A new crate holding three traits that already exist — `ModelBundle`, `BundleTable`, `BuiltinAction` — moved out of the Vantage UI application so a model crate can implement them.

## The problem it solves

A bundle is a Rust crate compiled into an application that hands it typed tables and the operations that go with them. The traits defining that lived *inside* the application, so only code inside the application could implement them — and a customer's model is not inside the application.

The workaround was a long-lived branch of the app per customer, carrying a Cargo feature, an optional path dependency pointing at the customer's repository, and a hand-written shim. Every release has to be merged onto every such branch. It is also load-bearing in an unobvious way: an optional path dependency to a sibling repo makes the whole workspace unresolvable for anyone without that sibling checked out at exactly the right relative path, feature enabled or not — so the manifest genuinely cannot live on the app's main branch.

Published here, the dependency arrow turns around. A model crate depends on `vantage-bundle`, implements `ModelBundle`, and any application compiles it in knowing nothing about that model but its name.

## The one thing that is not a straight move

The traits came from a codebase where every bundle was a SurrealDB one, and it showed: `build_vista(&self, key, db: &SurrealDB)` and `BuiltinAction::run(&self, db: &SurrealDB, …)`. A bundle over Postgres could not have implemented them. That is cheap to live with inside an application and expensive to live with in a published trait, where the first bundle over another database becomes a breaking change for everyone who implemented the first.

So the database is now the bundle's own associated type:

```rust
pub trait ModelBundle: Send + Sync {
    type Connection;
    fn build_vista(&self, key: &str, db: &Self::Connection) -> Result<Vista>;
    …
}
```

An application pins the type it holds connections for — `dyn ModelBundle<Connection = SurrealDB>` — so nothing changes for the one that exists today. `vantage-bundle` itself now depends on no datasource crate at all.

`tests/object_safe.rs` builds a bundle over a stand-in handle and uses it exactly as an application's registry does: `Vec<Arc<dyn ModelBundle<Connection = FakeDb>>>`, reaching `tables()`, the defaulted `model_actions()` (which mentions `Self::Connection` in its own signature), and an action through `Arc<dyn BuiltinAction<Connection = FakeDb>>`. Object safety here is the whole reason the associated type is viable rather than a generic parameter, so it is worth a test and not an assumption.

## Where it can live

Not `vantage-core` or `vantage-types`: `Vista` and `vantage_action::ModelAction` both sit above those, so a trait naming them has to sit above them in turn. This is the shelf it fits on, not a preference for a new crate.

## Nothing else is redesigned

Trait bodies are otherwise unchanged. Doc comments grew, because they now face people who cannot read the application's source to work out what is expected. The point worth stating twice is on `tables()`: it returns keys and datasources but no schema, because the application introspects the real shape from the `Vista` — a model that also described itself would eventually disagree with itself.

## Not done here

The application still defines these traits; it will re-export them from this crate instead, the chtags model will implement its own bundle, and the enterprise build will generate the registration shim it now keeps by hand. Those land after this is published, in that order, and end with the `chtags` branch of the app being deleted.

Workspace clippy, fmt and `cargo doc` clean; `cargo nextest run --workspace --all-features` — 2108 passed.