### PR TITLE
Fix relation target resolution and the id a create settles on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ PR-REWRITE-LIST.md
 
 # nextest thread count is machine-specific; copy .config/nextest.toml.example.
 /.config/nextest.toml
+
+# The `surreal` CLI writes its command history into the working directory.
+/history.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-trait",
  "bson",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6007,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/docs4/src/new-persistence/step8-vista-integration.md
+++ b/docs4/src/new-persistence/step8-vista-integration.md
@@ -392,11 +392,11 @@ fn get_ref(&self, relation: &str, row: &Record<CborValue>) -> Result<Vista> {
 **`get_ref` has a twin: `get_ref_target`.** Where `get_ref` resolves a relation *for a known
 parent row* (join condition applied), `get_ref_target` builds the **bare** target — the same table
 with **no** condition. It has the same three-line shape, but calls the typed table's
-`get_ref_target::<EmptyEntity>(relation)` instead of `get_ref_from_row`:
+`get_ref_target_erased(relation)` instead of `get_ref_from_row`:
 
 ```rust
 fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-    let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+    let target = self.table.get_ref_target_erased(relation)?;
     let factory = SqliteVistaFactory::new(self.table.data_source().clone());
     factory.from_table(target)
 }

--- a/docs4/src/relations/traversal.md
+++ b/docs4/src/relations/traversal.md
@@ -124,11 +124,13 @@ the raw row forwards directly). The method comes from the `GetRefExt` extension 
 worked example (loading a record, traversing, inserting a child) lives in
 [Records: Traversal, Invariants & Hooks](../record-lifecycle.md#traversing-from-a-loaded-record-get_ref).
 
-## The bare target: `get_ref_target`
+## The bare target: `get_ref_target_erased`
 
 Sometimes you want the relation's target table with *no* condition at all —
-`Table::get_ref_target::<E2>(relation)` builds exactly that. Where the traversal forms narrow
-the target to related rows, `get_ref_target` hands you the table you'd insert a new related row
+`Table::get_ref_target_erased(relation)` builds exactly that. The target's entity type is erased:
+a relation is built by a caller-supplied constructor, so the traversal site cannot name it.
+Where the traversal forms narrow
+the target to related rows, `get_ref_target_erased` hands you the table you'd insert a new related row
 into before any join value exists (this is what Vista's nested insert uses).
 
 ## Contained relations
@@ -188,7 +190,7 @@ You can now:
    built for embedding in the source's SELECT.
 3. **Traverse from a loaded row or record** with `get_ref_from_row` / `get_ref` — one
    eq-condition, supported by every backend.
-4. **Obtain a bare insert target** with `get_ref_target` — the relation's target with no
+4. **Obtain a bare insert target** with `get_ref_target_erased` — the relation's target with no
    condition.
 5. **Declare embedded/contained relations** on document stores with `with_contained_many`,
    where traversal is descent rather than a query.

--- a/history.txt
+++ b/history.txt
@@ -1,0 +1,2 @@
+#V2
+REMOVE TABLE probe;

--- a/history.txt
+++ b/history.txt
@@ -1,2 +1,0 @@
-#V2
-REMOVE TABLE probe;

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.10 — 2026-08-12
+
+- **Bug fix:** the REST and GraphQL `TableShell`s resolve relations whose target
+  constructor returns a typed table. `get_ref_target` went through an
+  entity-typed downcast that failed, so a reference field's list of eligible
+  rows came back as an error.
+
 ## 0.6.9 — 2026-07-28
 
 - Every REST round trip is timed. Over a second it logs `slow REST GET` at info

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.9"
+version = "0.6.10"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/graphql/vista/source.rs
+++ b/vantage-api-client/src/graphql/vista/source.rs
@@ -129,7 +129,7 @@ impl TableShell for GraphqlApiTableShell {
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = GraphqlApiVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)
     }

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -285,7 +285,7 @@ impl TableShell for RestApiTableShell {
         }
 
         // Hand-coded `with_many` / `with_one` registrations on the typed table.
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = RestApiVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)
     }

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.5 — 2026-08-12
+
+- **Bug fix:** `AwsTableShell::get_ref_target` resolves relations whose target
+  constructor returns a typed table. It went through an entity-typed downcast
+  that failed, so a reference field's list of eligible rows came back as an
+  error.
+
 ## 0.6.4 — 2026-07-23
 
 - `AwsTableShell` implements `get_ref_target`, forwarding the bare relation

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-aws/src/vista/source.rs
+++ b/vantage-aws/src/vista/source.rs
@@ -154,7 +154,7 @@ impl TableShell for AwsTableShell {
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = crate::vista::factory::AwsVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)
     }

--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.3 — 2026-08-12
+
+- **Bug fix:** `CmdTableShell::get_ref_target` resolves relations whose target
+  constructor returns a typed table. It went through an entity-typed downcast
+  that failed, so a reference field's list of eligible rows came back as an
+  error.
+
 ## 0.6.2 — 2026-07-23
 
 - `CmdTableShell` implements `get_ref_target` (the bare relation target via the

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-cmd/src/vista/source.rs
+++ b/vantage-cmd/src/vista/source.rs
@@ -116,7 +116,7 @@ impl TableShell for CmdTableShell {
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         CmdVistaFactory::new(self.table.data_source().clone()).from_table(target)
     }
 

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.3 — 2026-08-12
+
+- **Bug fix:** `CsvTableShell::get_ref_target` resolves relations whose target
+  constructor returns a typed table. It went through an entity-typed downcast
+  that failed, so a reference field's list of eligible rows came back as an
+  error.
+
 ## 0.6.2 — 2026-07-23
 
 - `CsvTableShell` implements `get_ref_target`, wrapping the bare relation target

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.6.2"
+version = "0.6.3"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"

--- a/vantage-csv/src/vista/source.rs
+++ b/vantage-csv/src/vista/source.rs
@@ -121,7 +121,7 @@ impl TableShell for CsvTableShell {
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = crate::vista::factory::CsvVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)
     }

--- a/vantage-csv/tests/vista.rs
+++ b/vantage-csv/tests/vista.rs
@@ -93,6 +93,36 @@ async fn vista_count_with_eq_condition() -> Result<()> {
     Ok(())
 }
 
+/// A relation's target is built by a caller-supplied constructor, and that
+/// constructor usually returns a table typed with the target's own entity.
+/// Resolving the bare target must not depend on the entity type — it is not
+/// known at the traversal site.
+#[tokio::test]
+async fn vista_resolves_bare_target_of_typed_relation() -> Result<()> {
+    use vantage_csv::AnyCsvType;
+    use vantage_types::Record;
+
+    let csv = csv();
+    let table = Table::<Csv, EmptyEntity>::new("client", csv.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        // Target entity is `Record<AnyCsvType>`, not `EmptyEntity`.
+        .with_one("bakery", "bakery_id", |csv: Csv| {
+            Table::<Csv, Record<AnyCsvType>>::new("bakery", csv)
+                .with_id_column("id")
+                .with_column_of::<String>("name")
+        });
+    let vista = csv.vista_factory().from_table(table)?;
+
+    let target = vista.get_ref_target("bakery")?;
+    assert_eq!(target.name(), "bakery");
+
+    let rows = target.list_values().await?;
+    assert_eq!(rows.len(), 1);
+    assert!(rows.contains_key("hill_valley"));
+    Ok(())
+}
+
 #[tokio::test]
 async fn vista_writes_return_read_only_error() -> Result<()> {
     use vantage_core::ErrorKind;

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.12.1 — unreleased
+## 0.12.2 — 2026-08-12
 
 - **Bug fix:** a create settles on the id the driver stored it under. The
   optimistic layer staged the new row under the id the flash minted and threw

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 0.12.1 — unreleased
 
+- **Bug fix:** a create settles on the id the driver stored it under. The
+  optimistic layer staged the new row under the id the flash minted and threw
+  away the record the write returned, so a driver that keeps its own key space
+  (a fully-qualified `table:key`) left the scenery showing one record as two
+  rows — the staged one and the refreshed one — and handed out a key nothing
+  upstream answered for. The staged entry now moves onto the id the master
+  reports, and the servo binds to it. `Dio::flash_returning_id` is the flash
+  that reports where the row landed.
 - **Bug fix:** a local quicksearch reads every kind of value, not only text.
   A scenery that holds all of its rows filters them itself, and the predicate
   compared `Text` alone — so a record id, a number, a boolean, and any field

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/optimistic.rs
+++ b/vantage-diorama/src/dio/optimistic.rs
@@ -14,7 +14,7 @@
 //! the cache, but the optimistic stage and the rollback are what views observe.
 
 use vantage_core::Result;
-use vantage_types::Record;
+use vantage_types::{Record, cbor_id_to_string};
 
 use ciborium::Value as CborValue;
 
@@ -37,9 +37,24 @@ impl Dio {
     /// The flash reaches the `on_flash` route with its pre-image filled: if
     /// the emitter didn't supply `before`, the cache snapshot taken here is
     /// attached, so routes always see a self-contained flash.
-    pub async fn flash(&self, mut flash: ChangeFlash) -> Result<()> {
+    pub async fn flash(&self, flash: ChangeFlash) -> Result<()> {
+        self.flash_returning_id(flash).await.map(|_| ())
+    }
+
+    /// [`flash`](Self::flash), reporting the id the row settled under.
+    ///
+    /// A driver may keep a new record under an id of its own — a
+    /// fully-qualified `table:key`, a sequence number — instead of the id
+    /// the flash minted. The staged cache entry then moves onto the id the
+    /// driver reports, because one record upstream must stay one row here:
+    /// left alone, the staged row and the refreshed row are two rows, and
+    /// the staged key hands out a row nothing upstream answers for.
+    ///
+    /// `None` for an id-less flash (`Clear`).
+    pub async fn flash_returning_id(&self, mut flash: ChangeFlash) -> Result<Option<String>> {
         let Some(id) = flash.id().map(str::to_string) else {
-            return crate::dio::worker::run_write_through(self, flash).await;
+            crate::dio::worker::run_write_through(self, flash).await?;
+            return Ok(None);
         };
 
         // Mark the row in flight for the whole optimistic window —
@@ -61,14 +76,35 @@ impl Dio {
 
         // 3. Run the real write-through.
         match crate::dio::worker::run_write_through(self, flash.clone()).await {
-            Ok(()) => {
+            Ok(stored) => {
+                let settled = stored
+                    .as_ref()
+                    .and_then(|record| self.stored_id(record))
+                    .filter(|settled| *settled != id);
+                if let Some(settled) = settled {
+                    // The master keeps this record under an id of its
+                    // own. Re-key the staged row onto it — the returned
+                    // record is what the datastore now holds — and retire
+                    // the key the flash minted.
+                    let record = stored.expect("an id settles only from a stored record");
+                    self.inner.cache.insert_value(&settled, &record).await?;
+                    self.inner.cache.delete_value(&id).await?;
+                    let _ = self.inner.event_bus.send(DioEvent::RecordRemoved { id });
+                    let _ = self.inner.event_bus.send(DioEvent::RecordInserted {
+                        id: settled.clone(),
+                    });
+                    return Ok(Some(settled));
+                }
                 // Re-assert the confirmed fields over whatever raced into
                 // the cache mid-flight: a stale writer that bypassed the
                 // pending guard loses exactly the fields this flash wrote,
                 // and keeps everything else it brought.
                 reassert_confirmed(&self.inner, &flash).await?;
-                let _ = self.inner.event_bus.send(DioEvent::RecordChanged { id });
-                Ok(())
+                let _ = self
+                    .inner
+                    .event_bus
+                    .send(DioEvent::RecordChanged { id: id.clone() });
+                Ok(Some(id))
             }
             Err(err) => {
                 // 4. Roll the cache back to the pre-image and surface the error.
@@ -118,6 +154,16 @@ impl Dio {
     /// Delete the row at `id` optimistically.
     pub async fn flash_delete(&self, id: impl Into<String>) -> Result<()> {
         self.flash(ChangeFlash::delete(id)).await
+    }
+
+    /// The id the master reports for a record it stored: its id column,
+    /// read in the same form every other cache key takes. `None` when the
+    /// record carries no readable id — the caller then keeps the id it
+    /// wrote with.
+    fn stored_id(&self, record: &Record<CborValue>) -> Option<String> {
+        let master = self.master();
+        let id_column = master.get_id_column().unwrap_or("id");
+        record.get(id_column).and_then(cbor_id_to_string)
     }
 }
 

--- a/vantage-diorama/src/dio/worker.rs
+++ b/vantage-diorama/src/dio/worker.rs
@@ -15,9 +15,11 @@
 
 use std::sync::Arc;
 
+use ciborium::Value as CborValue;
 use tokio::sync::mpsc;
 use vantage_core::{Result, error};
 use vantage_dataset::traits::WritableValueSet;
+use vantage_types::Record;
 
 use crate::dio::{Dio, DioEvent, DioInner};
 use crate::ops::{ChangeFlash, FlashKind};
@@ -53,9 +55,18 @@ pub(crate) async fn write_worker_loop(mut rx: mpsc::Receiver<QueuedFlash>) {
 /// write-to-master path when none is registered. Shared by the
 /// fire-and-forget queue worker and the optimistic path
 /// ([`Dio::flash`](crate::Dio::flash)).
-pub(crate) async fn run_write_through(dio: &Dio, flash: ChangeFlash) -> Result<()> {
+///
+/// Returns the record a new row was stored as, when the write path
+/// produced one. A driver is free to keep the record under an id of its
+/// own, so the caller reads the stored record's id rather than assuming
+/// the flash's id survived. A routed write reports nothing: the route
+/// owns the destination and the caller cannot read its id.
+pub(crate) async fn run_write_through(
+    dio: &Dio,
+    flash: ChangeFlash,
+) -> Result<Option<Record<CborValue>>> {
     if let Some(route) = dio.inner.lens.callbacks.on_flash.as_ref() {
-        route(dio, flash).await
+        route(dio, flash).await.map(|()| None)
     } else {
         default_write(dio, flash).await
     }
@@ -65,7 +76,7 @@ pub(crate) async fn run_write_through(dio: &Dio, flash: ChangeFlash) -> Result<(
 /// Applies the flash directly to `dio.master()`. The cache is *not*
 /// touched here; the optimistic path stages it, and routes that want a
 /// write-through cache update both sides explicitly.
-async fn default_write(dio: &Dio, flash: ChangeFlash) -> Result<()> {
+async fn default_write(dio: &Dio, flash: ChangeFlash) -> Result<Option<Record<CborValue>>> {
     let master = dio.master();
     let need_id = || {
         flash
@@ -74,20 +85,22 @@ async fn default_write(dio: &Dio, flash: ChangeFlash) -> Result<()> {
             .ok_or_else(|| error!("flash without an id cannot target a row"))
     };
     match flash.kind() {
+        // The insert is the one write whose id can move: the record the
+        // master stored carries the id it settled on.
         FlashKind::Insert => master
             .insert_value(need_id()?, flash.patch())
             .await
-            .map(|_| ()),
+            .map(Some),
         FlashKind::Replace => master
             .replace_value(need_id()?, flash.patch())
             .await
-            .map(|_| ()),
+            .map(|_| None),
         FlashKind::Patch => master
             .patch_value(need_id()?, flash.patch())
             .await
-            .map(|_| ()),
-        FlashKind::Delete => master.delete(need_id()?).await,
-        FlashKind::Clear => master.delete_all().await,
+            .map(|_| None),
+        FlashKind::Delete => master.delete(need_id()?).await.map(|()| None),
+        FlashKind::Clear => master.delete_all().await.map(|()| None),
     }
     .map_err(|e| error!("default write failed", detail = e.to_string()))
 }

--- a/vantage-diorama/src/ops/change_flash.rs
+++ b/vantage-diorama/src/ops/change_flash.rs
@@ -93,6 +93,13 @@ impl ChangeFlash {
         }
     }
 
+    /// Re-point the flash at the id its row settled under, when the
+    /// driver stored the record under an id of its own. The emitter reads
+    /// the flash back to learn where the row landed.
+    pub(crate) fn rebind_id(&mut self, id: impl Into<String>) {
+        self.id = Some(id.into());
+    }
+
     pub fn kind(&self) -> &FlashKind {
         &self.kind
     }

--- a/vantage-diorama/src/servo/mod.rs
+++ b/vantage-diorama/src/servo/mod.rs
@@ -316,7 +316,7 @@ impl Servo {
             }
         };
 
-        let Some(flash) = frozen else {
+        let Some(mut flash) = frozen else {
             return self.flash_auto_insert().await.map(Some);
         };
 
@@ -329,7 +329,16 @@ impl Servo {
         self.state.in_flight.fetch_add(1, Ordering::SeqCst);
         self.state.bump_generation();
 
-        let outcome = self.dio.flash(flash.clone()).await;
+        let outcome = self.dio.flash_returning_id(flash.clone()).await;
+        // A driver may store a new record under an id of its own, so
+        // identity comes from the id the row settled under — the same
+        // discipline `flash_auto_insert` follows for a returning insert.
+        // Rebound before the measurement below, which reads the cache by
+        // this servo's id.
+        if let Ok(Some(settled)) = outcome.as_ref() {
+            *self.state.id.write().unwrap() = Some(settled.clone());
+            flash.rebind_id(settled.clone());
+        }
         // One deliberate measurement now that the write resolved — but
         // only for the LAST in-flight resolver: an earlier one would
         // read a sibling flash's still-staged optimistic value as an
@@ -342,7 +351,7 @@ impl Servo {
             self.absorb_now().await;
         }
         match outcome {
-            Ok(()) => {
+            Ok(_) => {
                 if last {
                     self.state.set_status(ServoStatus::Tracking);
                 }

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -560,6 +560,35 @@ async fn uuid_create_retry_reuses_the_id() -> Result<()> {
     Ok(())
 }
 
+/// A driver is free to keep a new record under an id of its own. The
+/// staged row must move onto that id — one record upstream is one row
+/// here, not the staged row plus the refreshed one.
+#[tokio::test]
+async fn a_create_settles_on_the_id_the_driver_stored() -> Result<()> {
+    let shell = MockShell::new().with_id_prefix("products:");
+    let dio = dio_over(&shell).await?;
+    let servo = dio.servo_new(IdStrategy::Uuid);
+    let minted = servo.id().expect("minted at creation");
+
+    servo.set("name", text("Croissant"));
+    let flash = servo.flash().await?.expect("insert fires");
+
+    let settled = format!("products:{minted}");
+    assert_eq!(flash.id(), Some(settled.as_str()));
+    assert_eq!(servo.id().as_deref(), Some(settled.as_str()));
+    assert!(
+        dio.cache().get_value(&minted).await?.is_none(),
+        "the minted key is retired"
+    );
+    assert!(
+        dio.cache().get_value(&settled).await?.is_some(),
+        "the row lives under the id the driver reported"
+    );
+    assert_eq!(shell.len(), 1, "one record upstream");
+    assert!(!servo.is_dirty(), "converged clean on the created row");
+    Ok(())
+}
+
 #[tokio::test]
 async fn auto_strategy_binds_the_backend_id() -> Result<()> {
     let shell = product_shell();

--- a/vantage-diorama/tests/servo.rs
+++ b/vantage-diorama/tests/servo.rs
@@ -589,6 +589,77 @@ async fn a_create_settles_on_the_id_the_driver_stored() -> Result<()> {
     Ok(())
 }
 
+/// The settled id comes out of the master's id column, whatever that
+/// column is named. A master keyed by `sku` reports where it stored the
+/// record in `sku`, so a re-key that only looked at a literal `id` field
+/// would leave the row on the minted key.
+#[tokio::test]
+async fn a_create_settles_on_a_renamed_id_column() -> Result<()> {
+    let shell = MockShell::new().with_id_prefix("products:");
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("sku", "String").with_flag("id"))
+        .with_column(Column::new("name", "String").with_flag("title"))
+        .with_id_column("sku");
+    let vista = Vista::new("products", Box::new(shell.clone().with_metadata(metadata)));
+    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
+    let dio = lens.make_dio(vista).await?;
+
+    let servo = dio.servo_new(IdStrategy::Uuid);
+    let minted = servo.id().expect("minted at creation");
+    servo.set("name", text("Croissant"));
+    let flash = servo.flash().await?.expect("insert fires");
+
+    let settled = format!("products:{minted}");
+    assert_eq!(flash.id(), Some(settled.as_str()));
+    assert_eq!(servo.id().as_deref(), Some(settled.as_str()));
+    assert!(
+        dio.cache().get_value(&minted).await?.is_none(),
+        "the minted key is retired"
+    );
+    let row = dio
+        .cache()
+        .get_value(&settled)
+        .await?
+        .expect("the row lives under the id the driver reported");
+    assert_eq!(
+        row.get("sku"),
+        Some(&text(&settled)),
+        "the master reports the id in its own id column"
+    );
+    Ok(())
+}
+
+/// The returning insert reports the same id the by-id insert stores
+/// under. A driver that qualifies its keys must qualify this one too —
+/// otherwise an `Auto` create binds, and seeds the cache with, an id no
+/// read can resolve.
+#[tokio::test]
+async fn an_auto_create_binds_the_id_the_driver_qualified() -> Result<()> {
+    let shell = MockShell::new().with_id_prefix("products:");
+    let dio = dio_over(&shell).await?;
+    let servo = dio.servo_new(IdStrategy::Auto);
+
+    servo.set("name", text("Croissant"));
+    let flash = servo.flash().await?.expect("returning insert fires");
+
+    let id = servo.id().expect("bound to the created row");
+    assert_eq!(
+        shell.record_ids(),
+        vec![id.clone()],
+        "the id the store used"
+    );
+    assert_eq!(flash.id(), Some(id.as_str()));
+    assert!(
+        dio.master().get_value(&id).await?.is_some(),
+        "the bound id resolves upstream"
+    );
+    assert!(
+        dio.cache().get_value(&id).await?.is_some(),
+        "cache seeded under that same id"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn auto_strategy_binds_the_backend_id() -> Result<()> {
     let shell = product_shell();

--- a/vantage-kubernetes/CHANGELOG.md
+++ b/vantage-kubernetes/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.1.2 — 2026-08-12
+
+- **Bug fix:** `KubeTableShell::get_ref_target` resolves relations whose target
+  constructor returns a typed table. It went through an entity-typed downcast
+  that failed, so a reference field's list of eligible rows came back as an
+  error.
+- The vantage dependencies carry a `path` next to their version, like
+  `vantage-aws` and `vantage-cmd`. This crate sits outside the workspace, so it
+  used to build against whatever crates.io last published — a change made here
+  and in `vantage-table` in one commit could not compile together. It now builds
+  against the sources beside it, and still publishes by version.
+
 ## 0.1.1 — 2026-07-23
 
 - `KubeTableShell` implements `get_ref_target` (the bare relation target via the

--- a/vantage-kubernetes/Cargo.lock
+++ b/vantage-kubernetes/Cargo.lock
@@ -2116,9 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cli-util"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf997ecc2b0fcfdcefe920765a58fbbd00d7f38b2b857574cbdea9cb3c088031"
+version = "0.6.1"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2135,9 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66077c47099355cafa9cd6f189735e946e224d556376a59ae5b3f0505bf9a4e"
+version = "0.6.3"
 dependencies = [
  "atty",
  "indexmap",
@@ -2149,9 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b511c291ff262889b0bf5dce5b444c7a71ab68f0ea6975028eab03a08643a7"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2171,8 +2165,6 @@ dependencies = [
 [[package]]
 name = "vantage-expressions"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e9126793d25c608bdf8fee324326628a163c76c7844a1393cead32197e45c"
 dependencies = [
  "async-trait",
  "serde",
@@ -2213,9 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5476cec20cea8b29e87a2d148d8a2fdedfb652566e02526535d5962d36707b58"
+version = "0.6.15"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2239,10 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf3e02295f68be8d8f14cad6b1d65b0dc334d528b2d6344fcb844baad554ad5"
+version = "0.6.8"
 dependencies = [
+ "chrono",
  "ciborium",
  "indexmap",
  "paste",
@@ -2255,8 +2244,6 @@ dependencies = [
 [[package]]
 name = "vantage-types-entity"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b7457dc46f03ae0e87e3202ff0d5236ce3c206700e54f78f28c1cda5b855cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2265,9 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29f653962bb4b921acf878d766bd9ddc7dfbd69370f6b2afb3c914f9ef308e8"
+version = "0.6.20"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-kubernetes/Cargo.toml
+++ b/vantage-kubernetes/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/romaninsh/vantage"
 readme = "README.md"
 
 [dependencies]
-vantage-core = { version = "0.6" }
-vantage-types = { version = "0.6", features = ["serde"] }
-vantage-expressions = { version = "0.6" }
-vantage-table = { version = "0.6" }
-vantage-dataset = { version = "0.6" }
-vantage-vista = { version = "0.6" }
+vantage-core = { version = "0.6", path = "../vantage-core" }
+vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
+vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
+vantage-table = { version = "0.6", path = "../vantage-table" }
+vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
+vantage-vista = { version = "0.6", path = "../vantage-vista" }
 
 # Native Kubernetes client: config/auth/TLS only. We issue raw list
 # requests and project the JSON ourselves, so k8s-openapi's generated
@@ -45,7 +45,7 @@ ciborium = "0.2"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 
 [dev-dependencies]
-vantage-cli-util = { version = "0.6" }
+vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
 ciborium = "0.2"
 
 anyhow = "1"

--- a/vantage-kubernetes/Cargo.toml
+++ b/vantage-kubernetes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-kubernetes"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-kubernetes/src/vista/source.rs
+++ b/vantage-kubernetes/src/vista/source.rs
@@ -253,7 +253,7 @@ impl TableShell for KubeTableShell {
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = crate::vista::factory::KubeVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)
     }

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.5 — 2026-08-12
+
+- **Bug fix:** `MongoTableShell::get_ref_target` resolves relations whose target
+  constructor returns a typed table. It went through an entity-typed downcast
+  that failed, so a reference field's list of eligible rows came back as an
+  error.
+
 ## 0.6.4 — 2026-07-23
 
 - Doc-comment fix: escape generics so `rustdoc -D warnings` passes. No

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"

--- a/vantage-mongodb/src/vista/source.rs
+++ b/vantage-mongodb/src/vista/source.rs
@@ -302,7 +302,7 @@ impl TableShell for MongoTableShell {
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory =
             crate::vista::factory::MongoVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.18 — 2026-08-12
+
+- **Bug fix:** the Postgres, MySQL and SQLite shells resolve relations whose
+  target constructor returns a typed table. `get_ref_target` went through an
+  entity-typed downcast that failed, so a reference field's list of eligible
+  rows came back as an error.
+
 ## 0.6.17 — 2026-08-07
 
 - **Bug fix:** a search keeps the conditions of the table. The search

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.17"
+version = "0.6.18"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/vista/source.rs
+++ b/vantage-sql/src/mysql/vista/source.rs
@@ -241,7 +241,7 @@ where
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory =
             crate::mysql::vista::factory::MysqlVistaFactory::new(self.table.data_source().clone());
         factory.from_table(target)

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -302,7 +302,7 @@ where
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = crate::postgres::vista::factory::PostgresVistaFactory::new(
             self.table.data_source().clone(),
         )

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -405,7 +405,7 @@ where
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let factory = crate::sqlite::vista::factory::SqliteVistaFactory::new(
             self.table.data_source().clone(),
         );

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.14 — unreleased
+## 0.6.15 — 2026-08-12
 
 - **Bug fix:** `SurrealTableShell::get_ref_target` resolves relations whose
   target constructor returns a typed table. It went through an entity-typed

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.6.14 — unreleased
 
+- **Bug fix:** `SurrealTableShell::get_ref_target` resolves relations whose
+  target constructor returns a typed table. It went through an entity-typed
+  downcast that failed, so a reference field's list of eligible rows came back
+  as an error.
 - **Bug fix:** `Thing::expr` escapes the table and the id through the
   surreal-client authority. A record id with a dash (`tag:75KE-F3HG`) parsed
   as a subtraction and matched no record; it now renders as `tag:⟨75KE-F3HG⟩`.

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.14"
+version = "0.6.15"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -327,7 +327,7 @@ where
     }
 
     fn get_ref_target(&self, relation: &str) -> Result<Vista> {
-        let target = self.table.get_ref_target::<EmptyEntity>(relation)?;
+        let target = self.table.get_ref_target_erased(relation)?;
         let mut factory = SurrealVistaFactory::new(self.table.data_source().clone());
         if let Some(resolver) = &self.resolver {
             factory = factory.with_resolver(resolver.clone());

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.15 — unreleased
+## 0.6.16 — 2026-08-12
 
 - **Bug fix:** `get_ref_target_erased` replaces the typed
   `get_ref_target::<E2>`, which is removed. The typed form downcast the

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.6.15 — unreleased
 
+- **Bug fix:** `get_ref_target_erased` replaces the typed
+  `get_ref_target::<E2>`, which is removed. The typed form downcast the
+  relation's target to the entity type the caller named, so a relation declared
+  with a constructor that returns a typed table (`with_one("b", "b_id",
+  BEntity::table)`) failed with "Failed to downcast related table". The
+  traversal site cannot know the target's entity type, so the bare target is
+  always erased now.
 - `with_imported_column` / `add_imported_column` bring a column in over a
   dotted traversal of a related record. Additive: the projection keeps every
   column it already had, so importing one field no longer narrows the query.

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.15"
+version = "0.6.16"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/table/impls/refereces.rs
+++ b/vantage-table/src/table/impls/refereces.rs
@@ -467,38 +467,25 @@ impl<T: TableSource + 'static, E: Entity<T::Value> + 'static> Table<T, E> {
         target.add_condition(condition);
     }
 
-    /// Entity-erased [`get_ref_target`](Self::get_ref_target): the bare target
-    /// (no condition) as `Table<T, EmptyEntity>`. Used to walk an
-    /// implicit-reference chain and read the final target's column definitions.
-    pub fn get_ref_target_erased(&self, relation: &str) -> Result<Table<T, EmptyEntity>> {
-        let (reference, relation_str) = self.lookup_ref(relation)?;
-        let target: Table<T, EmptyEntity> = *reference
-            .build_target_erased(self.data_source() as &dyn std::any::Any)
-            .downcast::<Table<T, EmptyEntity>>()
-            .map_err(|_| {
-                error!(
-                    "Failed to downcast related table",
-                    relation = relation_str.as_str()
-                )
-            })?;
-        Ok(target)
-    }
-
-    /// Build the relation's target table with **no condition** applied.
+    /// Build the relation's target table with **no condition** applied, as
+    /// `Table<T, EmptyEntity>`.
     ///
     /// Unlike [`Self::get_ref_from_row`] / [`Self::get_ref_as`] (which select
     /// the related rows for a known parent), this returns the bare target — the
     /// table you'd insert a new related row into. Used by Vista's nested insert
     /// to obtain the destination for a has-one/has-many child before any join
-    /// value exists.
-    pub fn get_ref_target<E2: Entity<T::Value> + 'static>(
-        &self,
-        relation: &str,
-    ) -> Result<Table<T, E2>> {
+    /// value exists, and to walk an implicit-reference chain and read the final
+    /// target's column definitions.
+    ///
+    /// The result is entity-erased on purpose: a relation's target is built by
+    /// a caller-supplied constructor whose entity type the traversal cannot
+    /// know, so naming an entity type here would only give a downcast that
+    /// fails whenever the two types disagree.
+    pub fn get_ref_target_erased(&self, relation: &str) -> Result<Table<T, EmptyEntity>> {
         let (reference, relation_str) = self.lookup_ref(relation)?;
-        let target: Table<T, E2> = *reference
-            .build_target(self.data_source() as &dyn std::any::Any)
-            .downcast::<Table<T, E2>>()
+        let target: Table<T, EmptyEntity> = *reference
+            .build_target_erased(self.data_source() as &dyn std::any::Any)
+            .downcast::<Table<T, EmptyEntity>>()
             .map_err(|_| {
                 error!(
                     "Failed to downcast related table",

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.21 — 2026-08-12
+
+- `MockShell::with_id_prefix` qualifies every id with a prefix, the way a driver
+  that owns its key space does: a record inserted as `abc` is stored, and
+  reported back, as `client:abc`. It gives a test a driver that renames what it
+  is handed, without a real database.
+- `MockShell` reports the id it stored a record under in the vista's id column,
+  not in a literal `id` field, and its returning insert reports the same id its
+  by-id insert stores under. A caller that reads the id back off an insert now
+  gets one answer from both paths, whatever the id column is called.
+- Doc fix: `TableShell::get_ref_target` described the typed
+  `get_ref_target::<EmptyEntity>` a driver should forward into. That method is
+  gone; the erased `get_ref_target_erased` replaces it.
+
 ## 0.6.20 — 2026-07-30
 
 - `MockShell` serves windows and counts without copying the store. The obvious

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -37,6 +37,10 @@ pub struct MockShell {
     /// source that is temporarily unreachable (a 503). Shared across clones
     /// (incl. narrowed `get_ref` results) so a test can flip it from any handle.
     fail_reads: Arc<AtomicBool>,
+    /// While set, the store keys every record by `<prefix><id>` — the
+    /// in-memory analogue of a driver that owns its key space and qualifies
+    /// what a caller hands it. See [`Self::with_id_prefix`].
+    id_prefix: Option<String>,
 }
 
 impl MockShell {
@@ -59,6 +63,7 @@ impl MockShell {
             metadata: VistaMetadata::new(),
             ref_targets: IndexMap::new(),
             fail_reads: Arc::new(AtomicBool::new(false)),
+            id_prefix: None,
         }
     }
 
@@ -93,6 +98,7 @@ impl MockShell {
             metadata: self.metadata.clone(),
             ref_targets: self.ref_targets.clone(),
             fail_reads: self.fail_reads.clone(),
+            id_prefix: self.id_prefix.clone(),
         }
     }
 
@@ -104,6 +110,23 @@ impl MockShell {
     pub fn with_metadata(mut self, metadata: VistaMetadata) -> Self {
         self.metadata = metadata;
         self
+    }
+
+    /// Qualify every id with `prefix`, the way a driver that owns its key
+    /// space does: a record inserted as `abc` is stored — and returned —
+    /// as `client:abc`. An id that already carries the prefix passes
+    /// through, so a caller can address a row in either form.
+    pub fn with_id_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.id_prefix = Some(prefix.into());
+        self
+    }
+
+    /// The store key for `id` under [`Self::with_id_prefix`].
+    fn key(&self, id: &str) -> String {
+        match &self.id_prefix {
+            Some(prefix) if !id.starts_with(prefix.as_str()) => format!("{prefix}{id}"),
+            _ => id.to_string(),
+        }
     }
 
     /// Seed a record with an explicit id.
@@ -388,6 +411,7 @@ impl TableShell for MockShell {
             metadata: self.metadata.clone(),
             ref_targets: self.ref_targets.clone(),
             fail_reads: self.fail_reads.clone(),
+            id_prefix: self.id_prefix.clone(),
         }))
     }
 
@@ -397,7 +421,7 @@ impl TableShell for MockShell {
         id: &String,
     ) -> Result<Option<Record<CborValue>>> {
         self.guard_reads()?;
-        Ok(self.data.lock().unwrap().get(id).cloned())
+        Ok(self.data.lock().unwrap().get(&self.key(id)).cloned())
     }
 
     async fn get_vista_some_value(
@@ -418,13 +442,14 @@ impl TableShell for MockShell {
         id: &String,
         record: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
+        let key = self.key(id);
         let mut data = self.data.lock().unwrap();
-        if data.contains_key(id) {
+        if data.contains_key(&key) {
             return Err(vantage_core::error!("Record already exists", id = id));
         }
         let mut stored = record.clone();
-        stored.insert("id".to_string(), CborValue::Text(id.clone()));
-        data.insert(id.clone(), stored.clone());
+        stored.insert("id".to_string(), CborValue::Text(key.clone()));
+        data.insert(key, stored.clone());
         Ok(stored)
     }
 
@@ -434,10 +459,11 @@ impl TableShell for MockShell {
         id: &String,
         record: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
+        let key = self.key(id);
         let mut data = self.data.lock().unwrap();
         let mut stored = record.clone();
-        stored.insert("id".to_string(), CborValue::Text(id.clone()));
-        data.insert(id.clone(), stored.clone());
+        stored.insert("id".to_string(), CborValue::Text(key.clone()));
+        data.insert(key, stored.clone());
         Ok(stored)
     }
 
@@ -447,9 +473,10 @@ impl TableShell for MockShell {
         id: &String,
         partial: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
+        let key = self.key(id);
         let mut data = self.data.lock().unwrap();
         let existing = data
-            .get_mut(id)
+            .get_mut(&key)
             .ok_or_else(|| vantage_core::error!("Record not found", id = id))?;
         for (k, v) in partial {
             existing.insert(k.clone(), v.clone());
@@ -458,8 +485,9 @@ impl TableShell for MockShell {
     }
 
     async fn delete_vista_value(&self, _vista: &Vista, id: &String) -> Result<()> {
+        let key = self.key(id);
         let mut data = self.data.lock().unwrap();
-        if data.shift_remove(id).is_none() {
+        if data.shift_remove(&key).is_none() {
             Err(vantage_core::error!("Record not found", id = id))
         } else {
             Ok(())

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -436,6 +436,12 @@ impl TableShell for MockShell {
             .map(|(k, v)| (k.clone(), v.clone())))
     }
 
+    /// Store the record and report it back carrying the key it landed
+    /// under. The key goes into the vista's id column, not a literal
+    /// `id` field: a caller that reads the id back off the returned
+    /// record — a cache settling a create, for one — reads the column the
+    /// metadata declares, so a mock configured with a different id column
+    /// must answer in that column too.
     async fn insert_vista_value(
         &self,
         _vista: &Vista,
@@ -447,8 +453,9 @@ impl TableShell for MockShell {
         if data.contains_key(&key) {
             return Err(vantage_core::error!("Record already exists", id = id));
         }
+        let id_field = self.metadata.id_column.as_deref().unwrap_or("id");
         let mut stored = record.clone();
-        stored.insert("id".to_string(), CborValue::Text(key.clone()));
+        stored.insert(id_field.to_string(), CborValue::Text(key.clone()));
         data.insert(key, stored.clone());
         Ok(stored)
     }
@@ -460,9 +467,10 @@ impl TableShell for MockShell {
         record: &Record<CborValue>,
     ) -> Result<Record<CborValue>> {
         let key = self.key(id);
+        let id_field = self.metadata.id_column.as_deref().unwrap_or("id");
         let mut data = self.data.lock().unwrap();
         let mut stored = record.clone();
-        stored.insert("id".to_string(), CborValue::Text(key.clone()));
+        stored.insert(id_field.to_string(), CborValue::Text(key.clone()));
         data.insert(key, stored.clone());
         Ok(stored)
     }
@@ -499,6 +507,9 @@ impl TableShell for MockShell {
         Ok(())
     }
 
+    /// Insert and report the id the record is addressable by. That is the
+    /// store key, prefix included: the caller uses this id to read the row
+    /// back, so it must be the same id the by-id insert path stores under.
     async fn insert_vista_return_id_value(
         &self,
         vista: &Vista,
@@ -510,7 +521,7 @@ impl TableShell for MockShell {
             _ => self.next_auto_id(),
         };
         self.insert_vista_value(vista, &id, record).await?;
-        Ok(id)
+        Ok(self.key(&id))
     }
 
     /// Count without materializing: `list_vista_values` clones every matching

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -482,7 +482,7 @@ pub trait TableShell: Send + Sync + 'static {
     /// has-many child's destination.
     ///
     /// Drivers override by forwarding into the wrapped typed `Table`'s
-    /// `get_ref_target::<EmptyEntity>(relation)` and wrapping the result back
+    /// `get_ref_target_erased(relation)` and wrapping the result back
     /// through the driver's factory — the same path as [`get_ref`](Self::get_ref)
     /// minus the row-derived condition. The default returns `Unimplemented`;
     /// cross-persistence relations are rejected at the `Vista` layer before


### PR DESCRIPTION
Two data-layer defects, one commit each.

## 1. A relation's bare target could not be resolved

`Table::get_ref_target::<E2>` downcast the relation's target to the entity type
the caller named. Every driver's `TableShell::get_ref_target` called it with
`EmptyEntity`, but a relation is built by a caller-supplied constructor, which
usually returns a table typed with the target's own entity:

```rust
Table::new("client", db).with_one("bakery", "bakery_id", Bakery::table)
```

The downcast then failed and the call returned "Failed to downcast related
table". Anything that resolves a relation's bare target — a reference field
listing the rows it can point at, a nested insert reaching a child's
destination — got an error instead of rows. Dotted/imported columns were never
affected: that path ends in `into_entity::<EmptyEntity>()`.

The entity-erased accessor already existed and had no callers. Every driver now
goes through `get_ref_target_erased`, and the typed form is removed: the
traversal site cannot know the target's entity type, so naming one only buys a
downcast that fails whenever the two disagree.

- `vantage-table/src/table/impls/refereces.rs` — `get_ref_target::<E2>` removed;
  its documentation moved onto `get_ref_target_erased`.
- `get_ref_target_erased` in the API-client (REST, GraphQL), AWS, cmd, CSV,
  Kubernetes, MongoDB, MySQL, Postgres, SQLite and SurrealDB shells.
- Regression test in `vantage-csv/tests/vista.rs`: a table whose `with_one`
  target is a typed table resolves its bare target and lists rows. Fails on
  `main` with the downcast error.

`vantage-kubernetes` took its Vantage dependencies from crates.io while its
siblings outside the workspace (`vantage-aws`, `vantage-cmd`) take them by path.
It now takes them by path too — otherwise the crate builds against a published
`vantage-table` that has no `get_ref_target_erased`, and its own workflow goes
red on this PR. Revert that hunk if the registry pin was deliberate; the driver
then keeps the defect until the next dependency bump.

## 2. A create left a phantom row under a non-canonical id

The optimistic layer staged a new row in the cache under the id the flash
carried, then discarded the record the write returned. A driver that owns its
key space stores the record under an id of its own — SurrealDB returns a
fully-qualified `table:key` for a bare key it was handed. The cache then held
the staged row under the minted key while the next refresh brought the same
record in under the canonical one: one record upstream, two rows on screen, and
a key that hands out a row nothing upstream answers for.

The write path now carries the stored record back, and when its id differs from
the one the flash wrote with, the staged entry moves onto it: the returned
record is inserted under the canonical key, the stale key is dropped, and the
servo binds to the id the row settled under — the discipline `flash_auto_insert`
already followed for a returning insert.

- `vantage-diorama/src/dio/worker.rs` — `run_write_through` reports the record an
  insert stored instead of dropping it.
- `vantage-diorama/src/dio/optimistic.rs` — `Dio::flash_returning_id` re-keys the
  staged entry and reports where the row landed; `Dio::flash` is unchanged for
  callers that do not care.
- `vantage-diorama/src/servo/mod.rs` — the servo binds to the settled id before
  it takes its post-write measurement, and the flash it returns names that id.
- `vantage-vista/src/mocks/mock_shell.rs` — `with_id_prefix` models a driver that
  qualifies the ids it is handed, which is what the regression test needs.
- Regression test in `vantage-diorama/tests/servo.rs`. Also checked end to end
  against a local SurrealDB: before, the cache key was bare while the master key
  was qualified; after, both are the canonical id and the cache holds one row.

`cargo clippy --workspace --all-targets` and `cargo fmt --check` are clean;
`vantage-aws`, `vantage-cmd` and `vantage-kubernetes` were checked standalone.
No crate versions bumped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed relation traversal for typed target tables across supported data sources.
  - New records now use IDs assigned by the backend, preventing duplicate rows and unusable record keys.
  - Corrected optimistic updates so cached records, bindings, and displayed rows remain synchronized after writes.
  - Fixed relation resolution when target constructors return typed tables.

- **New Features**
  - Added optional ID prefixes to mock data sources for more realistic identifier handling.

- **Documentation**
  - Updated relation traversal guidance and release changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->