### PR TITLE
vista: render the query a driver would send, without sending it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-csv"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5755,6 +5755,7 @@ dependencies = [
  "redb",
  "rstest",
  "serde",
+ "serde_json",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -5775,11 +5776,12 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama-aggregate"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "ciborium",
  "indexmap 2.14.0",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5824,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-log-writer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5847,7 +5849,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-mongodb"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "async-trait",
  "bson",
@@ -5893,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5921,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6007,7 +6009,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-adapters"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-adapters/CHANGELOG.md
+++ b/vantage-api-adapters/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 — 2026-08-16
+
+- Its `TableShell` test fixture implements the new required
+  `preview_query`. No change to the crate's own surface.
+
 ## 0.6.0 — 2026-08-10
 
 First published release. The crate existed and was used, but carried

--- a/vantage-api-adapters/Cargo.toml
+++ b/vantage-api-adapters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-api-adapters"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Web-framework adapters that expose Vantage Dio/Scenery over HTTP"

--- a/vantage-api-adapters/tests/axum_dio.rs
+++ b/vantage-api-adapters/tests/axum_dio.rs
@@ -141,6 +141,9 @@ mod gated {
         fn driver_name(&self) -> &'static str {
             "gated-detail"
         }
+        fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+            serde_json::json!({ "driver": "gated-detail" })
+        }
     }
 }
 

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -10,6 +10,10 @@
   server under `FilterStrategy::Client` are reported separately as
   `client_side_filters` — the difference between a filter you configured and a
   filter the API applies.
+- `RestApiTableShell::preview_query` no longer collapses to an error when a URI
+  template placeholder is filled by a condition that resolves at fetch time. The
+  real fetch awaits those before building the path; the preview cannot, so it
+  shows the unfilled template and counts them under `unresolved_conditions`.
 
 ## 0.6.11 — 2026-08-16
 

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.12 — 2026-08-16
+
+- `GraphqlApiTableShell` implements `preview_query`, returning the endpoint and
+  the query document.
+- `RestApiTableShell` implements `preview_query`, returning the `GET` a read
+  would issue. It shares the URL builder with the real fetch path, so a previewed
+  URL cannot drift from the one that gets sent. Conditions that never reach the
+  server under `FilterStrategy::Client` are reported separately as
+  `client_side_filters` — the difference between a filter you configured and a
+  filter the API applies.
+
 ## 0.6.11 — 2026-08-16
 
 - GraphQL columns may be dotted paths. `run.commit.hash` groups into a nested

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.11"
+version = "0.6.12"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
@@ -29,7 +29,7 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/src/graphql/condition.rs
+++ b/vantage-api-client/src/graphql/condition.rs
@@ -226,6 +226,63 @@ impl GraphqlCondition {
             }
         })
     }
+
+    /// Synchronous counterpart to [`render`](Self::render), for previewing a
+    /// query without sending it.
+    ///
+    /// Every arm matches `render` but one: a deferred value does not exist yet
+    /// — it is produced by calling back to the caller at fetch time — so
+    /// rendering it here would mean doing the very work a preview exists to
+    /// avoid. Those become a `**deferred(...)` marker, which is not valid
+    /// GraphQL and is not meant to be: it marks the one place the previewed
+    /// document and the sent one differ.
+    ///
+    /// Literal conditions — most of them, and all the ones written by hand in
+    /// YAML — render identically to what gets sent.
+    pub fn render_preview(&self, dialect: FilterDialect) -> Result<Value> {
+        match self {
+            Self::Field(fc) => render_field(fc, dialect),
+            Self::DeferredField { field, op, .. } => {
+                Ok(Value::String(format!("**deferred({} {:?})", field, op)))
+            }
+            Self::And(parts) => {
+                let rendered = parts
+                    .iter()
+                    .map(|p| p.render_preview(dialect))
+                    .collect::<Result<Vec<Value>>>()?;
+                combine_and(rendered, dialect)
+            }
+            Self::Or(parts) => {
+                if matches!(dialect, FilterDialect::Generic) {
+                    return Err(error!(
+                        "Generic dialect does not support OR; switch to Hasura"
+                    ));
+                }
+                let rendered = parts
+                    .iter()
+                    .map(|p| p.render_preview(dialect))
+                    .collect::<Result<Vec<Value>>>()?;
+                Ok(Value::Object({
+                    let mut m = Map::new();
+                    m.insert("_or".into(), Value::Array(rendered));
+                    m
+                }))
+            }
+            Self::Not(inner) => {
+                if matches!(dialect, FilterDialect::Generic) {
+                    return Err(error!(
+                        "Generic dialect does not support NOT; switch to Hasura"
+                    ));
+                }
+                Ok(Value::Object({
+                    let mut m = Map::new();
+                    m.insert("_not".into(), inner.render_preview(dialect)?);
+                    m
+                }))
+            }
+            Self::Deferred(_) => Ok(Value::String("**deferred()".into())),
+        }
+    }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/vantage-api-client/src/graphql/select/render.rs
+++ b/vantage-api-client/src/graphql/select/render.rs
@@ -124,35 +124,88 @@ impl GraphqlSelect {
         Ok(RenderedQuery { query, variables })
     }
 
-    /// Human-readable preview — same shape as `render()` but synchronous
-    /// and lossy (skips Deferred resolution). Useful for logs and tests.
+    /// The document [`render`](Self::render) would produce, built synchronously
+    /// so it can be shown without sending anything.
+    ///
+    /// Mirrors `render` arm for arm — same filter, same order, same selection
+    /// set, same response envelope — and differs in exactly two ways, both
+    /// forced by not being allowed to do any work:
+    ///
+    /// 1. A **deferred** condition renders as a `**deferred(...)` marker rather
+    ///    than being awaited. Resolving one means asking the caller for a value
+    ///    that only exists mid-fetch.
+    /// 2. Pagination is **inlined** (`limit: 5`) instead of going through the
+    ///    `$limit` variable, so the document reads standalone. The server is
+    ///    told the same numbers either way.
+    ///
+    /// Everything else is the query that gets sent, and pastes into a GraphQL
+    /// client as-is.
     pub fn preview(&self) -> String {
-        let root = self.root_field.as_deref().unwrap_or("?");
-        let count = self.conditions.len();
-        let limit = self
-            .limit
-            .map(|l| format!(", limit: {}", l))
-            .unwrap_or_default();
-        let skip = self
-            .skip
-            .map(|s| format!(", offset: {}", s))
-            .unwrap_or_default();
-        let where_part = if count > 0 {
-            format!("(<{} conditions>{}{})", count, limit, skip)
-        } else if !limit.is_empty() || !skip.is_empty() {
-            format!(
-                "({})",
-                format!("{}{}", limit, skip).trim_start_matches(", ")
-            )
-        } else {
+        let root = self.root_field.as_deref().unwrap_or("<no root_field>");
+        let mut args: Vec<String> = Vec::new();
+
+        if let Some(Value::Object(map)) = &self.root_args {
+            for (name, value) in map {
+                args.push(format!("{}: {}", name, json_to_graphql_value(value)));
+            }
+        }
+
+        if !self.conditions.is_empty() {
+            let combined = if self.conditions.len() == 1 {
+                self.conditions[0].render_preview(self.dialect)
+            } else {
+                GraphqlCondition::And(self.conditions.clone()).render_preview(self.dialect)
+            };
+            let arg_name = self
+                .filter_arg_name
+                .as_deref()
+                .unwrap_or(match self.dialect {
+                    FilterDialect::Hasura => "where",
+                    FilterDialect::Generic => "find",
+                });
+            match combined {
+                Ok(value) => args.push(format!("{}: {}", arg_name, json_to_graphql_value(&value))),
+                // A dialect that cannot spell this filter fails at send time
+                // too. Surfacing that here is the point of previewing.
+                Err(e) => args.push(format!("{}: <unrenderable: {}>", arg_name, e)),
+            }
+        }
+
+        if !self.sort.is_empty() && matches!(self.dialect, FilterDialect::Hasura) {
+            let entries: Vec<String> = self
+                .sort
+                .iter()
+                .map(|(field, order)| format!("{}: {}", field, render_order(*order)))
+                .collect();
+            args.push(format!("order_by: [{{{}}}]", entries.join(", ")));
+        }
+
+        if let Some(limit) = self.limit {
+            args.push(format!("limit: {}", limit));
+        }
+        if let Some(skip) = self.skip {
+            args.push(format!("offset: {}", skip));
+        }
+
+        let mut selection_set = preview_selection_set(self);
+        for segment in self.response_path.iter().rev() {
+            selection_set = format!("{{ {} {} }}", segment, selection_set);
+        }
+
+        let args_str = if args.is_empty() {
             String::new()
-        };
-        let selection = if self.fields.is_empty() {
-            "{ ... }".to_string()
         } else {
-            format!("{{ {} }}", self.fields.join(" "))
+            format!("({})", args.join(", "))
         };
-        format!("{}{} {}", root, where_part, selection)
+        let op_name = self.operation_name.as_deref().unwrap_or("");
+        if op_name.is_empty() {
+            format!("query {{ {}{} {} }}", root, args_str, selection_set)
+        } else {
+            format!(
+                "query {} {{ {}{} {} }}",
+                op_name, root, args_str, selection_set
+            )
+        }
     }
 }
 
@@ -176,6 +229,57 @@ fn render_selection_set<'a>(
         }
         Ok(format!("{{ {} }}", parts.join(" ")))
     })
