### PR TITLE
graphql: nested column paths, connection envelopes, and honest capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.10"
+version = "0.6.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -21,7 +21,10 @@
   dropped. Vista treats equality push-down as universal, so dropping them
   silently widened results; rendering them produced a query the server
   rejected. A filter shape that can't be evaluated row-wise now errors rather
-  than quietly matching everything.
+  than quietly matching everything. A deferred filter value resolves once for
+  the whole set rather than per row, since resolving it fetches the parent
+  table; LIKE anchors are honoured, so `foo%` is a prefix rather than a
+  substring.
 
 ## 0.6.10 — 2026-08-12
 

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.6.11 — 2026-08-16
+
+- GraphQL columns may be dotted paths. `run.commit.hash` groups into a nested
+  selection set at render time and flattens back to a dotted key on decode, so
+  a schema that nests its scalars needs no relation machinery to read them. A
+  null parent leaves the column present and null rather than missing.
+- `args:` renders literal root-field arguments — for a field whose input object
+  is non-null there was previously no way to query it at all. `response_path:`
+  locates the rows inside a Relay-style connection, and shapes the query as
+  well as the response, so the two can't drift apart.
+- Per-table `filter`/`order`/`search`/`paginate` declare what a root field
+  really accepts, defaulting to what the dialect implies. The shell implements
+  `add_op_condition`/`add_order`/`add_search`/`clear_*` and the factory
+  advertises the matching capabilities; previously every capability was left
+  false, so consumers sorted and searched in memory even against a Hasura
+  schema that could have done it server-side.
+- With `filter: false` — a root field that takes no arguments at all —
+  conditions are applied client-side over the decoded rows instead of being
+  dropped. Vista treats equality push-down as universal, so dropping them
+  silently widened results; rendering them produced a query the server
+  rejected. A filter shape that can't be evaluated row-wise now errors rather
+  than quietly matching everything.
+
 ## 0.6.10 — 2026-08-12
 
 - **Bug fix:** the REST and GraphQL `TableShell`s resolve relations whose target

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.10"
+version = "0.6.11"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/graphql/api.rs
+++ b/vantage-api-client/src/graphql/api.rs
@@ -28,6 +28,78 @@ pub struct GraphqlApi {
     auth_header: Option<String>,
     pub(crate) dialect: FilterDialect,
     pub(crate) filter_arg_name: Option<String>,
+    pub(crate) root_args: Option<Value>,
+    pub(crate) response_path: Vec<String>,
+    pub(crate) supports: Supports,
+}
+
+/// Per-table overrides for what the server will actually accept, each
+/// `None` meaning "use the dialect's default".
+///
+/// These exist because a GraphQL endpoint is not uniform: on one schema
+/// the list field takes `where`/`order_by`/`limit`, on the next it takes
+/// no arguments at all. Spacelift's `stacks` is the second kind, and
+/// pushing a filter at it renders a query the server rejects outright —
+/// so this is what stops equality push-down, which Vista otherwise
+/// assumes every driver supports.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Supports {
+    pub filter: Option<bool>,
+    pub order: Option<bool>,
+    pub search: Option<bool>,
+    pub paginate: Option<bool>,
+}
+
+impl GraphqlApi {
+    /// Whether conditions may be pushed into the query. Defaults to true —
+    /// most list fields take some filter argument.
+    pub fn can_filter(&self) -> bool {
+        self.supports.filter.unwrap_or(true)
+    }
+
+    /// Whether `order_by:` may be rendered. Only Hasura has a spelling for
+    /// it today, so Generic defaults to sorting client-side.
+    pub fn can_order(&self) -> bool {
+        self.supports
+            .order
+            .unwrap_or(matches!(self.dialect, FilterDialect::Hasura))
+    }
+
+    /// Whether a quicksearch renders as an OR of `_ilike`s. Same story as
+    /// ordering: Hasura only. A search *is* a condition, so it also needs
+    /// filter push-down to be on.
+    pub fn can_search(&self) -> bool {
+        self.can_filter()
+            && self
+                .supports
+                .search
+                .unwrap_or(matches!(self.dialect, FilterDialect::Hasura))
+    }
+
+    /// Whether operators richer than equality can be rendered. Generic
+    /// rejects them at render time, so only Hasura qualifies.
+    pub fn can_filter_operators(&self) -> bool {
+        self.can_filter() && matches!(self.dialect, FilterDialect::Hasura)
+    }
+
+    /// Whether `limit:`/`offset:` may be rendered. Off by default: a
+    /// schema that doesn't take them turns every query into an error, and
+    /// the cost of not paging is one extra round of rows.
+    pub fn can_paginate(&self) -> bool {
+        self.supports.paginate.unwrap_or(false)
+    }
+
+    /// Path walked into the root field's value before rows are read —
+    /// `["edges", "node"]` for a Relay-style connection. Empty means the
+    /// root field's value is the row array itself.
+    pub fn response_path(&self) -> &[String] {
+        &self.response_path
+    }
+
+    /// Literal arguments always passed to the root field.
+    pub fn root_args(&self) -> Option<&Value> {
+        self.root_args.as_ref()
+    }
 }
 
 impl GraphqlApi {
@@ -127,6 +199,9 @@ pub struct GraphqlApiBuilder {
     auth_header: Option<String>,
     dialect: FilterDialect,
     filter_arg_name: Option<String>,
+    root_args: Option<Value>,
+    response_path: Vec<String>,
+    supports: Supports,
 }
 
 impl GraphqlApiBuilder {
@@ -137,7 +212,30 @@ impl GraphqlApiBuilder {
             auth_header: None,
             dialect: FilterDialect::Generic,
             filter_arg_name: None,
+            root_args: None,
+            response_path: Vec::new(),
+            supports: Supports::default(),
         }
+    }
+
+    /// Literal arguments always passed to the root field, e.g.
+    /// `json!({ "input": {} })` for a mandatory non-null input object.
+    pub fn root_args(mut self, args: Value) -> Self {
+        self.root_args = Some(args);
+        self
+    }
+
+    /// Dotted path walked into the root field's value before rows are
+    /// read — `"edges.node"` unwraps a Relay-style connection.
+    pub fn response_path(mut self, path: impl AsRef<str>) -> Self {
+        self.response_path = split_response_path(path.as_ref());
+        self
+    }
+
+    /// Override what the server accepts; see [`Supports`].
+    pub fn supports(mut self, supports: Supports) -> Self {
+        self.supports = supports;
+        self
     }
 
     /// Set the `Authorization` header value (e.g. `"Bearer <token>"`).
@@ -174,8 +272,20 @@ impl GraphqlApiBuilder {
             auth_header: self.auth_header,
             dialect: self.dialect,
             filter_arg_name: self.filter_arg_name,
+            root_args: self.root_args,
+            response_path: self.response_path,
+            supports: self.supports,
         }
     }
