### PR TITLE
vantage-api-adapters: publish it, so a consumer need not reach it over git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-adapters"
-version = "0.1.4"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-adapters/CHANGELOG.md
+++ b/vantage-api-adapters/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.0 — 2026-08-10
+
+First published release. The crate existed and was used, but carried
+`publish = false`, so the only way to depend on it was a git reference —
+and a graph that reaches this crate over git while reaching
+`vantage-core` from the registry ends up with two of the latter, which
+fails as unsatisfied trait bounds somewhere unrelated. Publishing it
+lets a consumer pin released versions throughout.
+
+Numbered 0.6.0, not 0.1.5: it moves with `vantage-core`, `vantage-types`
+and `vantage-action`, and the 0.1.x line was never released to disagree
+with.
+
+No API change from the unreleased 0.1.4 below.
+
 ## 0.1.4 — 2026-08-09
 
 - `DioRouter` gains `with_id_map`, `with_record_projection` and

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "vantage-api-adapters"
-version = "0.1.4"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Web-framework adapters that expose Vantage Dio/Scenery over HTTP"
 repository = "https://github.com/romaninsh/vantage"
-publish = false
 
 [lib]
 doctest = false


### PR DESCRIPTION
Drops `publish = false` and numbers the first release 0.6.0.

## Why now

A consumer that needs this crate has only ever had one option: a git reference. That is fine on its own and poison in combination — a graph that reaches `vantage-api-adapters` over git while reaching `vantage-core` from the registry gets **two** `vantage-core`s, and cargo will not unify them. It surfaces far from the cause; in the chtags repository it looked like this, in a file nobody had touched:

```
error[E0599]: the method `to_cbor` exists for struct `Vec<FoundRecord>`,
              but its trait bounds were not satisfied
error[E0277]: `?` couldn't convert the error to `VantageError`
```

So a consumer of this crate cannot pin released versions of anything else either — one unpublished crate pulls its whole dependency graph onto git. Publishing removes that.

## The version

0.6.0 rather than 0.1.5. It moves in lockstep with `vantage-core`, `vantage-types` and `vantage-action`, all 0.6, and the 0.1.x line was never released, so there is no history to disagree with. The changelog says as much for anyone who reads the numbers later and wonders what happened to 0.2 through 0.5.

## Verification

`cargo package -p vantage-api-adapters` packages 10 files and then *verifies* the packaged crate — building it in isolation against the published `vantage-core 0.6.3`, `vantage-types 0.6.8`, `vantage-action 0.6.0`, `vantage-diorama 0.12.1` and the rest, rather than against the workspace paths. That is the check that matters for a first publish: it proves the version requirements in the manifest are satisfiable from the registry alone.

Workspace clippy and fmt clean. No source change.