+}
+
+/// Synchronous [`render_selection_set`], for [`GraphqlSelect::preview`].
+///
+/// Where the async version errors on an empty selection set, this reports it
+/// inline as `{ <empty selection set> }` — a preview's job is to show the query
+/// as it stands, and "you selected no fields" is exactly the fault worth seeing.
+fn preview_selection_set(select: &GraphqlSelect) -> String {
+    if select.fields.is_empty() && select.sub_selections.is_empty() {
+        return "{ <empty selection set> }".to_string();
+    }
+    let mut parts = FieldTree::from_paths(&select.fields).into_parts();
+    for (field, child) in &select.sub_selections {
+        parts.push(format!("{}{}", field, preview_inline_subselection(child)));
+    }
+    format!("{{ {} }}", parts.join(" "))
+}
+
+/// Synchronous [`render_inline_subselection`], for [`GraphqlSelect::preview`].
+fn preview_inline_subselection(child: &GraphqlSelect) -> String {
+    let mut args: Vec<String> = Vec::new();
+    if !child.conditions.is_empty() {
+        let condition = if child.conditions.len() == 1 {
+            child.conditions[0].clone()
+        } else {
+            GraphqlCondition::And(child.conditions.clone())
+        };
+        let arg_name = child
+            .filter_arg_name
+            .as_deref()
+            .unwrap_or(match child.dialect {
+                FilterDialect::Hasura => "where",
+                FilterDialect::Generic => "find",
+            });
+        match condition.render_preview(child.dialect) {
+            Ok(value) => args.push(format!("{}: {}", arg_name, json_to_graphql_value(&value))),
+            Err(e) => args.push(format!("{}: <unrenderable: {}>", arg_name, e)),
+        }
+    }
+    if let Some(limit) = child.limit {
+        args.push(format!("limit: {}", limit));
+    }
+    if let Some(skip) = child.skip {
+        args.push(format!("offset: {}", skip));
+    }
+    let args_str = if args.is_empty() {
+        String::new()
+    } else {
+        format!("({})", args.join(", "))
+    };
+    format!("{} {}", args_str, preview_selection_set(child))
 }
 
 /// Dotted field paths grouped back into the tree GraphQL wants:
@@ -321,6 +425,68 @@ mod tests {
     use serde_json::json;
 
     use crate::graphql::condition::{FieldCondition, FilterDialect, GraphqlOp};
+    use crate::graphql::types::AnyGraphqlType;
+    use vantage_expressions::{DeferredFn, ExpressiveEnum};
+
+    /// The guarantee worth pinning: for a query with no deferred conditions and
+    /// no pagination, previewing and rendering produce the *same document*. If
+    /// these ever diverge, a preview has started lying about what gets sent.
+    #[tokio::test]
+    async fn preview_matches_render_for_a_literal_query() {
+        let select = GraphqlSelect::new()
+            .with_root_field("launches")
+            .with_field("id")
+            .with_field("rocket.name")
+            .with_dialect(FilterDialect::Generic)
+            .with_condition(GraphqlCondition::Field(FieldCondition::new(
+                "mission_name",
+                GraphqlOp::Eq,
+                json!("FalconSat"),
+            )));
+
+        let rendered = select.render().await.unwrap();
+        assert_eq!(select.preview(), rendered.query);
+        // And it is the real thing, not two matching placeholders.
+        assert!(
+            select.preview().contains("\"FalconSat\""),
+            "the condition value is rendered, not summarised: {}",
+            select.preview()
+        );
+    }
+
+    /// Pagination is the one deliberate difference: `render` sends `$limit` as a
+    /// variable, `preview` inlines the number so the document reads standalone.
+    #[test]
+    fn preview_inlines_pagination() {
+        let preview = GraphqlSelect::new()
+            .with_root_field("launches")
+            .with_field("id")
+            .with_limit(Some(5), Some(10))
+            .preview();
+        assert_eq!(preview, "query { launches(limit: 5, offset: 10) { id } }");
+    }
+
+    /// A deferred condition is the other: its value only exists mid-fetch, so
+    /// preview marks it instead of awaiting it.
+    #[test]
+    fn preview_marks_a_deferred_condition_rather_than_resolving_it() {
+        let preview = GraphqlSelect::new()
+            .with_root_field("runs")
+            .with_field("id")
+            .with_dialect(FilterDialect::Generic)
+            .with_condition(GraphqlCondition::DeferredField {
+                field: "stack_id".into(),
+                op: GraphqlOp::Eq,
+                value_fn: DeferredFn::new(|| {
+                    Box::pin(async { Ok(ExpressiveEnum::Scalar(AnyGraphqlType::from(json!("x")))) })
+                }),
+            })
+            .preview();
+        assert!(
+            preview.contains("**deferred(stack_id"),
+            "deferred values are marked, never awaited: {preview}"
+        );
+    }
 
     #[tokio::test]
     async fn renders_minimal_query() {

--- a/vantage-api-client/src/graphql/vista/source.rs
+++ b/vantage-api-client/src/graphql/vista/source.rs
@@ -236,4 +236,16 @@ impl TableShell for GraphqlApiTableShell {
     fn driver_name(&self) -> &'static str {
         "graphql"
     }
+
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        // `GraphqlSelect::preview` is the synchronous renderer: it produces the
+        // real document, and spells out any condition whose value is only known
+        // at fetch time rather than resolving it. See `render()` for the
+        // executed form, which differs only in those deferred branches.
+        serde_json::json!({
+            "driver": "graphql",
+            "endpoint": self.table.data_source().endpoint(),
+            "query": self.table.select().preview(),
+        })
+    }
 }

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -270,6 +270,71 @@ impl RestApi {
         s
     }
 