+}
+
+/// Split a dotted response path, dropping empty segments so a stray
+/// leading or trailing dot doesn't produce a lookup for `""`.
+pub(crate) fn split_response_path(path: &str) -> Vec<String> {
+    path.split('.')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 #[cfg(test)]

--- a/vantage-api-client/src/graphql/impls/table_source.rs
+++ b/vantage-api-client/src/graphql/impls/table_source.rs
@@ -26,7 +26,7 @@ use vantage_table::traits::table_source::TableSource;
 use vantage_types::{Entity, Record};
 
 use crate::graphql::api::GraphqlApi;
-use crate::graphql::condition::{GraphqlCondition, GraphqlOp};
+use crate::graphql::condition::{FieldCondition, GraphqlCondition, GraphqlOp};
 use crate::graphql::operation::GraphqlOperation;
 use crate::graphql::select::GraphqlSelect;
 use crate::graphql::types::{AnyGraphqlType, GraphqlType as _};
@@ -143,72 +143,81 @@ fn pluck<'a>(row: &'a Value, path: &str) -> Option<&'a Value> {
 /// — a relation tab would list every parent's children — so the driver
 /// honours it here instead.
 async fn retain_matching(rows: Vec<Value>, conditions: &[GraphqlCondition]) -> Result<Vec<Value>> {
+    // Resolved up front: a deferred value fetches the parent table, so
+    // resolving per row would issue one round trip per row and could
+    // compare different rows against different values.
+    let conditions = resolve_deferred(conditions).await?;
     let mut kept = Vec::with_capacity(rows.len());
     for row in rows {
-        let mut all = true;
-        for condition in conditions {
-            if !matches_condition(&row, condition).await? {
-                all = false;
-                break;
-            }
-        }
-        if all {
+        if conditions.iter().all(|c| matches_condition(&row, c)) {
             kept.push(row);
         }
     }
     Ok(kept)
 }
 
-fn matches_condition<'a>(
-    row: &'a Value,
-    condition: &'a GraphqlCondition,
-) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + 'a>> {
+/// Replace every `DeferredField` with the plain `Field` it resolves to,
+/// walking nested groups. `Deferred` produces a dialect-shaped filter
+/// object rather than `field op value`, so there is nothing to evaluate
+/// against a row — refusing beats quietly keeping every row.
+fn resolve_deferred<'a>(
+    conditions: &'a [GraphqlCondition],
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<GraphqlCondition>>> + Send + 'a>>
+{
     Box::pin(async move {
-        match condition {
-            GraphqlCondition::Field(fc) => Ok(compare(row, &fc.field, &fc.op, &fc.value)),
-            GraphqlCondition::DeferredField {
-                field,
-                op,
-                value_fn,
-            } => {
-                let resolved = value_fn.call().await?;
-                let value = match resolved {
-                    ExpressiveEnum::Scalar(v) => v.to_json(),
-                    other => {
-                        return Err(error!(
-                            "Deferred filter resolved to a non-scalar",
-                            got = format!("{:?}", other)
-                        ));
-                    }
-                };
-                Ok(compare(row, field, op, &value))
-            }
-            GraphqlCondition::And(parts) => {
-                for part in parts {
-                    if !matches_condition(row, part).await? {
-                        return Ok(false);
-                    }
+        let mut out = Vec::with_capacity(conditions.len());
+        for condition in conditions {
+            out.push(match condition {
+                GraphqlCondition::DeferredField {
+                    field,
+                    op,
+                    value_fn,
+                } => {
+                    let value = match value_fn.call().await? {
+                        ExpressiveEnum::Scalar(v) => v.to_json(),
+                        other => {
+                            return Err(error!(
+                                "Deferred filter resolved to a non-scalar",
+                                got = format!("{:?}", other)
+                            ));
+                        }
+                    };
+                    GraphqlCondition::Field(FieldCondition::new(field.clone(), op.clone(), value))
                 }
-                Ok(true)
-            }
-            GraphqlCondition::Or(parts) => {
-                for part in parts {
-                    if matches_condition(row, part).await? {
-                        return Ok(true);
-                    }
+                GraphqlCondition::And(parts) => {
+                    GraphqlCondition::And(resolve_deferred(parts).await?)
                 }
-                Ok(parts.is_empty())
-            }
-            GraphqlCondition::Not(inner) => Ok(!matches_condition(row, inner).await?),
-            // A dynamic filter sub-object is dialect-shaped, not
-            // `field op value`, so there is nothing to evaluate against a
-            // row. Refusing beats quietly keeping every row.
-            GraphqlCondition::Deferred(_) => Err(error!(
-                "Deferred filter cannot be applied client-side; \
-                 this root field accepts no filter argument"
-            )),
+                GraphqlCondition::Or(parts) => GraphqlCondition::Or(resolve_deferred(parts).await?),
+                GraphqlCondition::Not(inner) => GraphqlCondition::Not(Box::new(
+                    resolve_deferred(std::slice::from_ref(inner.as_ref()))
+                        .await?
+                        .remove(0),
+                )),
+                GraphqlCondition::Deferred(_) => {
+                    return Err(error!(
+                        "Deferred filter cannot be applied client-side; \
+                         this root field accepts no filter argument"
+                    ));
+                }
+                plain => plain.clone(),
+            });
         }
+        Ok(out)
     })
+}
+
+/// Evaluate a deferred-free condition against one row.
+fn matches_condition(row: &Value, condition: &GraphqlCondition) -> bool {
+    match condition {
+        GraphqlCondition::Field(fc) => compare(row, &fc.field, &fc.op, &fc.value),
+        GraphqlCondition::And(parts) => parts.iter().all(|p| matches_condition(row, p)),
+        GraphqlCondition::Or(parts) => {
+            parts.is_empty() || parts.iter().any(|p| matches_condition(row, p))
+        }
+        GraphqlCondition::Not(inner) => !matches_condition(row, inner),
+        // `resolve_deferred` removed these before the row loop.
+        GraphqlCondition::DeferredField { .. } | GraphqlCondition::Deferred(_) => false,
+    }
 }
 
 /// Compare one row's value at `path` against `expected`. Ordering
@@ -227,6 +236,11 @@ fn compare(row: &Value, path: &str, op: &GraphqlOp, expected: &Value) -> bool {
         Value::Array(items) => items.iter().any(|item| item == actual),
         single => single == actual,
     };
+    // LIKE anchors decide the shape of the test: `%foo%` is a substring,
+    // `foo%` a prefix, `%foo` a suffix, and a bare `foo` an exact match.
+    // Collapsing all four to `contains` would have matched rows the server
+    // excludes. An interior `%` or an `_` is compared literally — narrower
+    // than the server, which is the safe direction to be wrong in.
     let text_match = |case_sensitive: bool| match (actual.as_str(), expected.as_str()) {
         (Some(a), Some(pattern)) => {
             let (a, pattern) = if case_sensitive {
@@ -234,7 +248,13 @@ fn compare(row: &Value, path: &str, op: &GraphqlOp, expected: &Value) -> bool {
             } else {
                 (a.to_lowercase(), pattern.to_lowercase())
             };
-            a.contains(pattern.trim_matches('%'))
+            let core = pattern.trim_matches('%');
+            match (pattern.starts_with('%'), pattern.ends_with('%')) {
+                (true, true) => a.contains(core),
+                (true, false) => a.ends_with(core),
+                (false, true) => a.starts_with(core),
+                (false, false) => a == core,
+            }
         }
         _ => false,
     };
@@ -938,8 +958,6 @@ mod shape_tests {
     use serde_json::json;
     use vantage_types::EmptyEntity;
 
-    use crate::graphql::types::GraphqlType as _;
-
     fn paths(items: &[&str]) -> Vec<String> {
         items.iter().map(|s| s.to_string()).collect()
     }
@@ -1044,6 +1062,56 @@ mod local_filter_tests {
         let kept = retain_matching(rows(), &[cond]).await.unwrap();
         assert_eq!(kept.len(), 1);
         assert_eq!(pluck(&kept[0], "stack.id"), Some(&json!("api-uat")));
+    }
+
+    /// A LIKE pattern's anchors decide the test: collapsing every form to
+    /// `contains` matched rows the server would exclude.
+    #[tokio::test]
+    async fn like_anchors_are_honoured() {
+        let rows = vec![
+            json!({ "stack": { "id": "api-uat" } }),
+            json!({ "stack": { "id": "frontend-uat" } }),
+        ];
+        let prefix = GraphqlCondition::Field(FieldCondition::new(
+            "stack.id",
+            GraphqlOp::Like,
+            json!("api%"),
+        ));
+        let kept = retain_matching(rows.clone(), &[prefix]).await.unwrap();
+        assert_eq!(kept.len(), 1, "`api%` is a prefix, not a substring");
+
+        let substring = GraphqlCondition::Field(FieldCondition::new(
+            "stack.id",
+            GraphqlOp::Like,
+            json!("%uat%"),
+        ));
+        assert_eq!(retain_matching(rows, &[substring]).await.unwrap().len(), 2);
+    }
+
+    /// A deferred value hits the network, so it must resolve once for the
+    /// whole set rather than once per row.
+    #[tokio::test]
+    async fn a_deferred_value_resolves_once_for_all_rows() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&calls);
+        let cond = GraphqlCondition::DeferredField {
+            field: "stack.id".into(),
+            op: GraphqlOp::Eq,
+            value_fn: DeferredFn::new(move || {
+                let counter = Arc::clone(&counter);
+                Box::pin(async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    Ok(ExpressiveEnum::Scalar(AnyGraphqlType::new(
+                        "api-uat".to_string(),
+                    )))
+                })
+            }),
+        };
+        let kept = retain_matching(rows(), &[cond]).await.unwrap();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     /// A filter that can't be evaluated row-wise must fail rather than

--- a/vantage-api-client/src/graphql/impls/table_source.rs
+++ b/vantage-api-client/src/graphql/impls/table_source.rs
@@ -51,6 +51,9 @@ fn select_from_table<E: Entity<AnyGraphqlType>>(table: &Table<GraphqlApi, E>) ->
     if let Some(args) = api.root_args.clone() {
         select = select.with_root_args(args);
     }
+    if !api.response_path().is_empty() {
+        select = select.with_response_path(api.response_path().to_vec());
+    }
 
     // Selection set
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();

--- a/vantage-api-client/src/graphql/impls/table_source.rs
+++ b/vantage-api-client/src/graphql/impls/table_source.rs
@@ -29,7 +29,7 @@ use crate::graphql::api::GraphqlApi;
 use crate::graphql::condition::{GraphqlCondition, GraphqlOp};
 use crate::graphql::operation::GraphqlOperation;
 use crate::graphql::select::GraphqlSelect;
-use crate::graphql::types::AnyGraphqlType;
+use crate::graphql::types::{AnyGraphqlType, GraphqlType as _};
 
 /// Build a `GraphqlSelect` from a table's current state.
 ///
@@ -129,6 +129,132 @@ fn pluck<'a>(row: &'a Value, path: &str) -> Option<&'a Value> {
         cursor = cursor.get(segment)?;
     }
     Some(cursor)
+}
+
+/// Apply conditions in memory, for a root field that takes no filter
+/// argument.
+///
+/// Vista treats equality push-down as universal, so a consumer narrowing
+/// this table never learns the server can't do it. Dropping the condition
+/// at render time and returning every row would silently widen the result
+/// — a relation tab would list every parent's children — so the driver
+/// honours it here instead.
+async fn retain_matching(rows: Vec<Value>, conditions: &[GraphqlCondition]) -> Result<Vec<Value>> {
+    let mut kept = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut all = true;
+        for condition in conditions {
+            if !matches_condition(&row, condition).await? {
+                all = false;
+                break;
+            }
+        }
+        if all {
+            kept.push(row);
+        }
+    }
+    Ok(kept)
+}
+
+fn matches_condition<'a>(
+    row: &'a Value,
+    condition: &'a GraphqlCondition,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send + 'a>> {
+    Box::pin(async move {
+        match condition {
+            GraphqlCondition::Field(fc) => Ok(compare(row, &fc.field, &fc.op, &fc.value)),
+            GraphqlCondition::DeferredField {
+                field,
+                op,
+                value_fn,
+            } => {
+                let resolved = value_fn.call().await?;
+                let value = match resolved {
+                    ExpressiveEnum::Scalar(v) => v.to_json(),
+                    other => {
+                        return Err(error!(
+                            "Deferred filter resolved to a non-scalar",
+                            got = format!("{:?}", other)
+                        ));
+                    }
+                };
+                Ok(compare(row, field, op, &value))
+            }
+            GraphqlCondition::And(parts) => {
+                for part in parts {
+                    if !matches_condition(row, part).await? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            GraphqlCondition::Or(parts) => {
+                for part in parts {
+                    if matches_condition(row, part).await? {
+                        return Ok(true);
+                    }
+                }
+                Ok(parts.is_empty())
+            }
+            GraphqlCondition::Not(inner) => Ok(!matches_condition(row, inner).await?),
+            // A dynamic filter sub-object is dialect-shaped, not
+            // `field op value`, so there is nothing to evaluate against a
+            // row. Refusing beats quietly keeping every row.
+            GraphqlCondition::Deferred(_) => Err(error!(
+                "Deferred filter cannot be applied client-side; \
+                 this root field accepts no filter argument"
+            )),
+        }
+    })
+}
+
+/// Compare one row's value at `path` against `expected`. Ordering
+/// comparisons work on numbers and strings; everything else falls back to
+/// structural equality.
+fn compare(row: &Value, path: &str, op: &GraphqlOp, expected: &Value) -> bool {
+    let actual = pluck(row, path).unwrap_or(&Value::Null);
+    let ordering = || match (actual.as_f64(), expected.as_f64()) {
+        (Some(a), Some(b)) => a.partial_cmp(&b),
+        _ => match (actual.as_str(), expected.as_str()) {
+            (Some(a), Some(b)) => Some(a.cmp(b)),
+            _ => None,
+        },
+    };
+    let contains = || match expected {
+        Value::Array(items) => items.iter().any(|item| item == actual),
+        single => single == actual,
+    };
+    let text_match = |case_sensitive: bool| match (actual.as_str(), expected.as_str()) {
+        (Some(a), Some(pattern)) => {
+            let (a, pattern) = if case_sensitive {
+                (a.to_string(), pattern.to_string())
+            } else {
+                (a.to_lowercase(), pattern.to_lowercase())
+            };
+            a.contains(pattern.trim_matches('%'))
+        }
+        _ => false,
+    };
+    match op {
+        GraphqlOp::Eq => actual == expected,
+        GraphqlOp::Ne => actual != expected,
+        GraphqlOp::Gt => matches!(ordering(), Some(std::cmp::Ordering::Greater)),
+        GraphqlOp::Gte => matches!(
+            ordering(),
+            Some(std::cmp::Ordering::Greater) | Some(std::cmp::Ordering::Equal)
+        ),
+        GraphqlOp::Lt => matches!(ordering(), Some(std::cmp::Ordering::Less)),
+        GraphqlOp::Lte => matches!(
+            ordering(),
+            Some(std::cmp::Ordering::Less) | Some(std::cmp::Ordering::Equal)
+        ),
+        GraphqlOp::In => contains(),
+        GraphqlOp::NotIn => !contains(),
+        GraphqlOp::Like => text_match(true),
+        GraphqlOp::ILike => text_match(false),
+        GraphqlOp::IsNull => actual.is_null(),
+        GraphqlOp::IsNotNull => !actual.is_null(),
+    }
 }
 
 /// Convert a JSON row into `(Id, Record<AnyGraphqlType>)`. The id is
@@ -292,6 +418,14 @@ impl TableSource for GraphqlApi {
                     got = format!("{:?}", other)
                 ));
             }