+    /// Render the request a read would issue, without issuing it.
+    ///
+    /// Shares [`endpoint_url`](Self::endpoint_url) and
+    /// [`build_query_string`](Self::build_query_string) with the real fetch
+    /// path, so a previewed URL cannot drift from the one that gets sent.
+    ///
+    /// One difference is deliberate: `fetch_raw_body` first *awaits* any
+    /// deferred condition (a foreign key whose value arrives with the parent
+    /// row), and awaiting is what a preview must not do. Those are counted
+    /// under `deferred_conditions` and left out of the URL instead.
+    pub(crate) fn preview_request<'a>(
+        &self,
+        table_name: &str,
+        window: Option<(i64, i64)>,
+        conditions: impl IntoIterator<Item = &'a Expression<CborValue>>,
+    ) -> serde_json::Value {
+        let conds: Vec<&Expression<CborValue>> = conditions.into_iter().collect();
+
+        let (endpoint, consumed) = match self.endpoint_url(table_name, &conds) {
+            Ok(pair) => pair,
+            // A URI template with no matching condition fails here exactly as
+            // it would on a real fetch — which makes it the useful answer.
+            Err(e) => {
+                return serde_json::json!({
+                    "driver": "rest-api",
+                    "base_url": self.base_url,
+                    "error": e.to_string(),
+                });
+            }
+        };
+
+        let (query_consumed, client_filters): (Vec<usize>, Vec<(String, String)>) =
+            if self.filter_strategy == FilterStrategy::Client {
+                let filters = conds
+                    .iter()
+                    .enumerate()
+                    .filter(|(i, _)| !consumed.contains(i))
+                    .filter_map(|(_, c)| crate::condition_to_query_param(c))
+                    .collect();
+                ((0..conds.len()).collect(), filters)
+            } else {
+                (consumed, Vec::new())
+            };
+
+        let query = self.build_query_string(window, &conds, &query_consumed);
+        let deferred = conds
+            .iter()
+            .filter(|c| crate::condition_to_query_param(c).is_none())
+            .count();
+
+        serde_json::json!({
+            "driver": "rest-api",
+            "method": "GET",
+            "url": join_query(&endpoint, &query),
+            "auth_header": self.auth_header.as_ref().map(|_| "<set>"),
+            // Under `FilterStrategy::Client` these never reach the server: the
+            // rows come back unfiltered and are narrowed in memory.
+            "client_side_filters": client_filters
+                .into_iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>(),
+            "deferred_conditions": deferred,
+        })
+    }
+
     /// Fetch data from the API endpoint and return parsed records.
     ///
     /// `id_field` selects which JSON field is treated as the record ID;

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -288,10 +288,30 @@ impl RestApi {
     ) -> serde_json::Value {
         let conds: Vec<&Expression<CborValue>> = conditions.into_iter().collect();
 
+        // Conditions the query-param lowering cannot peel into an eq pair —
+        // deferred foreign keys, and anything else not shaped `field = value`.
+        let unresolved = conds
+            .iter()
+            .filter(|c| crate::condition_to_query_param(c).is_none())
+            .count();
+
         let (endpoint, consumed) = match self.endpoint_url(table_name, &conds) {
             Ok(pair) => pair,
-            // A URI template with no matching condition fails here exactly as
-            // it would on a real fetch — which makes it the useful answer.
+            // A URI template placeholder went unfilled. If some condition is
+            // still unresolved, the real fetch would have awaited it *before*
+            // building the path, so this is a preview limitation and the
+            // template is the honest answer. With nothing outstanding, the
+            // fetch would fail here too — report that.
+            Err(_) if unresolved > 0 => {
+                return serde_json::json!({
+                    "driver": "rest-api",
+                    "method": "GET",
+                    "url": format!("{}/{}", self.base_url, table_name),
+                    "unresolved_conditions": unresolved,
+                    "note": "path placeholders are filled from conditions resolved \
+                             at fetch time; the template is shown unfilled",
+                });
+            }
             Err(e) => {
                 return serde_json::json!({
                     "driver": "rest-api",
@@ -315,10 +335,6 @@ impl RestApi {
             };
 
         let query = self.build_query_string(window, &conds, &query_consumed);
-        let deferred = conds
-            .iter()
-            .filter(|c| crate::condition_to_query_param(c).is_none())
-            .count();
 
         serde_json::json!({
             "driver": "rest-api",
@@ -331,7 +347,7 @@ impl RestApi {
                 .into_iter()
                 .map(|(k, v)| format!("{k}={v}"))
                 .collect::<Vec<_>>(),
-            "deferred_conditions": deferred,
+            "unresolved_conditions": unresolved,
         })
     }
 

--- a/vantage-api-client/src/rest/api.rs
+++ b/vantage-api-client/src/rest/api.rs
@@ -205,6 +205,36 @@ impl RestApi {
         Ok((format!("{}/{}", self.base_url, path), consumed))
     }
 
+    /// Decide which conditions go in the query string and which are applied to
+    /// the rows after they arrive.
+    ///
+    /// Under [`FilterStrategy::Client`] non-path eq-conditions are *not* sent —
+    /// the API rejects or ignores unknown params — so they come back as
+    /// client-side filters and every condition is marked consumed to keep it out
+    /// of the URL. Otherwise nothing is filtered locally and only the path
+    /// placeholders are consumed.
+    ///
+    /// Shared by the real fetch and by [`preview_request`](Self::preview_request)
+    /// so a previewed URL cannot claim a filter the fetch would have applied in
+    /// memory, or vice versa.
+    fn split_filters(
+        &self,
+        conds: &[&Expression<CborValue>],
+        consumed: Vec<usize>,
+    ) -> (Vec<usize>, Vec<(String, String)>) {
+        if self.filter_strategy == FilterStrategy::Client {
+            let filters = conds
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| !consumed.contains(i))
+                .filter_map(|(_, c)| crate::condition_to_query_param(c))
+                .collect();
+            ((0..conds.len()).collect(), filters)
+        } else {
+            (consumed, Vec::new())
+        }
+    }
+
     /// Build the combined query-string from pagination + conditions.
     /// `consumed` lists condition indices already baked into the URI
     /// path; those don't appear in the query string. Conditions that
@@ -321,19 +351,7 @@ impl RestApi {
             }
         };
 
-        let (query_consumed, client_filters): (Vec<usize>, Vec<(String, String)>) =
-            if self.filter_strategy == FilterStrategy::Client {
-                let filters = conds
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, _)| !consumed.contains(i))
-                    .filter_map(|(_, c)| crate::condition_to_query_param(c))
-                    .collect();
-                ((0..conds.len()).collect(), filters)
-            } else {
-                (consumed, Vec::new())
-            };
-
+        let (query_consumed, client_filters) = self.split_filters(&conds, consumed);
         let query = self.build_query_string(window, &conds, &query_consumed);
 
         serde_json::json!({
@@ -449,23 +467,7 @@ impl RestApi {
         let conds: Vec<&Expression<CborValue>> = resolved.iter().collect();
         let (endpoint, consumed) = self.endpoint_url(table_name, &conds)?;
 
-        // Under `FilterStrategy::Client`, non-path eq-conditions are applied
-        // to the fetched rows in memory rather than sent as query params (the
-        // API rejects/ignores unknown params). Collect them, and keep them out
-        // of the query string by marking every condition as consumed.
-        let (query_consumed, client_filters): (Vec<usize>, Vec<(String, String)>) =
-            if self.filter_strategy == FilterStrategy::Client {
-                let filters = conds
-                    .iter()
-                    .enumerate()
-                    .filter(|(i, _)| !consumed.contains(i))
-                    .filter_map(|(_, c)| crate::condition_to_query_param(c))
-                    .collect();
-                ((0..conds.len()).collect(), filters)
-            } else {
-                (consumed, Vec::new())
-            };
-
+        let (query_consumed, client_filters) = self.split_filters(&conds, consumed);
         let query = self.build_query_string(window, &conds, &query_consumed);
         let url = join_query(&endpoint, &query);
 

--- a/vantage-api-client/src/rest/vista/source.rs
+++ b/vantage-api-client/src/rest/vista/source.rs
@@ -297,4 +297,15 @@ impl TableShell for RestApiTableShell {
     fn driver_name(&self) -> &'static str {
         "rest-api"
     }
+
+    /// The HTTP GET a read would issue — path template filled in, conditions
+    /// lowered to query params, pagination applied.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        let window = self.table.pagination().map(|p| (p.skip(), p.limit()));
+        self.table.data_source().preview_request(
+            self.table.table_name(),
+            window,
+            self.table.conditions(),
+        )
+    }
 }

--- a/vantage-aws/CHANGELOG.md
+++ b/vantage-aws/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.6 — 2026-08-16
+
+- `AwsTableShell` implements `preview_query`, decoding the table name into its
+  service, target, protocol and array key, and listing the conditions the RPC
+  would carry. A malformed table name reports its error here, before any
+  request.
+
 ## 0.6.5 — 2026-08-12
 
 - **Bug fix:** `AwsTableShell::get_ref_target` resolves relations whose target

--- a/vantage-aws/Cargo.lock
+++ b/vantage-aws/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-aws"
-version = "0.6.4"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atty",
  "indexmap",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2200,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.14"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2224,8 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.3"
+version = "0.6.8"
 dependencies = [
+ "chrono",
  "ciborium",
  "indexmap",
  "paste",
@@ -2246,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.14"
+version = "0.6.22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2254,6 +2255,7 @@ dependencies = [
  "futures-core",
  "indexmap",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "vantage-core",

--- a/vantage-aws/Cargo.toml
+++ b/vantage-aws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-aws"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -16,7 +16,7 @@ vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
@@ -43,7 +43,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 [dev-dependencies]
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-cli-util = { version = "0.6", path = "../vantage-cli-util" }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 anyhow = "1"
 tokio = { version = "1", features = ["full"] }

--- a/vantage-aws/src/vista/source.rs
+++ b/vantage-aws/src/vista/source.rs
@@ -170,6 +170,43 @@ impl TableShell for AwsTableShell {
     fn driver_name(&self) -> &'static str {
         "aws"
     }
+
+    /// The RPC a read would dispatch: the operation decoded out of the table
+    /// name, plus the conditions that become request parameters.
+    ///
+    /// AWS APIs only push down their own request params (`PathPrefix`,
+    /// `logGroupNamePrefix`, …); a condition naming a *record* field is applied
+    /// to the response instead. Which is which isn't known until the rows come
+    /// back, so both are listed together under `conditions` — the split is
+    /// reported honestly in the note rather than guessed at here.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        let table_name = self.table.table_name();
+        let conditions: Vec<String> = self
+            .table
+            .conditions()
+            .map(|c| format!("{} = {:?}", c.field(), c))
+            .collect();
+
+        match crate::dispatch::parse_table_name(table_name) {
+            Ok(op) => serde_json::json!({
+                "driver": "aws",
+                "service": op.service,
+                "target": op.target,
+                "protocol": format!("{:?}", op.protocol),
+                "array_key": op.array_key,
+                "paginated": op.cursor.is_some(),
+                "conditions": conditions,
+                "note": "conditions naming a request parameter are pushed down; \
+                         conditions naming a record field are applied to the \
+                         response after it arrives",
+            }),
+            Err(e) => serde_json::json!({
+                "driver": "aws",
+                "table": table_name,
+                "error": e.to_string(),
+            }),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.4 — 2026-08-16
+
+- `CmdTableShell` implements `preview_query`. A cmd table's argv is assembled
+  inside its Rhai script, by the same call that runs it, so no preview can render
+  the argv without running the command. It reports what decides the argv instead:
+  the locked program, the script, and the scope values it would be evaluated
+  with.
+
 ## 0.6.3 — 2026-08-12
 
 - **Bug fix:** `CmdTableShell::get_ref_target` resolves relations whose target

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.2"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atty",
  "indexmap",
@@ -1480,7 +1480,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.14"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1536,8 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.3"
+version = "0.6.8"
 dependencies = [
+ "chrono",
  "ciborium",
  "indexmap",
  "paste",
@@ -1558,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.14"
+version = "0.6.22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1566,6 +1567,7 @@ dependencies = [
  "futures-core",
  "indexmap",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "vantage-core",

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -21,7 +21,7 @@ vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 # Rhai builds the argv and parses the output. "serde" gives us the
 # serde_json::Value <-> Dynamic bridge used by `parse_json`.

--- a/vantage-cmd/src/vista/source.rs
+++ b/vantage-cmd/src/vista/source.rs
@@ -131,4 +131,48 @@ impl TableShell for CmdTableShell {
     fn driver_name(&self) -> &'static str {
         "cmd"
     }
+
+    /// A cmd table's argv is built *by* its Rhai script, and that script builds
+    /// it by calling `run(...)` — so there is no argv to render without running
+    /// the command. What this reports instead is everything that decides the
+    /// argv: the locked program, the script itself, and the values seeded into
+    /// its scope. Read the script against these and you can see the command it
+    /// will assemble.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        let script_name = self.table.table_name();
+        let source = self.table.data_source();
+        let (limit, offset) = match self.table.pagination() {
+            Some(p) => (Some(p.limit()), Some(p.skip())),
+            None => (None, None),
+        };
+        let conditions: Vec<serde_json::Value> = self
+            .table
+            .conditions()
+            .map(|c| {
+                serde_json::json!({
+                    "field": c.field(),
+                    "op": c.op(),
+                    "value": c.json_value(),
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "driver": "cmd",
+            "command": source.command(),
+            "script_name": script_name,
+            "script": source
+                .spec_for(script_name)
+                .map(|spec| spec.script.to_string())
+                .unwrap_or_else(|e| format!("<no script registered: {e}>")),
+            "scope": {
+                "columns": self.table.columns().keys().collect::<Vec<_>>(),
+                "conditions": conditions,
+                "limit": limit,
+                "offset": offset,
+            },
+            "note": "the script builds its own argv and runs it; these are the \
+                     scope values it would be evaluated with",
+        })
+    }
 }

--- a/vantage-csv/CHANGELOG.md
+++ b/vantage-csv/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.4 — 2026-08-16
+
+- `CsvTableShell` implements `preview_query`, naming the file that gets read and
+  recording that conditions and ordering are applied in memory afterwards — they
+  change nothing about what is read from disk.
+
 ## 0.6.3 — 2026-08-12
 
 - **Bug fix:** `CsvTableShell::get_ref_target` resolves relations whose target

--- a/vantage-csv/Cargo.toml
+++ b/vantage-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-csv"
-version = "0.6.3"
+version = "0.6.4"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for CSV files"
@@ -25,10 +25,10 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }

--- a/vantage-csv/src/vista/source.rs
+++ b/vantage-csv/src/vista/source.rs
@@ -137,4 +137,24 @@ impl TableShell for CsvTableShell {
     fn driver_name(&self) -> &'static str {
         "csv"
     }
+
+    /// A CSV table is one file, read whole. Conditions never reach a server —
+    /// they filter the parsed rows — so the only thing a preview can name is
+    /// which file gets opened, and that filtering happens after it is read.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        let table_name = self.table.table_name();
+        serde_json::json!({
+            "driver": "csv",
+            "file": self
+                .table
+                .data_source()
+                .base_dir()
+                .join(format!("{table_name}.csv"))
+                .display()
+                .to_string(),
+            "note": "the whole file is read; conditions and ordering are applied \
+                     in memory afterwards, so they change nothing about what is \
+                     read from disk",
+        })
+    }
 }

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -5,6 +5,8 @@
 - `AggregateShell` implements `preview_query`, recording that an aggregate is
   derived in memory from its source Dio's cached rows and costs no request of its
   own.
+- `AggregateShell::preview_query` reports the active order alongside its
+  conditions and search.
 
 ## 0.6.6 — 2026-07-30
 

--- a/vantage-diorama-aggregate/CHANGELOG.md
+++ b/vantage-diorama-aggregate/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.7 — 2026-08-16
+
+- `AggregateShell` implements `preview_query`, recording that an aggregate is
+  derived in memory from its source Dio's cached rows and costs no request of its
+  own.
+
 ## 0.6.6 — 2026-07-30
 
 - Recompute lines render in the same shape as the rest of the diorama debug

--- a/vantage-diorama-aggregate/Cargo.toml
+++ b/vantage-diorama-aggregate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama-aggregate"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Reactive client-side aggregation over a Vantage Diorama"
@@ -13,8 +13,10 @@ doctest = false
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 vantage-diorama = { version = "0.12", path = "../vantage-diorama" }
+# `TableShell::preview_query` answers with a driver-shaped JSON value.
+serde_json = "1"
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama-aggregate/src/derived/shell.rs
+++ b/vantage-diorama-aggregate/src/derived/shell.rs
@@ -146,6 +146,13 @@ impl TableShell for AggregateShell {
             .iter()
             .map(|(field, value)| format!("{field} = {value:?}"))
             .collect();
+        let order = self.order.as_ref().map(|(column, dir)| {
+            let dir = match dir {
+                SortDirection::Ascending => "asc",
+                SortDirection::Descending => "desc",
+            };
+            format!("{column} {dir}")
+        });
         serde_json::json!({
             "driver": "aggregate",
             "name": vista.name(),
@@ -153,6 +160,7 @@ impl TableShell for AggregateShell {
                      query, no request. Preview the source table to see what \
                      fetches the rows this reduces.",
             "conditions": conditions,
+            "order": order,
             "search": self.search,
         })
     }

--- a/vantage-diorama-aggregate/src/derived/shell.rs
+++ b/vantage-diorama-aggregate/src/derived/shell.rs
@@ -136,6 +136,27 @@ impl TableShell for AggregateShell {
         "aggregate"
     }
 
+    /// An aggregate is derived in memory from the rows its source Dio already
+    /// holds, so it issues no query and costs no request. The narrowing below
+    /// is applied to the derived rows. To see what feeds it, preview the source
+    /// table.
+    fn preview_query(&self, vista: &Vista) -> serde_json::Value {
+        let conditions: Vec<String> = self
+            .conditions
+            .iter()
+            .map(|(field, value)| format!("{field} = {value:?}"))
+            .collect();
+        serde_json::json!({
+            "driver": "aggregate",
+            "name": vista.name(),
+            "note": "derived in memory from the source Dio's cached rows — no \
+                     query, no request. Preview the source table to see what \
+                     fetches the rows this reduces.",
+            "conditions": conditions,
+            "search": self.search,
+        })
+    }
+
     async fn list_vista_values(
         &self,
         _vista: &Vista,

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## 0.12.3 — 2026-08-16
 
 - `DioShell` implements `preview_query`. A facade read hits the local cache, so
-  the query worth seeing is the master's — reported verbatim — alongside this
-  handle's own narrowing, which is applied to cached rows and sent nowhere. The
-  two are kept separate: merging them would suggest a facade filter reached the
-  server.
+  the query worth seeing is the master's — and specifically the **planned**
+  master, carrying whatever `plan` pushed down. Only the clauses the master
+  refused appear under `facade`, since those are the ones actually answered over
+  cached rows. The split is the point: the same condition is a server-side
+  filter against one driver and an in-memory one against the next, and putting
+  it in the wrong column tells a reader the server never saw it.
 
 ## 0.12.2 — 2026-08-12
 

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.12.3 — 2026-08-16
+
+- `DioShell` implements `preview_query`. A facade read hits the local cache, so
+  the query worth seeing is the master's — reported verbatim — alongside this
+  handle's own narrowing, which is applied to cached rows and sent nowhere. The
+  two are kept separate: merging them would suggest a facade filter reached the
+  server.
+
 ## 0.12.2 — 2026-08-12
 
 - **Bug fix:** a create settles on the id the driver stored it under. The

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -12,10 +12,12 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.6.18", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 vantage-vista-factory = { version = "0.6", path = "../vantage-vista-factory" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
+# `TableShell::preview_query` answers with a driver-shaped JSON value.
+serde_json = "1"
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }

--- a/vantage-diorama/src/dio/impls/table_shell.rs
+++ b/vantage-diorama/src/dio/impls/table_shell.rs
@@ -199,10 +199,10 @@ impl TableShell for DioShell {
     /// seeing is the **master's**, which is what filled that cache in the first
     /// place.
     ///
-    /// Which clauses that master carries is not a given: [`plan`](DioShell::plan)
-    /// offers each one to a private clone and keeps whatever it accepts, so the
-    /// same condition is a server-side filter against one driver and an
-    /// in-memory one against the next. The preview therefore reports the
+    /// Which clauses that master carries is not a given: `plan` offers each one
+    /// to a private clone and keeps whatever it accepts, so the same condition
+    /// is a server-side filter against one driver and an in-memory one against
+    /// the next. The preview therefore reports the
     /// **planned** master, and lists under `facade` only what the master
     /// refused. Reporting the bare master and every clause as local would put
     /// pushed-down filters in the wrong column — lossy is acceptable here,

--- a/vantage-diorama/src/dio/impls/table_shell.rs
+++ b/vantage-diorama/src/dio/impls/table_shell.rs
@@ -194,6 +194,41 @@ impl TableShell for DioShell {
     fn driver_name(&self) -> &'static str {
         "dio"
     }
+
+    /// A facade read hits the local cache, not a backend — so the query worth
+    /// seeing is the **master's**, which is what filled that cache in the first
+    /// place. It is reported verbatim under `master`, alongside this handle's
+    /// own narrowing, which is applied to the cached rows and never sent
+    /// anywhere.
+    ///
+    /// The two are deliberately not merged: a condition on the facade and the
+    /// same condition on the master are different operations with different
+    /// costs, and flattening them would suggest the filter reached the server.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        let master = self.dio.master.read().unwrap();
+        let conditions: Vec<String> = self
+            .query
+            .conditions
+            .iter()
+            .map(|(field, value)| format!("{field} = {value:?}"))
+            .collect();
+        let order = self.query.order.as_ref().map(|(col, dir)| {
+            let dir = match dir {
+                SortDirection::Ascending => "asc",
+                SortDirection::Descending => "desc",
+            };
+            format!("{col} {dir}")
+        });
+
+        serde_json::json!({
+            "driver": "dio",
+            "note": "reads come from the local cache; this issues no query of \
+                     its own. `master` is the query that populates that cache; \
+                     `facade` is applied to the cached rows in memory.",
+            "master": master.preview_query(),
+            "facade": { "conditions": conditions, "order": order },
+        })
+    }
 }
 
 impl DioShell {

--- a/vantage-diorama/src/dio/impls/table_shell.rs
+++ b/vantage-diorama/src/dio/impls/table_shell.rs
@@ -197,22 +197,30 @@ impl TableShell for DioShell {
 
     /// A facade read hits the local cache, not a backend — so the query worth
     /// seeing is the **master's**, which is what filled that cache in the first
-    /// place. It is reported verbatim under `master`, alongside this handle's
-    /// own narrowing, which is applied to the cached rows and never sent
-    /// anywhere.
+    /// place.
     ///
-    /// The two are deliberately not merged: a condition on the facade and the
-    /// same condition on the master are different operations with different
-    /// costs, and flattening them would suggest the filter reached the server.
+    /// Which clauses that master carries is not a given: [`plan`](DioShell::plan)
+    /// offers each one to a private clone and keeps whatever it accepts, so the
+    /// same condition is a server-side filter against one driver and an
+    /// in-memory one against the next. The preview therefore reports the
+    /// **planned** master, and lists under `facade` only what the master
+    /// refused. Reporting the bare master and every clause as local would put
+    /// pushed-down filters in the wrong column — lossy is acceptable here,
+    /// wrong is not.
     fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
-        let master = self.dio.master.read().unwrap();
-        let conditions: Vec<String> = self
-            .query
+        let (planned, local) = self.plan();
+        let master = match &planned {
+            Some(narrowed) => narrowed.preview_query(),
+            // Nothing pushed down: the master runs unnarrowed.
+            None => self.dio.master.read().unwrap().preview_query(),
+        };
+
+        let conditions: Vec<String> = local
             .conditions
             .iter()
             .map(|(field, value)| format!("{field} = {value:?}"))
             .collect();
-        let order = self.query.order.as_ref().map(|(col, dir)| {
+        let order = local.order.as_ref().map(|(col, dir)| {
             let dir = match dir {
                 SortDirection::Ascending => "asc",
                 SortDirection::Descending => "desc",
@@ -223,9 +231,10 @@ impl TableShell for DioShell {
         serde_json::json!({
             "driver": "dio",
             "note": "reads come from the local cache; this issues no query of \
-                     its own. `master` is the query that populates that cache; \
-                     `facade` is applied to the cached rows in memory.",
-            "master": master.preview_query(),
+                     its own. `master` is the query that populates that cache, \
+                     carrying every clause the driver accepted; `facade` is what \
+                     it refused, applied to the cached rows in memory.",
+            "master": master,
             "facade": { "conditions": conditions, "order": order },
         })
     }

--- a/vantage-diorama/tests/augment.rs
+++ b/vantage-diorama/tests/augment.rs
@@ -507,6 +507,9 @@ mod counting {
         fn driver_name(&self) -> &'static str {
             "counting-detail"
         }
+        fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+            serde_json::json!({ "driver": "counting-detail" })
+        }
     }
 }
 

--- a/vantage-diorama/tests/augment_scheduler.rs
+++ b/vantage-diorama/tests/augment_scheduler.rs
@@ -161,6 +161,9 @@ mod gated {
         fn driver_name(&self) -> &'static str {
             "gated-detail"
         }
+        fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+            serde_json::json!({ "driver": "gated-detail" })
+        }
     }
 }
 

--- a/vantage-diorama/tests/facade_query.rs
+++ b/vantage-diorama/tests/facade_query.rs
@@ -326,3 +326,52 @@ async fn an_unnarrowed_facade_reads_the_cache() -> Result<()> {
     );
     Ok(())
 }
+
+// ---- preview: which side of the split a clause landed on -------------------
+
+/// A clause the master accepted belongs in the previewed master query, not in
+/// the facade's local list. Attributing a pushed-down filter to the cache would
+/// tell a reader the server never saw it.
+#[tokio::test]
+async fn preview_reports_a_pushed_down_condition_on_the_master() -> Result<()> {
+    let shell = capable_master();
+    shell.set_record("a", row("gamma", 3));
+    let dio = eager_dio(Vista::new("items", Box::new(shell.clone()))).await?;
+
+    let mut narrowed = dio.vista();
+    narrowed.add_condition_eq("name", CborValue::Text("gamma".into()))?;
+    narrowed.add_order("price", SortDirection::Descending)?;
+
+    let preview = narrowed.preview_query();
+    let master = preview["master"].to_string();
+    assert!(
+        master.contains("gamma"),
+        "the master accepted the filter, so it must appear there: {preview}",
+    );
+    assert_eq!(
+        preview["facade"]["conditions"],
+        serde_json::json!([]),
+        "nothing was refused, so nothing is applied over the cache: {preview}",
+    );
+    assert_eq!(preview["facade"]["order"], serde_json::Value::Null);
+    Ok(())
+}
+
+/// The mirror case. CSV can neither order nor filter here, so every clause is
+/// answered over the cache and the master query stays bare.
+#[tokio::test]
+async fn preview_reports_a_refused_order_on_the_facade() -> Result<()> {
+    let dio = eager_dio(csv_master()?).await?;
+
+    let mut narrowed = dio.vista();
+    narrowed.add_order("name", SortDirection::Ascending)?;
+
+    let preview = narrowed.preview_query();
+    assert_eq!(
+        preview["facade"]["order"],
+        serde_json::json!("name asc"),
+        "CSV refused the order, so it is applied locally: {preview}",
+    );
+    assert_eq!(preview["driver"], serde_json::json!("dio"));
+    Ok(())
+}

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.14 — 2026-08-16
+
+- The shaped and live-folder shells implement `preview_query`. Shaping forwards
+  to the shell it wraps, since latency and injected faults do not change the
+  query; the live-folder shells report the local path they read.
+
 ## 0.6.13 — 2026-07-30
 
 - **A faker table can now be ordered.** `build` and `build_shaped` seeded the

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-core"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "atty",
  "indexmap",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-dataset"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.0"
+version = "0.12.3"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2148,6 +2148,7 @@ dependencies = [
  "libc",
  "redb",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2175,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2183,6 +2184,7 @@ dependencies = [
  "fake",
  "indexmap",
  "rhai",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",
@@ -2197,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.14"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2221,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-types"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "chrono",
  "ciborium",
@@ -2244,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.20"
+version = "0.6.22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2252,6 +2254,7 @@ dependencies = [
  "futures-core",
  "indexmap",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "vantage-core",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.13"
+version = "0.6.14"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -17,8 +17,10 @@ readme = "README.md"
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 vantage-diorama = { version = "0.12", path = "../vantage-diorama" }
+# `TableShell::preview_query` answers with a driver-shaped JSON value.
+serde_json = "1"
 
 # Universal value carrier across the type-erased Vista / ChangeEvent boundary.
 ciborium = "0.2"

--- a/vantage-faker/src/live_folder/listing_shell.rs
+++ b/vantage-faker/src/live_folder/listing_shell.rs
@@ -247,4 +247,12 @@ impl TableShell for FolderListingShell {
     fn driver_name(&self) -> &'static str {
         "live-folder-listing"
     }
+
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "live-folder-listing",
+            "path": self.path,
+            "note": "a local directory read — no query, and nothing leaves the machine",
+        })
+    }
 }

--- a/vantage-faker/src/live_folder/size_shell.rs
+++ b/vantage-faker/src/live_folder/size_shell.rs
@@ -140,6 +140,14 @@ impl TableShell for FolderSizeShell {
     fn driver_name(&self) -> &'static str {
         "live-folder-size"
     }
+
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "live-folder-size",
+            "note": "rows are computed by walking a local directory tree — no \
+                     query, and nothing leaves the machine",
+        })
+    }
 }
 
 fn size_record(path: &str, size: u64, file_count: u64) -> Record<CborValue> {

--- a/vantage-faker/src/shape.rs
+++ b/vantage-faker/src/shape.rs
@@ -321,6 +321,19 @@ impl TableShell for ShapedShell {
         "faker-shaped"
     }
 
+    /// Shaping adds latency, page-size negotiation and injected faults around
+    /// another shell; it does not change the query. So the wrapped shell's
+    /// preview is the answer, tagged with the shaping around it.
+    fn preview_query(&self, vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "faker-shaped",
+            "page_size": self.page_size,
+            "note": "simulated backend: latency and faults are layered over the \
+                     wrapped shell without altering its query",
+            "shaped": self.inner.preview_query(vista),
+        })
+    }
+
     async fn list_vista_values(
         &self,
         vista: &Vista,

--- a/vantage-kubernetes/CHANGELOG.md
+++ b/vantage-kubernetes/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.1 — 2026-08-16
+
+- `KubeTableShell` implements `preview_query`, naming the collection it lists and
+  reporting that search and ordering are applied to the returned rows rather than
+  pushed to the API server.
+- **Version:** this crate jumps from 0.1.x to the 0.6 line its dependents already
+  require. The old number could never satisfy a `0.6` requirement, so consumers
+  silently resolved the registry copy instead of a local path patch.
+
 ## 0.1.2 — 2026-08-12
 
 - **Bug fix:** `KubeTableShell::get_ref_target` resolves relations whose target

--- a/vantage-kubernetes/CHANGELOG.md
+++ b/vantage-kubernetes/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Version:** this crate jumps from 0.1.x to the 0.6 line its dependents already
   require. The old number could never satisfy a `0.6` requirement, so consumers
   silently resolved the registry copy instead of a local path patch.
+- `KubeTableShell::preview_query` reports the shell's `page_size`.
 
 ## 0.1.2 — 2026-08-12
 

--- a/vantage-kubernetes/Cargo.lock
+++ b/vantage-kubernetes/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-kubernetes"
-version = "0.1.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.15"
+version = "0.6.16"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.20"
+version = "0.6.22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2260,6 +2260,7 @@ dependencies = [
  "futures-core",
  "indexmap",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "vantage-core",

--- a/vantage-kubernetes/Cargo.toml
+++ b/vantage-kubernetes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-kubernetes"
-version = "0.1.2"
+version = "0.6.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -16,7 +16,7 @@ vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 # Native Kubernetes client: config/auth/TLS only. We issue raw list
 # requests and project the JSON ourselves, so k8s-openapi's generated

--- a/vantage-kubernetes/src/vista/source.rs
+++ b/vantage-kubernetes/src/vista/source.rs
@@ -269,4 +269,29 @@ impl TableShell for KubeTableShell {
     fn driver_name(&self) -> &'static str {
         "kubernetes"
     }
+
+    /// The collection this shell lists, plus the narrowing it applies *after*
+    /// the API answers. Search and ordering are client-side here — they never
+    /// reach the API server, so a slow list is not made faster by either.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        let orders: Vec<String> = self
+            .orders
+            .iter()
+            .map(|(field, dir)| {
+                let dir = match dir {
+                    SortDirection::Ascending => "asc",
+                    SortDirection::Descending => "desc",
+                };
+                format!("{field} {dir}")
+            })
+            .collect();
+
+        serde_json::json!({
+            "driver": "kubernetes",
+            "collection": self.table.table_name(),
+            "client_side": { "search": self.search, "order": orders },
+            "note": "the collection is listed through the Kubernetes API; search \
+                     and ordering are applied to the returned rows in memory",
+        })
+    }
 }