+        };
+
+        // Conditions the query couldn't carry are applied here, so a
+        // narrowed table returns narrowed rows either way.
+        let arr = if table.data_source().can_filter() {
+            arr
+        } else {
+            retain_matching(arr, &table.conditions().cloned().collect::<Vec<_>>()).await?
         };
 
         let id_name = table.id_field().map(|c| c.name().to_string());
@@ -866,5 +1000,56 @@ mod shape_tests {
             crate::graphql::condition::FieldCondition::new("space", GraphqlOp::Eq, json!("root")),
         ));
         assert!(select_from_table(&table).conditions.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod local_filter_tests {
+    use super::*;
+    use crate::graphql::condition::FieldCondition;
+    use serde_json::json;
+
+    fn rows() -> Vec<Value> {
+        vec![
+            json!({ "stack": { "id": "api-uat" }, "run": { "id": "1", "delta": { "addCount": 4 } } }),
+            json!({ "stack": { "id": "api-dev" }, "run": { "id": "2", "delta": { "addCount": 0 } } }),
+        ]
+    }
+
+    /// The narrowing a binder tab applies has to survive even though the
+    /// root field takes no filter argument — otherwise the tab would list
+    /// every stack's runs.
+    #[tokio::test]
+    async fn equality_on_a_dotted_path_narrows_locally() {
+        let cond = GraphqlCondition::Field(FieldCondition::new(
+            "stack.id",
+            GraphqlOp::Eq,
+            json!("api-uat"),
+        ));
+        let kept = retain_matching(rows(), &[cond]).await.unwrap();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(pluck(&kept[0], "run.id"), Some(&json!("1")));
+    }
+
+    #[tokio::test]
+    async fn ordering_comparisons_work_on_numbers() {
+        let cond = GraphqlCondition::Field(FieldCondition::new(
+            "run.delta.addCount",
+            GraphqlOp::Gt,
+            json!(1),
+        ));
+        let kept = retain_matching(rows(), &[cond]).await.unwrap();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(pluck(&kept[0], "stack.id"), Some(&json!("api-uat")));
+    }
+
+    /// A filter that can't be evaluated row-wise must fail rather than
+    /// quietly returning everything.
+    #[tokio::test]
+    async fn an_opaque_deferred_filter_is_refused() {
+        let cond = GraphqlCondition::Deferred(DeferredFn::new(|| {
+            Box::pin(async { Ok(ExpressiveEnum::Scalar(AnyGraphqlType::new(1i64))) })
+        }));
+        assert!(retain_matching(rows(), &[cond]).await.is_err());
     }
 }

--- a/vantage-api-client/src/graphql/impls/table_source.rs
+++ b/vantage-api-client/src/graphql/impls/table_source.rs
@@ -48,6 +48,9 @@ fn select_from_table<E: Entity<AnyGraphqlType>>(table: &Table<GraphqlApi, E>) ->
     if let Some(name) = api.filter_arg_name.clone() {
         select = select.with_filter_arg_name(name);
     }
+    if let Some(args) = api.root_args.clone() {
+        select = select.with_root_args(args);
+    }
 
     // Selection set
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -62,25 +65,33 @@ fn select_from_table<E: Entity<AnyGraphqlType>>(table: &Table<GraphqlApi, E>) ->
         }
     }
 