--- a/vantage-kubernetes/src/vista/source.rs
+++ b/vantage-kubernetes/src/vista/source.rs
@@ -290,6 +290,9 @@ impl TableShell for KubeTableShell {
             "driver": "kubernetes",
             "collection": self.table.table_name(),
             "client_side": { "search": self.search, "order": orders },
+            // Shell-owned, and consumed by fetch_page/fetch_next rather than by
+            // the listing itself — so it is reported rather than folded in.
+            "page_size": self.page_size,
             "note": "the collection is listed through the Kubernetes API; search \
                      and ordering are applied to the returned rows in memory",
         })

--- a/vantage-log-writer/CHANGELOG.md
+++ b/vantage-log-writer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.2 — 2026-08-16
+
+- `LogWriterTableShell` implements `preview_query`, stating plainly that a
+  write-only sink refuses every read and so has no read query to preview.
+
 ## 0.6.1 — unreleased
 
 - CBOR↔JSON at the insert boundary uses the shared `vantage-types` walker; tagged

--- a/vantage-log-writer/Cargo.toml
+++ b/vantage-log-writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-log-writer"
-version = "0.6.1"
+version = "0.6.2"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for append-only log files (JSONL)"
@@ -27,11 +27,11 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 tempfile = "3"
 tokio = { version = "1.48", features = ["full"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }

--- a/vantage-log-writer/src/vista/source.rs
+++ b/vantage-log-writer/src/vista/source.rs
@@ -122,4 +122,15 @@ impl TableShell for LogWriterTableShell {
     fn driver_name(&self) -> &'static str {
         "log-writer"
     }
+
+    /// Write-only: every read on this shell errors, so there is no read query
+    /// to preview. Said plainly rather than left to be inferred from an empty
+    /// object.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "log-writer",
+            "note": "write-only sink — it accepts inserts and refuses every read, \
+                     so there is no read query to preview",
+        })
+    }
 }

--- a/vantage-mongodb/CHANGELOG.md
+++ b/vantage-mongodb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.6 — 2026-08-16
+
+- `MongoTableShell` implements `preview_query`, returning the collection and the
+  rendered find.
+
 ## 0.6.5 — 2026-08-12
 
 - **Bug fix:** `MongoTableShell::get_ref_target` resolves relations whose target

--- a/vantage-mongodb/Cargo.toml
+++ b/vantage-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-mongodb"
-version = "0.6.5"
+version = "0.6.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "MongoDB persistence backend for Vantage framework"
@@ -16,7 +16,7 @@ vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
 
 bson = "2"
 ciborium = { version = "0.2", features = ["std"] }
@@ -33,4 +33,4 @@ futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 pretty_assertions = "1"
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }

--- a/vantage-mongodb/src/vista/source.rs
+++ b/vantage-mongodb/src/vista/source.rs
@@ -463,6 +463,16 @@ impl TableShell for MongoTableShell {
     fn driver_name(&self) -> &'static str {
         "mongodb"
     }
+
+    /// The find as it stands — collection, filter document, projection, sort
+    /// and limit — rendered the way `MongoSelect` spells them.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "mongodb",
+            "collection": self.table.table_name(),
+            "find": self.table.select().preview(),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.19 — 2026-08-16
+
+- The SQLite, Postgres and MySQL shells implement `preview_query`, returning the
+  SELECT as it stands with values rendered inline. The executed form binds those
+  same values as parameters.
+
 ## 0.6.18 — 2026-08-12
 
 - **Bug fix:** the Postgres, MySQL and SQLite shells resolve relations whose

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.18"
+version = "0.6.19"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -25,7 +25,7 @@ paste = "1.0"
 
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
-vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
@@ -43,7 +43,7 @@ rhai = { version = "1.25", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 sqlformat = "0.3"
 
 # The name must be unique across the workspace: cargo writes every

--- a/vantage-sql/src/mysql/vista/source.rs
+++ b/vantage-sql/src/mysql/vista/source.rs
@@ -288,4 +288,15 @@ where
     fn driver_name(&self) -> &'static str {
         "mysql"
     }
+
+    /// The SELECT as it stands: every condition, order and page size applied so
+    /// far, rendered with values inline. The executed form binds those values as
+    /// `?` parameters instead — same query, different spelling.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "mysql",
+            "table": self.table.table_name(),
+            "sql": self.table.select().preview(),
+        })
+    }
 }

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -394,4 +394,15 @@ where
     fn driver_name(&self) -> &'static str {
         "postgres"
     }
+
+    /// The SELECT as it stands: every condition, order and page size applied so
+    /// far, rendered with values inline. The executed form binds those values as
+    /// `$N` parameters instead — same query, different spelling.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "postgres",
+            "table": self.table.table_name(),
+            "sql": self.table.select().preview(),
+        })
+    }
 }

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -456,4 +456,15 @@ where
     fn driver_name(&self) -> &'static str {
         "sqlite"
     }
+
+    /// The SELECT as it stands: every condition, order and page size applied so
+    /// far, rendered with values inline. The executed form binds those values as
+    /// `?N` parameters instead — same query, different spelling.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "sqlite",
+            "table": self.table.table_name(),
+            "sql": self.table.select().preview(),
+        })
+    }
 }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - `SurrealTableShell` implements `preview_query`, returning the SurrealQL SELECT
   with conditions, ordering and page size applied.
+- `SurrealTableShell::preview_query` reports the shell's `page_size`. It is
+  consumed by `fetch_page`/`fetch_next` rather than by the statement, so it is
+  named separately instead of folded into a `LIMIT` a plain list never sends.
 
 ## 0.6.15 — 2026-08-12
 

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.16 — 2026-08-16
+
+- `SurrealTableShell` implements `preview_query`, returning the SurrealQL SELECT
+  with conditions, ordering and page size applied.
+
 ## 0.6.15 — 2026-08-12
 
 - **Bug fix:** `SurrealTableShell::get_ref_target` resolves relations whose

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.15"
+version = "0.6.16"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -26,7 +26,7 @@ vantage-expressions = { version = "0.6", path = "../vantage-expressions", featur
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
 surreal-client = { version = "0.6", path = "../surreal-client" }
 
 async-stream = "0.3"
@@ -93,7 +93,7 @@ bakery_model3 = { path = "../bakery_model3" }
 futures = "0.3"
 serde_yaml_ng = "0.10"
 tokio = { version = "1.52", features = ["full"] }
-vantage-vista = { version = "0.6", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 [[example]]
 name = "expr"

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -562,6 +562,16 @@ where
         "surrealdb"
     }
 
+    /// The SurrealQL SELECT as it stands, with every condition, order and page
+    /// size applied so far rendered inline.
+    fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "surrealdb",
+            "table": self.table.table_name(),
+            "surql": self.table.select().preview(),
+        })
+    }
+
     /// Layer SurrealDB's expression vocabulary on top of vantage-vista's
     /// conventional `Vista` verbs, plus a `with_condition(<expr>)` builder that
     /// routes a native `Expression` through [`add_raw_condition`](Self::add_raw_condition).

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -562,13 +562,19 @@ where
         "surrealdb"
     }
 
-    /// The SurrealQL SELECT as it stands, with every condition, order and page
-    /// size applied so far rendered inline.
+    /// The SurrealQL SELECT as it stands, with every condition and order
+    /// applied so far rendered inline.
+    ///
+    /// `page_size` is reported separately because it lives on the shell, not on
+    /// the table: `fetch_page`/`fetch_next` turn it into a `START`/`LIMIT` at
+    /// call time, so it is absent from the statement below. Folding it in would
+    /// show a `LIMIT` that a plain `list_values()` never sends.
     fn preview_query(&self, _vista: &Vista) -> serde_json::Value {
         serde_json::json!({
             "driver": "surrealdb",
             "table": self.table.table_name(),
             "surql": self.table.select().preview(),
+            "page_size": self.page_size,
         })
     }
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.6.22 — 2026-08-16
+
+- `TableShell::preview_query` renders the query a driver would send, without
+  sending it. It is required, not defaulted: adding a driver now forces an
+  answer rather than letting it inherit silence. The answer is a free-form,
+  driver-shaped `serde_json::Value` carrying a `driver` key — SQL returns its
+  `sql`, GraphQL its `query`, a cmd datasource the script and scope that build
+  its argv. Drivers with no query to show say so in a `note`.
+- The method is synchronous and performs no I/O, by contract. A value known only
+  at fetch time renders as a placeholder rather than being awaited, which is what
+  makes preview safe to expose where fetching is not.
+- `preview_script` runs a builder script on an engine carrying the conventional
+  verbs and *no* terminal fetch verbs, returning the rendered query. `list()` on
+  that engine is an unknown function, so the guarantee that nothing is fetched is
+  structural rather than a promise about how the API is used. The script needs no
+  terminal verb: its final expression is the query itself.
+- `Vista::preview_query` forwards to the shell.
+- `serde_json` is no longer optional — the preview type is part of the trait.
+
 ## 0.6.21 — 2026-08-12
 
 - `MockShell::with_id_prefix` qualifies every id with a prefix, the way a driver

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -22,7 +22,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 thiserror = "2.0"
 rhai = { version = "1.25", optional = true }