-    // Conditions
-    for cond in table.conditions() {
-        select.conditions.push(cond.clone());
-    }
-
-    // Orders: GraphqlCondition's `Field` variant carries the column name.
-    for (cond, direction) in table.orders() {
-        if let GraphqlCondition::Field(fc) = cond {
-            let order = if matches!(direction, vantage_table::sorting::SortDirection::Ascending) {
-                Order::Asc
-            } else {
-                Order::Desc
-            };
-            select.sort.push((fc.field.clone(), order));
+    // Conditions, orders and pagination only reach the wire when the root
+    // field actually takes those arguments — otherwise they'd render a
+    // query the server rejects, and the consumer applies them locally.
+    if api.can_filter() {
+        for cond in table.conditions() {
+            select.conditions.push(cond.clone());
         }
     }
 
-    // Pagination
-    if let Some(pagination) = table.pagination() {
+    // Orders: GraphqlCondition's `Field` variant carries the column name.
+    if api.can_order() {
+        for (cond, direction) in table.orders() {
+            if let GraphqlCondition::Field(fc) = cond {
+                let order = if matches!(direction, vantage_table::sorting::SortDirection::Ascending)
+                {
+                    Order::Asc
+                } else {
+                    Order::Desc
+                };
+                select.sort.push((fc.field.clone(), order));
+            }
+        }
+    }
+
+    if api.can_paginate()
+        && let Some(pagination) = table.pagination()
+    {
         select.limit = Some(pagination.limit());
         select.skip = Some(pagination.skip());
     }
@@ -88,30 +99,75 @@ fn select_from_table<E: Entity<AnyGraphqlType>>(table: &Table<GraphqlApi, E>) ->
     select
 }
 
+/// Walk `path` into the root field's value to reach the row array.
+///
+/// Each segment indexes an object, or maps over an array — so
+/// `["edges", "node"]` turns `{ edges: [{ node: … }] }` into `[…]`
+/// in one pass, which is every Relay-style connection.
+fn descend(value: &Value, path: &[String]) -> Value {
+    let Some((segment, rest)) = path.split_first() else {
+        return value.clone();
+    };
+    let stepped = match value {
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .map(|item| item.get(segment.as_str()).cloned().unwrap_or(Value::Null))
+                .collect(),
+        ),
+        other => other.get(segment.as_str()).cloned().unwrap_or(Value::Null),
+    };
+    descend(&stepped, rest)
+}
+
+/// Resolve a dotted path against a row. A missing or null link yields
+/// `None`, so `run.commit.hash` on a run with no commit is absent rather
+/// than an error.
+fn pluck<'a>(row: &'a Value, path: &str) -> Option<&'a Value> {
+    let mut cursor = row;
+    for segment in path.split('.') {
+        cursor = cursor.get(segment)?;
+    }
+    Some(cursor)
+}
+
 /// Convert a JSON row into `(Id, Record<AnyGraphqlType>)`. The id is
 /// stringified from whatever JSON shape the server returned — most
 /// schemas use `String` or numeric ids, both of which we coerce to
 /// `String` since that's our `Id` type.