-serde_json = { version = "1", optional = true }
+# Not optional: `TableShell::preview_query` returns a driver-shaped
+# `serde_json::Value`, so the type is part of the trait every driver implements.
+serde_json = "1"
 # `rt`/`rt-multi-thread` for the spawn_blocking + Handle::block_on bridge that
 # drives the async Vista fetches from the synchronous Rhai engine.
 tokio = { version = "1.52", features = ["rt", "rt-multi-thread"], optional = true }
@@ -34,7 +36,7 @@ tokio = { version = "1.52", features = ["rt", "rt-multi-thread"], optional = tru
 # (`list`/`get_some`/`count`/`capabilities`/`columns`/`references`) and the
 # `run_script` runner. Backends layer their vendor expression vocabulary on top
 # via `TableShell::register_rhai_extensions`.
-rhai = ["dep:rhai", "dep:serde_json", "dep:tokio", "vantage-types/serde"]
+rhai = ["dep:rhai", "dep:tokio", "vantage-types/serde"]
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/vantage-vista/src/contained.rs
+++ b/vantage-vista/src/contained.rs
@@ -273,6 +273,16 @@ impl TableShell for ContainedShell {
     fn driver_name(&self) -> &'static str {
         "contained"
     }
+
+    fn preview_query(&self, vista: &Vista) -> serde_json::Value {
+        serde_json::json!({
+            "driver": "contained",
+            "relation": vista.name(),
+            "note": "embedded in the parent row — these records arrived with the \
+                     parent and cost no query of their own. Preview the parent \
+                     table to see what fetches them.",
+        })
+    }
 }
 
 /// Fixed id for the single record of a `contains_one` relation.

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -35,8 +35,8 @@ pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 pub use rhai::{
     AugmentSourceFn, DEFAULT_LIMIT, LazyValueFn, MAX_LIMIT, MIN_LIMIT, RhaiVista, TargetResolver,
     augment_source_closure, eval_augment_source, eval_lazy_expression, eval_modify_script,
-    eval_ref_script, lazy_value_closure, register_conventional_onto, register_fetch_verbs,
-    run_script,
+    eval_ref_script, lazy_value_closure, preview_script, register_conventional_onto,
+    register_fetch_verbs, run_script,
 };
 pub use sort::SortDirection;
 pub use source::{TableShell, VistaChange, VistaChangeStream};

--- a/vantage-vista/src/mocks/mock_shell.rs
+++ b/vantage-vista/src/mocks/mock_shell.rs
@@ -546,6 +546,33 @@ impl TableShell for MockShell {
         "mock"
     }
 
+    /// The mock has no query language, so it reports the narrowing state a real
+    /// driver would translate: which filters, order and search are pending.
+    /// Enough for tests to assert that a builder verb reached the shell.
+    fn preview_query(&self, vista: &Vista) -> serde_json::Value {
+        let filters: Vec<String> = self
+            .filters
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(field, value)| format!("{field} = {value:?}"))
+            .collect();
+        let order = self.order.lock().unwrap().as_ref().map(|(col, dir)| {
+            let dir = match dir {
+                SortDirection::Ascending => "asc",
+                SortDirection::Descending => "desc",
+            };
+            format!("{col} {dir}")
+        });
+        serde_json::json!({
+            "driver": "mock",
+            "table": vista.name(),
+            "filters": filters,
+            "order": order,
+            "search": self.search.lock().unwrap().clone(),
+        })
+    }
+
     fn add_eq_condition(&mut self, field: &str, value: &CborValue) -> Result<()> {
         self.filters
             .lock()

--- a/vantage-vista/src/rhai.rs
+++ b/vantage-vista/src/rhai.rs
@@ -13,6 +13,11 @@
 //!   [`runtime::run_script`] runner that drives their async fetches from
 //!   synchronous Rhai.
 //!
+//! [`runtime::preview_script`] is the third combination: the builder layer with
+//! *no* terminal verbs, rendering the query a script built instead of running
+//! it. An engine that cannot fetch is a stronger guarantee than an engine that
+//! merely isn't asked to.
+//!
 //! [`convert`] and [`introspect`] are shared internals (value round-tripping and
 //! schema/capability map building).
 
@@ -28,4 +33,4 @@ pub use conventional::{
     lazy_value_closure, register_conventional_onto,
 };
 pub use fetch::register_fetch_verbs;
-pub use runtime::{DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, run_script};
+pub use runtime::{DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, preview_script, run_script};

--- a/vantage-vista/src/rhai/runtime.rs
+++ b/vantage-vista/src/rhai/runtime.rs
@@ -20,7 +20,7 @@
 
 use rhai::{Dynamic, Engine};
 
-use super::conventional::{TargetResolver, register_conventional_onto};
+use super::conventional::{RhaiVista, TargetResolver, register_conventional_onto};
 use super::convert::dynamic_to_json;
 use super::fetch::register_fetch_verbs;
 
@@ -63,6 +63,58 @@ pub async fn run_script(
     .map_err(|e| format!("data-fetch script task failed to run: {e}"))?
 }
 
+/// Build a query with the conventional verbs and render what it *would* send,
+/// without sending anything.
+///
+/// The engine this runs on carries [`register_conventional_onto`] and nothing
+/// else — the terminal fetch verbs are deliberately absent, so there is no path
+/// from a preview script to a backend read. That is the point: preview is safe
+/// to expose in places where fetching is not, and the safety is structural
+/// rather than a promise about how the verb is used.
+///
+/// Consequently the script takes no terminal verb at all. Its final expression
+/// must *be* the built query:
+///
+/// ```rhai
+/// table("orders").add_condition_eq("status", "paid").set_page_size(20)
+/// ```
+///
+/// A reference can be previewed against a literal parent row, since `get_ref`
+/// reads the join value straight out of the map it is handed:
+///
+/// ```rhai
+/// table("orders").get_ref("client", #{ id: "42" })
+/// ```
+///
+/// Synchronous throughout: the resolver builds vistas without fetching, and
+/// [`TableShell::preview_query`](crate::TableShell::preview_query) is
+/// contractually I/O-free. Returns the driver-shaped JSON that method produced.
+pub fn preview_script(
+    script: String,
+    resolver: TargetResolver,
+) -> Result<serde_json::Value, String> {
+    let mut engine = Engine::new();
+    register_conventional_onto(&mut engine, resolver);
+
+    let result: Dynamic = engine.eval::<Dynamic>(&script).map_err(|e| e.to_string())?;
+    let handle: RhaiVista = result.try_cast::<RhaiVista>().ok_or_else(|| {
+        "preview script must end on the query itself, e.g. \
+         `table(\"orders\").add_condition_eq(\"status\", \"paid\")` — this engine \
+         has no terminal verbs (`list`, `count`, `get_some`), because it never \
+         fetches"
+            .to_string()
+    })?;
+
+    let vista = handle
+        .0
+        .lock()
+        .map_err(|_| "preview script: result mutex poisoned".to_string())?
+        .take()
+        .ok_or_else(|| "preview script: vista already consumed".to_string())?;
+
+    Ok(vista.preview_query())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,7 +153,11 @@ mod tests {
             );
         let metadata = VistaMetadata::new()
             .with_column(Column::new("id", "String").with_flag("id"))
-            .with_column(Column::new("name", "String").with_flag("title"))
+            .with_column(
+                Column::new("name", "String")
+                    .with_flag("title")
+                    .with_flag("orderable"),
+            )
             .with_id_column("id");
         Vista::new("users", Box::new(source.with_metadata(metadata)))
     }
@@ -110,6 +166,34 @@ mod tests {
         Arc::new(|name: &str| {
             if name == "users" {
                 Ok(users_vista())
+            } else {
+                Err(vantage_core::error!("unknown table", table = name))
+            }
+        })
+    }
+
+    /// `users` with a `posts` has-many hanging off it, joined on `author`.
+    fn users_with_posts() -> Vista {
+        let posts = MockShell::new();
+        let metadata = VistaMetadata::new()
+            .with_column(Column::new("id", "String").with_flag("id"))
+            .with_id_column("id")
+            .with_reference(crate::Reference::new(
+                "posts",
+                "posts",
+                crate::ReferenceKind::HasMany,
+                "author",
+            ));
+        let source = MockShell::new()
+            .with_metadata(metadata)
+            .with_ref_target("posts", posts);
+        Vista::new("users", Box::new(source))
+    }
+
+    fn ref_resolver() -> TargetResolver {
+        Arc::new(|name: &str| {
+            if name == "users" {
+                Ok(users_with_posts())
             } else {
                 Err(vantage_core::error!("unknown table", table = name))
             }
@@ -180,6 +264,65 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.contains("unknown table"), "got: {err}");
+    }
+
+    #[test]
+    fn preview_renders_the_built_query() {
+        let json = preview_script(
+            r#"table("users").add_condition_eq("id", "3").add_order("name", "desc")"#.into(),
+            resolver(),
+        )
+        .unwrap();
+        assert_eq!(json["driver"], serde_json::json!("mock"));
+        assert_eq!(json["table"], serde_json::json!("users"));
+        assert!(
+            json["filters"][0].as_str().unwrap().starts_with("id ="),
+            "the condition reached the shell: {json}"
+        );
+        assert_eq!(json["order"], serde_json::json!("name desc"));
+    }
+
+    /// The security assertion: the preview engine carries the builder verbs and
+    /// nothing else, so there is no way to spell a fetch on it.
+    #[test]
+    fn preview_engine_has_no_terminal_verbs() {
+        for script in [
+            r#"table("users").list()"#,
+            r#"table("users").count()"#,
+            r#"table("users").get_some()"#,
+        ] {
+            let err = preview_script(script.into(), resolver())
+                .expect_err("a fetch verb must not exist on the preview engine");
+            assert!(
+                err.contains("Function not found"),
+                "expected an unknown-function error for `{script}`, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn preview_of_a_non_query_explains_itself() {
+        let err = preview_script(r#""just a string""#.into(), resolver()).unwrap_err();
+        assert!(
+            err.contains("must end on the query itself"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn preview_traverses_a_reference_from_a_literal_row() {
+        // No fetch anywhere: `get_ref` reads the join value out of the map it
+        // is handed, so a drill-down previews from a made-up parent row.
+        let json = preview_script(
+            r#"table("users").get_ref("posts", #{ id: "1" })"#.into(),
+            ref_resolver(),
+        )
+        .unwrap();
+        assert_eq!(json["table"], serde_json::json!("posts"));
+        assert!(
+            json["filters"][0].as_str().unwrap().starts_with("author ="),
+            "the join condition is visible: {json}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/vantage-vista/src/rhai/runtime.rs
+++ b/vantage-vista/src/rhai/runtime.rs
@@ -86,9 +86,22 @@ pub async fn run_script(
 /// table("orders").get_ref("client", #{ id: "42" })
 /// ```
 ///
-/// Synchronous throughout: the resolver builds vistas without fetching, and
-/// [`TableShell::preview_query`](crate::TableShell::preview_query) is
-/// contractually I/O-free. Returns the driver-shaped JSON that method produced.
+/// Returns the driver-shaped JSON that
+/// [`TableShell::preview_query`](crate::TableShell::preview_query) produced.
+///
+/// # What is and isn't guaranteed
+///
+/// What this enforces is that **no terminal fetch verb exists** on the engine,
+/// and `preview_query` is contractually I/O-free. What it does *not* enforce is
+/// the behaviour of the two things the caller supplies: the `resolver`, and
+/// whatever `get_ref` does inside a driver. Both are ordinary sync functions
+/// that construct a vista rather than read one, and neither can await — but
+/// neither is prevented from blocking on something either.
+///
+/// So: a preview script cannot *fetch the set it describes*. That is the useful
+/// guarantee, and it is structural. "Nothing at all leaves the process" would be
+/// a stronger claim than the types support, and is only as true as the resolver
+/// handed in.
 pub fn preview_script(
     script: String,
     resolver: TargetResolver,
@@ -303,10 +316,7 @@ mod tests {
     #[test]
     fn preview_of_a_non_query_explains_itself() {
         let err = preview_script(r#""just a string""#.into(), resolver()).unwrap_err();
-        assert!(
-            err.contains("must end on the query itself"),
-            "got: {err}"
-        );
+        assert!(err.contains("must end on the query itself"), "got: {err}");
     }
 
     #[test]

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -547,6 +547,32 @@ pub trait TableShell: Send + Sync + 'static {
         "unknown"
     }
 
+    // ---- Preview -----------------------------------------------------------
+
+    /// Render the query this shell would send, **without sending it**.
+    ///
+    /// Free-form and driver-shaped: SQL answers with `sql`, GraphQL with a
+    /// `query` document, a cmd datasource with the argv it would spawn. The
+    /// only convention is a `driver` key naming the driver, so a reader can
+    /// tell what the rest of the object means.
+    ///
+    /// There is no default and no `Result`. No default, so a new driver is
+    /// forced to answer rather than inheriting silence; no `Result`, because
+    /// "there is no query" is an answer, not a failure — a driver that
+    /// generates its rows in-process says so in a `note` and is done.
+    ///
+    /// # Contract
+    ///
+    /// **Synchronous, and performs no I/O.** That is what makes preview safe
+    /// to expose where fetching is not. A value known only at fetch time (an
+    /// unresolved foreign-key narrowing) renders as a placeholder; it is never
+    /// awaited.
+    ///
+    /// **Lossy is acceptable, wrong is not.** A preview that omits a detail
+    /// should say so in a `note`. A preview showing a filter the driver would
+    /// not actually send is a bug.
+    fn preview_query(&self, vista: &Vista) -> serde_json::Value;
+
     // ---- Scripting ---------------------------------------------------------
 
     /// Contribute backend-specific vocabulary to a Rhai engine that

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -58,6 +58,15 @@ impl Vista {
         self.source.driver_name()
     }
 
+    /// Render the query this vista would send, without sending it — see
+    /// [`TableShell::preview_query`] for the shape and the no-I/O contract.
+    ///
+    /// A debugging surface: it reports what the *next* read would ask the
+    /// backend for, given every condition, order and page size applied so far.
+    pub fn preview_query(&self) -> serde_json::Value {
+        self.source.preview_query(self)
+    }
+
     // ---- metadata accessors -----------------------------------------------
     //
     // All schema accessors forward to the shell. Vista holds none of the


### PR DESCRIPTION
A Vista could run a query but never show one. When a table came back empty, returned far too much, or quietly ignored a filter, the only evidence available was the rows it didn't return — the query itself stopped at the driver, and nothing above `TableShell` could reach it. Every driver already knew how to render one (`SqliteSelect::preview`, `SurrealSelect::preview`, `GraphqlSelect::preview`); there was simply no way to ask.

### The boundary

`TableShell::preview_query` renders the query a driver would send, without sending it.

It is **required, not defaulted**. A default would let a new driver inherit silence, and silence is indistinguishable from "no query exists" — so the compiler asks every shell instead. It returns a free-form `serde_json::Value` shaped by the driver, with one convention: a `driver` key naming which.

There is no `Result`. "There is no query" is an answer, not a failure — a faker table generates rows in-process and says so in a `note`.

```rust
fn preview_query(&self, vista: &Vista) -> serde_json::Value;
```

**Synchronous, and performs no I/O, by contract.** That is not incidental: it is what makes preview safe to expose where fetching is not. A value known only at fetch time — an unresolved foreign key — renders as a marker rather than being awaited.

### An engine that cannot fetch

`preview_script` runs a builder script on an engine carrying the conventional verbs and *not* `register_fetch_verbs`:

```rhai
table("orders").add_condition_eq("status", "paid").set_page_size(20)
```

No terminal verb, because the final expression *is* the query. `list()` on that engine is an unknown function, so "nothing is fetched" is structural rather than a promise about how the API gets used:

```
table("orders").list()      -> Function not found: list (Vista)
table("orders").count()     -> Function not found: count (Vista)
table("orders").get_some()  -> Function not found: get_some (Vista)
```

A reference previews against a literal parent row — `get_ref` reads the join value out of the map it is handed, so no fetch is needed to build the drill-down:

```rhai
table("orders").get_ref("client", #{ id: "42" })
```

### What each driver answers

| Driver | Renders |
|---|---|
| sqlite / postgres / mysql | `sql` — the SELECT with values inline |
| surrealdb | `surql` |
| graphql | `endpoint` + the `query` document |
| rest-api | `method`, `url`, and `client_side_filters` |
| cmd | the locked `command`, the `script`, and its `scope` |
| mongodb | `collection` + `find` |

The REST shell shares `endpoint_url`/`build_query_string` with the real fetch path, so a previewed URL cannot drift from the one that gets sent. Its `client_side_filters` is the interesting field: under `FilterStrategy::Client` those conditions never reach the server, which is the difference between a filter you configured and a filter the API applies.

A cmd table's argv is assembled *inside* its Rhai script, by the same call that runs it — no preview can render the argv without running the command. It reports what decides the argv instead: the locked program, the script, and the scope values it would be evaluated with.

The rest say plainly why they have no query. A contained relation arrived with its parent. An aggregate is derived in memory from its source Dio's cached rows. A `DioShell` read hits the cache, so it forwards its master's query verbatim and lists its own narrowing separately — merging the two would suggest a facade filter reached the server.

### GraphQL's preview was rewritten

It summarised its filter as `stacks(<1 conditions>)` and omitted the `query { }` wrapper, which made it useless for exactly the schema it is most needed on. `GraphqlCondition::Field` holds a plain `serde_json::Value` and `render_field` was already synchronous, so the lossiness was never necessary.

`preview` now mirrors `render` arm for arm, and a test pins the two to the **same document** for any query without deferred values. Two differences remain, both forced by not being allowed to do work: pagination is inlined (`limit: 5`) rather than sent through `$limit`, so the document reads standalone; and a deferred condition renders as `**deferred(field Eq)` rather than being awaited.

Before and after, against Spacelift:

```
stacks(<1 conditions>) { id name description state blocker.id ... }

query { stacks(find: {state: "FINISHED"}) { id name description state blocker { id } ... } }
```

### Versions

Patch bumps across every touched crate, and each driver's `vantage-vista` requirement raised to `0.6.22` — a driver implementing a required method cannot be paired with a vista that lacks it.

`vantage-kubernetes` jumps **0.1.2 → 0.6.1**. Its version could never satisfy the `0.6` its dependents ask for, so consumers silently resolved a registry copy instead of the local path — and a registry driver cannot implement a method the local vantage-vista has only just added.

**`vantage-spacetimedb` is not included.** It resolves the whole vantage family from crates.io rather than by path; pointing only its vista at the working copy produces two incompatible type graphs. It will need `preview_query` before 0.6.22 can be published.

### Tests

1880 passing. New coverage: the rendered query reflects the conditions and ordering applied; every fetch verb is absent from the preview engine; a non-query script explains itself; a reference previews from a literal row; GraphQL preview and render agree on the document; pagination inlines; a deferred condition is marked rather than resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added no-I/O query previews across supported data sources, including SQL, GraphQL, REST, AWS, MongoDB, Kubernetes, SurrealDB, and command-based sources.
  * Preview results show the planned query, filters, ordering, pagination, endpoints, and driver-specific details.
  * Added script previews that validate query-building logic without executing data-fetch operations.
  * Added clear explanations for locally processed, cached, embedded, write-only, and in-memory data sources.
* **Documentation**
  * Updated changelogs and package versions for the new preview capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->