-fn row_to_record(row: &Value, id_field: Option<&str>) -> Result<(String, Record<AnyGraphqlType>)> {
+fn row_to_record(
+    row: &Value,
+    fields: &[String],
+    id_field: Option<&str>,
+) -> Result<(String, Record<AnyGraphqlType>)> {
     let obj = row
         .as_object()
         .ok_or_else(|| error!("Expected JSON object for row", got = format!("{:?}", row)))?;
 
     let id = match id_field {
-        Some(field) => obj
-            .get(field)
+        Some(field) => pluck(row, field)
             .map(value_to_string)
             .ok_or_else(|| error!("Row missing id field", field = field.to_string()))?,
         // No id field declared — fall back to "id" then to a stringified row index later.
-        None => obj.get("id").map(value_to_string).unwrap_or_default(),
+        None => pluck(row, "id").map(value_to_string).unwrap_or_default(),
     };
 
-    let mut fields: IndexMap<String, AnyGraphqlType> = IndexMap::new();
-    for (k, v) in obj {
-        fields.insert(k.clone(), AnyGraphqlType::untyped(v.clone()));
+    // Each declared path becomes a dotted key, so a nested scalar reads as
+    // an ordinary flat column and a null parent still leaves the column
+    // present (as null) rather than missing.
+    let mut out: IndexMap<String, AnyGraphqlType> = IndexMap::new();
+    if fields.is_empty() {
+        for (k, v) in obj {
+            out.insert(k.clone(), AnyGraphqlType::untyped(v.clone()));
+        }
+    } else {
+        for path in fields {
+            let value = pluck(row, path).cloned().unwrap_or(Value::Null);
+            out.insert(path.clone(), AnyGraphqlType::untyped(value));
+        }
     }
 
-    Ok((id, Record::from_indexmap(fields)))
+    Ok((id, Record::from_indexmap(out)))
 }
 
 fn value_to_string(v: &Value) -> String {
@@ -224,9 +280,10 @@ impl TableSource for GraphqlApi {
                 field = root.to_string()
             )
         })?;
+        let rows = descend(rows, table.data_source().response_path());
 
         let arr = match rows {
-            Value::Array(a) => a.clone(),
+            Value::Array(a) => a,
             Value::Null => Vec::new(),
             other => {
                 return Err(error!(
@@ -240,7 +297,7 @@ impl TableSource for GraphqlApi {
         let id_name = table.id_field().map(|c| c.name().to_string());
         let mut out = IndexMap::with_capacity(arr.len());
         for (idx, row) in arr.iter().enumerate() {
-            let (mut id, rec) = row_to_record(row, id_name.as_deref())?;
+            let (mut id, rec) = row_to_record(row, &select.fields, id_name.as_deref())?;
             if id.is_empty() {
                 id = idx.to_string();
             }
@@ -281,12 +338,13 @@ impl TableSource for GraphqlApi {
                 field = root.to_string()
             )
         })?;
+        let rows = descend(rows, table.data_source().response_path());
 
         let arr = match rows {
-            Value::Array(a) => a.clone(),
+            Value::Array(a) => a,
             Value::Null => return Ok(None),
             // Some `byId`-style root fields return a single object instead of an array.
-            Value::Object(_) => vec![rows.clone()],
+            obj @ Value::Object(_) => vec![obj],
             other => {
                 return Err(error!(
                     "Unexpected response shape for get",
@@ -296,7 +354,7 @@ impl TableSource for GraphqlApi {
         };
         match arr.into_iter().next() {
             Some(row) => {
-                let (_id, rec) = row_to_record(&row, Some(&id_name))?;
+                let (_id, rec) = row_to_record(&row, &select.fields, Some(&id_name))?;
                 Ok(Some(rec))
             }
             None => Ok(None),
@@ -654,7 +712,7 @@ mod tests {
     #[test]
     fn row_to_record_extracts_id_and_fields() {
         let row = json!({ "id": "5", "mission_name": "FalconSat", "launch_year": 2006 });
-        let (id, rec) = row_to_record(&row, Some("id")).unwrap();
+        let (id, rec) = row_to_record(&row, &[], Some("id")).unwrap();
         assert_eq!(id, "5");
         assert_eq!(rec.iter().count(), 3);
     }
@@ -662,7 +720,7 @@ mod tests {
     #[test]
     fn row_to_record_stringifies_numeric_id() {
         let row = json!({ "id": 42, "name": "x" });
-        let (id, _rec) = row_to_record(&row, Some("id")).unwrap();
+        let (id, _rec) = row_to_record(&row, &[], Some("id")).unwrap();
         assert_eq!(id, "42");
     }
 
@@ -734,5 +792,79 @@ mod tests {
         };
         let r = cond.render(FilterDialect::Generic).await.unwrap();
         assert_eq!(r, json!({ "launch_id": 7 }));
+    }
+}
+
+#[cfg(test)]
+mod shape_tests {
+    use super::*;
+    use serde_json::json;
+    use vantage_types::EmptyEntity;
+
+    use crate::graphql::types::GraphqlType as _;
+
+    fn paths(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn descend_unwraps_a_relay_connection() {
+        let payload = json!({
+            "total": 2,
+            "edges": [{ "node": { "run": { "id": "a" } } }, { "node": { "run": { "id": "b" } } }]
+        });
+        let rows = descend(&payload, &paths(&["edges", "node"]));
+        assert_eq!(
+            rows,
+            json!([{ "run": { "id": "a" } }, { "run": { "id": "b" } }])
+        );
+    }
+
+    #[test]
+    fn descend_with_an_empty_path_is_the_identity() {
+        let payload = json!([{ "id": "a" }]);
+        assert_eq!(descend(&payload, &[]), payload);
+    }
+
+    #[test]
+    fn declared_paths_become_dotted_columns() {
+        let row = json!({ "run": { "id": "a", "commit": { "hash": "deadbeef" } }, "stack": { "id": "api-uat" } });
+        let fields = paths(&["run.id", "run.commit.hash", "stack.id"]);
+        let (id, rec) = row_to_record(&row, &fields, Some("run.id")).unwrap();
+        assert_eq!(id, "a");
+        assert_eq!(
+            rec.get("run.commit.hash").map(|v| v.to_json()),
+            Some(json!("deadbeef"))
+        );
+        assert_eq!(
+            rec.get("stack.id").map(|v| v.to_json()),
+            Some(json!("api-uat"))
+        );
+    }
+
+    #[test]
+    fn a_null_parent_leaves_the_column_present_and_null() {
+        let row = json!({ "run": { "id": "a", "commit": null } });
+        let fields = paths(&["run.id", "run.commit.hash"]);
+        let (_id, rec) = row_to_record(&row, &fields, Some("run.id")).unwrap();
+        assert_eq!(
+            rec.get("run.commit.hash").map(|v| v.to_json()),
+            Some(json!(null))
+        );
+    }
+
+    #[test]
+    fn conditions_stay_local_when_the_root_field_takes_no_filter() {
+        let api = GraphqlApi::builder("https://api.test/graphql")
+            .supports(crate::graphql::api::Supports {
+                filter: Some(false),
+                ..Default::default()
+            })
+            .build();
+        let mut table = Table::<GraphqlApi, EmptyEntity>::new("stacks", api).with_id_column("id");
+        table.add_condition(GraphqlCondition::Field(
+            crate::graphql::condition::FieldCondition::new("space", GraphqlOp::Eq, json!("root")),
+        ));
+        assert!(select_from_table(&table).conditions.is_empty());
     }
 }

--- a/vantage-api-client/src/graphql/select/builder.rs
+++ b/vantage-api-client/src/graphql/select/builder.rs
@@ -42,6 +42,13 @@ impl GraphqlSelect {
         self
     }
 
+    /// Envelope the rows sit inside — `["edges", "node"]` wraps the
+    /// selection set in `edges { node { … } }`.
+    pub fn with_response_path(mut self, path: Vec<String>) -> Self {
+        self.response_path = path;
+        self
+    }
+
     /// Add a sub-selection — used for nested relationships in Phase 6.
     pub fn with_sub_selection(mut self, name: impl Into<String>, child: GraphqlSelect) -> Self {
         self.sub_selections.push((name.into(), child));

--- a/vantage-api-client/src/graphql/select/builder.rs
+++ b/vantage-api-client/src/graphql/select/builder.rs
@@ -35,6 +35,13 @@ impl GraphqlSelect {
         self
     }
 
+    /// Literal arguments always passed to the root field. Expects a JSON
+    /// object; anything else is ignored at render time.
+    pub fn with_root_args(mut self, args: serde_json::Value) -> Self {
+        self.root_args = Some(args);
+        self
+    }
+
     /// Add a sub-selection — used for nested relationships in Phase 6.
     pub fn with_sub_selection(mut self, name: impl Into<String>, child: GraphqlSelect) -> Self {
         self.sub_selections.push((name.into(), child));

--- a/vantage-api-client/src/graphql/select/mod.rs
+++ b/vantage-api-client/src/graphql/select/mod.rs
@@ -39,6 +39,11 @@ pub struct GraphqlSelect {
     /// `input: {}` on Spacelift's `searchRuns(input: SearchInput!)`, say.
     /// Rendered inline alongside any filter/pagination arguments.
     pub root_args: Option<serde_json::Value>,
+    /// Envelope the rows sit inside, e.g. `["edges", "node"]` for a Relay
+    /// connection. The selection set is wrapped in these on the way out
+    /// and the response is unwrapped through them on the way back, so the
+    /// two can never drift apart.
+    pub response_path: Vec<String>,
     /// Nested selection sets for relationship traversal. Built up by
     /// the Phase 6 `with_many`/`with_one` paths.
     pub sub_selections: Vec<(String, GraphqlSelect)>,
@@ -82,6 +87,7 @@ impl Default for GraphqlSelect {
             operation_name: None,
             fields: Vec::new(),
             root_args: None,
+            response_path: Vec::new(),
             sub_selections: Vec::new(),
             conditions: Vec::new(),
             sort: Vec::new(),

--- a/vantage-api-client/src/graphql/select/mod.rs
+++ b/vantage-api-client/src/graphql/select/mod.rs
@@ -31,9 +31,14 @@ pub struct GraphqlSelect {
     pub root_field: Option<String>,
     /// Optional operation name (e.g. `query GetLaunches { … }`).
     pub operation_name: Option<String>,
-    /// Selected scalar fields. Empty = use the schema's id field as a
-    /// fallback so we at least get *something* back.
+    /// Selected fields. A dotted path (`run.commit.hash`) groups into a
+    /// nested selection set at render time, so a schema that nests its
+    /// scalars needs no relation machinery to read them.
     pub fields: Vec<String>,
+    /// Literal arguments always passed to the root field — the mandatory
+    /// `input: {}` on Spacelift's `searchRuns(input: SearchInput!)`, say.
+    /// Rendered inline alongside any filter/pagination arguments.
+    pub root_args: Option<serde_json::Value>,
     /// Nested selection sets for relationship traversal. Built up by
     /// the Phase 6 `with_many`/`with_one` paths.
     pub sub_selections: Vec<(String, GraphqlSelect)>,
@@ -76,6 +81,7 @@ impl Default for GraphqlSelect {
             root_field: None,
             operation_name: None,
             fields: Vec::new(),
+            root_args: None,
             sub_selections: Vec::new(),
             conditions: Vec::new(),
             sort: Vec::new(),

--- a/vantage-api-client/src/graphql/select/render.rs
+++ b/vantage-api-client/src/graphql/select/render.rs
@@ -37,6 +37,15 @@ impl GraphqlSelect {
         let mut var_decls: Vec<String> = Vec::new();
         let mut args: Vec<String> = Vec::new();
 
+        // ── Literal root arguments ───────────────────────────────
+        // First, so a mandatory `input:` reads before the filter it
+        // often has nothing to do with.
+        if let Some(Value::Object(map)) = &self.root_args {
+            for (name, value) in map {
+                args.push(format!("{}: {}", name, json_to_graphql_value(value)));
+            }
+        }
+
         // ── Filter (inline) ──────────────────────────────────────
         if !self.conditions.is_empty() {
             let combined = if self.conditions.len() == 1 {
@@ -155,13 +164,65 @@ fn render_selection_set<'a>(
                 root = select.root_field.clone().unwrap_or_default()
             ));
         }
-        let mut parts: Vec<String> = select.fields.clone();
+        let mut parts = FieldTree::from_paths(&select.fields).into_parts();
         for (field, child) in &select.sub_selections {
             let inner = render_inline_subselection(child).await?;
             parts.push(format!("{}{}", field, inner));
         }
         Ok(format!("{{ {} }}", parts.join(" ")))
     })
+}
+
+/// Dotted field paths grouped back into the tree GraphQL wants:
+/// `["run.id", "run.state", "isModule"]` → `run { id state } isModule`.
+///
+/// Insertion order is preserved at every level, so the rendered query
+/// reads in the order the columns were declared. A path that is both a
+/// leaf and a parent (`run` alongside `run.id`) renders as the parent —
+/// selecting an object without a sub-selection is invalid GraphQL anyway.
+#[derive(Default)]
+struct FieldTree {
+    children: Vec<(String, FieldTree)>,
+}
+
+impl FieldTree {
+    fn from_paths<S: AsRef<str>>(paths: &[S]) -> Self {
+        let mut root = FieldTree::default();
+        for path in paths {
+            root.insert(path.as_ref());
+        }
+        root
+    }
+
+    fn insert(&mut self, path: &str) {
+        let (head, rest) = match path.split_once('.') {
+            Some((head, rest)) => (head, Some(rest)),
+            None => (path, None),
+        };
+        let at = match self.children.iter().position(|(name, _)| name == head) {
+            Some(at) => at,
+            None => {
+                self.children.push((head.to_string(), FieldTree::default()));
+                self.children.len() - 1
+            }
+        };
+        if let Some(rest) = rest {
+            self.children[at].1.insert(rest);
+        }
+    }
+
+    fn into_parts(self) -> Vec<String> {
+        self.children
+            .into_iter()
+            .map(|(name, child)| {
+                if child.children.is_empty() {
+                    name
+                } else {
+                    format!("{} {{ {} }}", name, child.into_parts().join(" "))
+                }
+            })
+            .collect()
+    }
 }
 
 /// Render a sub-selection (a child of a parent's selection set). Args
@@ -398,5 +459,41 @@ mod tests {
         let v = json!({ "mission_name": "FalconSat", "year": 2006 });
         let rendered = json_to_graphql_value(&v);
         assert_eq!(rendered, "{mission_name: \"FalconSat\", year: 2006}");
+    }
+}
+
+#[cfg(test)]
+mod nesting_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn dotted_fields_group_into_nested_selections() {
+        let q = GraphqlSelect::new()
+            .with_root_field("searchRuns")
+            .with_field("run.id")
+            .with_field("run.state")
+            .with_field("run.commit.hash")
+            .with_field("stack.id")
+            .with_field("isModule")
+            .render()
+            .await
+            .unwrap();
+        assert_eq!(
+            q.query,
+            "query { searchRuns { run { id state commit { hash } } stack { id } isModule } }"
+        );
+    }
+
+    #[tokio::test]
+    async fn root_args_render_before_the_filter() {
+        let q = GraphqlSelect::new()
+            .with_root_field("searchRuns")
+            .with_root_args(json!({ "input": {} }))
+            .with_field("run.id")
+            .render()
+            .await
+            .unwrap();
+        assert_eq!(q.query, "query { searchRuns(input: {}) { run { id } } }");
     }
 }

--- a/vantage-api-client/src/graphql/select/render.rs
+++ b/vantage-api-client/src/graphql/select/render.rs
@@ -92,7 +92,12 @@ impl GraphqlSelect {
         }
 
         // ── Selection set ────────────────────────────────────────
-        let selection_set = render_selection_set(self).await?;
+        // Wrapped in the response envelope, so the query asks for rows
+        // exactly where the decoder will look for them.
+        let mut selection_set = render_selection_set(self).await?;
+        for segment in self.response_path.iter().rev() {
+            selection_set = format!("{{ {} {} }}", segment, selection_set);
+        }
 
         // ── Assemble document ────────────────────────────────────
         let op_name = self.operation_name.as_deref().unwrap_or("");
@@ -495,5 +500,31 @@ mod nesting_tests {
             .await
             .unwrap();
         assert_eq!(q.query, "query { searchRuns(input: {}) { run { id } } }");
+    }
+}
+
+#[cfg(test)]
+mod envelope_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The envelope has to shape the query too — asking for `run` at the
+    /// root of a connection field is a server-side error, and the decoder
+    /// would then be reading a path the query never selected.
+    #[tokio::test]
+    async fn response_path_wraps_the_selection_set() {
+        let q = GraphqlSelect::new()
+            .with_root_field("searchRuns")
+            .with_root_args(json!({ "input": {} }))
+            .with_response_path(vec!["edges".into(), "node".into()])
+            .with_field("run.id")
+            .with_field("stack.id")
+            .render()
+            .await
+            .unwrap();
+        assert_eq!(
+            q.query,
+            "query { searchRuns(input: {}) { edges { node { run { id } stack { id } } } } }"
+        );
     }
 }

--- a/vantage-api-client/src/graphql/vista/factory.rs
+++ b/vantage-api-client/src/graphql/vista/factory.rs
@@ -47,6 +47,11 @@ impl GraphqlApiVistaFactory {
     {
         let name = table.table_name().to_string();
         let metadata = metadata_from_table(&table);
+        // Advertise what this table's root field will actually accept, so a
+        // consumer either pushes the work to the server or does it locally —
+        // rather than the old blanket "nothing is supported", which had every
+        // grid sorting in memory even against a Hasura schema that could.
+        let api = table.data_source().clone();
         let any_table = table.into_entity::<EmptyEntity>();
 
         let source = GraphqlApiTableShell::new(
@@ -54,6 +59,10 @@ impl GraphqlApiVistaFactory {
             VistaCapabilities {
                 can_count: true,
                 can_traverse_to_record: true,
+                can_order: api.can_order(),
+                can_search: api.can_search(),
+                can_filter_operators: api.can_filter_operators(),
+                can_set_page_size: api.can_paginate(),
                 ..VistaCapabilities::default()
             },
             metadata,
@@ -86,6 +95,18 @@ impl GraphqlApiVistaFactory {
             if let Some(arg) = block.filter_arg.clone() {
                 api.filter_arg_name = Some(arg);
             }
+            if let Some(args) = block.args.clone() {
+                api.root_args = Some(args);
+            }
+            if let Some(path) = block.response_path.as_deref() {
+                api.response_path = crate::graphql::api::split_response_path(path);
+            }
+            api.supports = crate::graphql::api::Supports {
+                filter: block.filter,
+                order: block.order,
+                search: block.search,
+                paginate: block.paginate,
+            };
         }
 
         let root_field = spec
@@ -401,5 +422,56 @@ graphql:
             api.vista_factory().build_from_spec(spec),
             "Unknown filter dialect",
         );
+    }
+}
+
+#[cfg(test)]
+mod capability_tests {
+    use super::*;
+    use crate::graphql::api::GraphqlApi;
+
+    fn vista_from(yaml: &str) -> vantage_vista::Vista {
+        let spec: GraphqlApiVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
+        GraphqlApi::new("https://api.test/graphql")
+            .vista_factory()
+            .build_from_spec(spec)
+            .unwrap()
+    }
+
+    /// A generic-dialect table can't spell `order_by` or `_ilike`, so it
+    /// must say so and let the consumer sort and search locally.
+    #[test]
+    fn generic_dialect_advertises_client_side_sort_and_search() {
+        let vista = vista_from(
+            "name: launches\ncolumns:\n  id:\n    type: string\n    flags: [id]\ngraphql:\n  dialect: generic\n",
+        );
+        let caps = vista.capabilities();
+        assert!(!caps.can_order);
+        assert!(!caps.can_search);
+        assert!(!caps.can_filter_operators);
+    }
+
+    /// Hasura can, so the same table on that dialect pushes the work down.
+    #[test]
+    fn hasura_dialect_advertises_server_side_sort_and_search() {
+        let vista = vista_from(
+            "name: launches\ncolumns:\n  id:\n    type: string\n    flags: [id]\ngraphql:\n  dialect: hasura\n",
+        );
+        let caps = vista.capabilities();
+        assert!(caps.can_order);
+        assert!(caps.can_search);
+        assert!(caps.can_filter_operators);
+    }
+
+    /// `filter: false` is for a root field that takes no arguments at all;
+    /// nothing derived from a condition may be advertised.
+    #[test]
+    fn filter_false_disables_everything_condition_shaped() {
+        let vista = vista_from(
+            "name: stacks\ncolumns:\n  id:\n    type: string\n    flags: [id]\ngraphql:\n  dialect: hasura\n  filter: false\n",
+        );
+        let caps = vista.capabilities();
+        assert!(!caps.can_search);
+        assert!(!caps.can_filter_operators);
     }
 }

--- a/vantage-api-client/src/graphql/vista/source.rs
+++ b/vantage-api-client/src/graphql/vista/source.rs
@@ -10,9 +10,10 @@
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
-use vantage_core::Result;
+use vantage_core::{Result, error};
 use vantage_dataset::traits::ReadableValueSet;
 use vantage_table::column::core::Column;
+use vantage_table::sorting::{OrderBy, SortDirection};
 use vantage_table::table::Table;
 use vantage_types::{EmptyEntity, Record};
 use vantage_vista::{
@@ -24,11 +25,15 @@ use crate::graphql::api::GraphqlApi;
 use crate::graphql::operation::GraphqlOperation;
 use crate::graphql::types::AnyGraphqlType;
 use crate::graphql::vista::factory::GraphqlApiVistaFactory;
+use vantage_table::traits::table_source::TableSource as _;
 
 pub struct GraphqlApiTableShell {
     pub(crate) table: Table<GraphqlApi, EmptyEntity>,
     pub(crate) capabilities: VistaCapabilities,
     pub(crate) metadata: VistaMetadata,
+    /// Handle for the quicksearch condition, so the next `add_search`
+    /// replaces it rather than stacking another OR-of-ilikes on top.
+    search_handle: Option<vantage_table::conditions::ConditionHandle>,
 }
 
 impl GraphqlApiTableShell {
@@ -41,6 +46,7 @@ impl GraphqlApiTableShell {
             table,
             capabilities,
             metadata,
+            search_handle: None,
         }
     }
 
@@ -112,6 +118,91 @@ impl TableShell for GraphqlApiTableShell {
         let native = AnyGraphqlType::from(value.clone());
         let condition = Column::<AnyGraphqlType>::new(field).eq(native);
         self.table.add_condition(condition);
+        Ok(())
+    }
+
+    fn add_op_condition(
+        &mut self,
+        field: &str,
+        op: vantage_vista::FilterOp,
+        value: &CborValue,
+    ) -> Result<()> {
+        use vantage_vista::FilterOp;
+        let column = Column::<AnyGraphqlType>::new(field);
+        // Whether a given operator has a spelling is the dialect's call,
+        // made at render time — Generic rejects everything but equality.
+        let condition = match op {
+            FilterOp::InSet | FilterOp::NotInSet => {
+                let items: Vec<AnyGraphqlType> = match value {
+                    CborValue::Array(items) => {
+                        items.iter().cloned().map(AnyGraphqlType::from).collect()
+                    }
+                    single => vec![AnyGraphqlType::from(single.clone())],
+                };
+                if matches!(op, FilterOp::InSet) {
+                    column.in_(items)
+                } else {
+                    column.not_in(items)
+                }
+            }
+            scalar_op => {
+                let native = AnyGraphqlType::from(value.clone());
+                match scalar_op {
+                    FilterOp::Eq => column.eq(native),
+                    FilterOp::Ne => column.ne(native),
+                    FilterOp::Gt => column.gt(native),
+                    FilterOp::Gte => column.gte(native),
+                    FilterOp::Lt => column.lt(native),
+                    FilterOp::Lte => column.lte(native),
+                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                }
+            }
+        };
+        self.table.add_condition(condition);
+        Ok(())
+    }
+
+    fn add_order(&mut self, field: &str, dir: vantage_vista::SortDirection) -> Result<()> {
+        if !self.table.columns().contains_key(field) {
+            return Err(error!("Unknown column for add_order", field = field));
+        }
+        // Vista's add_order is replace-semantics.
+        self.table.clear_orders();
+        // The table's order list is typed as conditions, and the renderer
+        // reads the column name back out of the `Field` variant — so an
+        // eq-condition on the column is how an order carries its field.
+        // The value is never rendered.
+        let expression = Column::<AnyGraphqlType>::new(field).eq(field);
+        let direction = match dir {
+            vantage_vista::SortDirection::Ascending => SortDirection::Ascending,
+            vantage_vista::SortDirection::Descending => SortDirection::Descending,
+        };
+        self.table.add_order(OrderBy {
+            expression,
+            direction,
+        });
+        Ok(())
+    }
+
+    fn clear_orders(&mut self) -> Result<()> {
+        self.table.clear_orders();
+        Ok(())
+    }
+
+    fn add_search(&mut self, text: &str) -> Result<()> {
+        if let Some(handle) = self.search_handle.take() {
+            let _ = self.table.temp_remove_condition(handle);
+        }
+        let api = self.table.data_source().clone();
+        let condition = api.search_table_condition(&self.table, text);
+        self.search_handle = Some(self.table.temp_add_condition(condition));
+        Ok(())
+    }
+
+    fn clear_search(&mut self) -> Result<()> {
+        if let Some(handle) = self.search_handle.take() {
+            let _ = self.table.temp_remove_condition(handle);
+        }
         Ok(())
     }
 

--- a/vantage-api-client/src/graphql/vista/spec.rs
+++ b/vantage-api-client/src/graphql/vista/spec.rs
@@ -51,6 +51,31 @@ pub struct GraphqlBlock {
     /// Falls back to the dialect default if absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub filter_arg: Option<String>,
+
+    /// Literal arguments always passed to the root field, e.g.
+    /// `args: { input: {} }` for Spacelift's `searchRuns(input:
+    /// SearchInput!)` — a non-null argument the query is invalid without.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<serde_json::Value>,
+
+    /// Dotted path walked into the root field's value to reach the rows.
+    /// `edges.node` unwraps a Relay-style connection; omit it when the
+    /// root field returns the array directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_path: Option<String>,
+
+    /// What this root field will actually accept. Each is `None` by
+    /// default, meaning "whatever the dialect implies" — set one only to
+    /// contradict that. A field taking no arguments at all needs
+    /// `filter: false`, or every narrowing renders a rejected query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filter: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub search: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paginate: Option<bool>,
 }
 
 /// Per-column block — flattens into `ColumnSpec`. Optional today;


### PR DESCRIPTION
The GraphQL driver could only read a flat selection set off a root field that happened to take its own filter/order/limit arguments. Real schemas aren't that uniform. Spacelift nests its scalars under `run`/`commit`/`delta`, returns rows inside a Relay connection, requires a non-null `input` argument, and exposes a `stacks` field that takes no arguments at all — none of which was reachable.

### Nested column paths

Dotted column names group into a nested selection set at render time and flatten back to dotted keys on decode, so `run.commit.hash` is an ordinary column:

```yaml
columns:
  - { name: run.id, type: string, flags: [id] }
  - { name: run.commit.hash, type: string }
  - { name: stack.id, type: string }
```

A null parent leaves the column present and null rather than missing, so a run with no commit doesn't lose the column.

### Root arguments and the response envelope

`args:` renders literal root-field arguments; `response_path:` locates the rows. The path shapes **both** directions — the selection set is wrapped in it on the way out and the response unwrapped through it on the way back, so the query can't ask for rows somewhere the decoder won't look:

```yaml
graphql:
  root_field: searchRuns
  args: { input: {} }
  response_path: edges.node
```

renders `searchRuns(input: {}) { edges { node { run { id } stack { id } } } }`.

### Capabilities that match reality

Per-table `filter`/`order`/`search`/`paginate`, defaulting to what the dialect implies. Hasura advertises `can_order`/`can_search`/`can_filter_operators`; Generic doesn't, because it can't spell `order_by` or `_ilike`. The shell gained real `add_op_condition`/`add_order`/`add_search`/`clear_*` implementations following the SurrealDB shell — previously every capability was left `false`, so consumers sorted and searched in memory even against a schema that could have done it server-side.

One case needed care. Vista treats equality push-down as universal, so a consumer narrowing a table never learns the server can't do it. Against an argument-less root field that rendered a query the server rejects outright — and simply dropping the condition would have silently *widened* the result set, which is worse. With `filter: false` the driver now applies conditions client-side over the decoded rows (dotted paths, ordering comparisons, in/not-in), and refuses loudly for a filter shape that can't be evaluated row-wise rather than quietly keeping everything.

Also restored the datasource-level `dialect:`/`filter_arg:`, which `vantage-ui` parsed and then dropped on the floor behind a TODO.

### Tests

100 passing. New coverage: dotted-path grouping, root-arg rendering, envelope wrapping in the query, connection unwrapping in the response, null-parent columns, client-side narrowing on a dotted path, ordering comparisons, refusal of an opaque deferred filter, and capability advertisement per dialect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for GraphQL root-field arguments and nested response paths.
  - Added rendering for nested field selections and dotted field names.
  - Added configurable support for filtering, ordering, searching, and pagination.
  - Added GraphQL filtering operators, sorting, and replaceable search conditions.
  - Added support for Relay-style and nested response formats.

- **Bug Fixes**
  - Improved handling of unsupported server-side operations through local filtering.
  - Improved mapping of nested fields, null parents, and selected field paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->