### PR TITLE
WIP: aggregate pushdown is half-landed — transport exists, no backend implements it

### DIFF
--- a/agent/todo/aggregate-pushdown.md
+++ b/agent/todo/aggregate-pushdown.md
@@ -1,31 +1,74 @@
 # Aggregate pushdown: server-side sum/count behind a capability
 
-**Today:** `ValueScenery` computes every aggregate — `count`, `sum`, `max`,
-`min`, `custom` — by scanning the Dio cache, unconditionally. There is no
-aggregate method on `TableShell` and no capability to advertise one;
-`VistaCapabilities::can_count` exists but even `ValueScenery::count()`
-ignores it. The local scan is *coverage-honest*: it aggregates what has been
-observed so far and climbs as hydration proceeds (learn-6's `total rows`
-status value depends on exactly this).
+**Status: scaffolding landed, nothing uses it.** The transport exists on
+`main` and no backend implements it, so every aggregate still resolves
+by scanning the Dio cache. Audited 2026-08-22 — the "Today" section below
+described the state *before* that scaffolding merged and was stale.
 
-**Want:** a `can_aggregate` capability + a `TableShell` aggregate method, so
-backends that can compute server-side (SQL, Surreal, some REST reports) do.
-Routing rules:
+## What is on main
 
-- **Augment-owned columns always compute locally** — they only exist in the
-  cache (learn-6's `rows` is derived from file contents; the master has never
-  heard of it). Pushdown is impossible in principle.
+- `vantage-vista/src/aggregate.rs` — `AggregateSpec { op, column, alias,
+  group_by }` with collision-free `cache_key` derivation, unit-tested.
+- `TableShell::aggregate_vista(&self, vista, spec) -> Result<Option<Vista>>`
+  (`vantage-vista/src/source.rs:240`) — the pushdown hook. Documented at
+  length: the returned vista's capabilities describe the DERIVED set, and
+  must not inherit condition support, because a condition on an aggregate
+  is `HAVING` — a different operation over different values.
+- `Vista::aggregate` (`vantage-vista/src/vista.rs:204`) and
+  `Dio::master_aggregate` (`vantage-diorama/src/dio/mod.rs:711`).
+
+An aggregation deliberately returns a **new set**, not a number: `count(*)`
+is a one-row table, `GROUP BY` is one row per group, and both are ordinary
+sets you can condition, order or count again. That shape decision is
+settled and worth keeping.
+
+## What is missing
+
+1. **No implementors.** `aggregate_vista` is overridden by exactly zero
+   drivers — SQL, Surreal, Mongo, REST all inherit the default `Ok(None)`.
+   Every call takes the local path. Compare `add_op_condition`, whose
+   equivalent rollout *did* reach six backends.
+2. **No `can_aggregate` capability.** `VistaCapabilities` carries 17
+   `can_*` flags and none for aggregation, so a consumer cannot ask
+   whether pushdown is available before requesting it — it can only call
+   and interpret `None`.
+3. **`ValueScenery` never attempts pushdown.** It still reduces over the
+   cache unconditionally via its own `Aggregate` enum
+   (`Count`/`CountWhere`/`Sum`/`Max`/`Min`/`Custom`,
+   `vantage-diorama/src/scenery/value.rs:79`). `master_aggregate` and
+   `ValueScenery` are two disconnected paths; nothing bridges them.
+4. **No observed-vs-authoritative split.** Neither `sum_observed` nor any
+   equivalent exists. This is the requirement the original note called
+   out hardest and it is entirely unstarted — see below.
+5. **A rotted doc example.** `Dio::master_aggregate`'s doc comment builds
+   its spec with `AggregateSpec::new("count", "failed").condition("Event", …)`.
+   There is no `condition` method — the builder is `new`/`column`/`group_by`
+   only, and `AggregateSpec`'s own docs say conditions deliberately do not
+   live there (narrow the source vista first, then aggregate it). The
+   example is ```` ```ignore ```` so nothing catches it.
+
+## The semantic decision, still open
+
+The local scan is *coverage-honest*: it aggregates what has been observed
+so far and climbs as hydration proceeds. learn-6's `total rows` status
+value depends on exactly that behaviour.
+
+Pushing down changes the meaning. The same `sum(col)` would be "total of
+everything" on one backend and "total of what we've seen" on another.
+
+**Do not switch silently.** Make it visible in the API — e.g. `sum(col)`
+(authoritative when capable, error otherwise) vs `sum_observed(col)`
+(always local) — and document which one a status bar should use during
+hydration.
+
+Routing rules, once there is something to route:
+
+- **Augment-owned columns always compute locally.** They only exist in the
+  cache (learn-6's `rows` is derived from file contents; the master has
+  never heard of it). Pushdown is impossible in principle.
 - **Native columns may push down** when the capability is there — but the
-  result is the *authoritative total*, not the observed one, and it must
-  re-query on `Refreshing`/`DatasetChanged` instead of recomputing from local
-  state.
-
-**Do NOT switch silently.** Observed-vs-authoritative is a semantic choice,
-not an optimization: the same `sum(col)` would mean "total of everything" on
-one backend and "total of what we've seen" on another. Make it visible in the
-API — e.g. `sum(col)` (authoritative when capable, error/local otherwise) vs
-`sum_observed(col)` (always local, coverage-honest) — and document which one
-a status bar should use during hydration.
+  result is the authoritative total, and it must re-query on
+  `Refreshing`/`DatasetChanged` rather than recomputing from local state.
 
 **Consumers:** ValueScenery builders, learn-6/learn-7 status values, any
 vantage-ui aggregate badge.


### PR DESCRIPTION
You asked whether the server-side aggregate work was left incomplete. It was — and the reason it looked untracked is that `agent/todo/aggregate-pushdown.md` still described the state *before* the scaffolding merged. Its opening line claimed "there is no aggregate method on `TableShell` and no capability to advertise one", which stopped being true when `aggregate_vista` landed.

This PR only corrects that doc. **No code changes** — the point is to make the gap visible and get a decision on the open semantic question. Draft accordingly.

### What actually landed

- `AggregateSpec { op, column, alias, group_by }` with collision-free `cache_key` derivation, unit-tested — `vantage-vista/src/aggregate.rs`
- `TableShell::aggregate_vista(&self, vista, spec) -> Result<Option<Vista>>` — `vantage-vista/src/source.rs:240`
- `Vista::aggregate` — `vantage-vista/src/vista.rs:204`
- `Dio::master_aggregate` — `vantage-diorama/src/dio/mod.rs:711`

The shape decision looks right and worth keeping: an aggregation returns a **new set**, not a number. `count(*)` is a one-row table, `GROUP BY` is one row per group, and both are ordinary sets you can condition, order or count again.

### What is missing

1. **Zero implementors.** `aggregate_vista` is overridden by no driver at all — SQL, Surreal, Mongo, REST all inherit the default `Ok(None)`, so every call takes the local path. Worth contrasting with `add_op_condition`, whose equivalent rollout did reach six backends.
2. **No `can_aggregate` capability.** `VistaCapabilities` has 17 `can_*` flags and none for aggregation, so a consumer cannot ask before calling — only call and interpret `None`.
3. **`ValueScenery` never attempts pushdown.** It still reduces over the cache unconditionally through its own `Aggregate` enum (`vantage-diorama/src/scenery/value.rs:79`). `master_aggregate` and `ValueScenery` are two disconnected paths and nothing bridges them.
4. **No observed-vs-authoritative split.** The requirement the original note pressed hardest is entirely unstarted.
5. **A rotted doc example.** `Dio::master_aggregate`'s doc builds its spec with `AggregateSpec::new("count", "failed").condition("Event", …)`. There is no `condition` method — the builder is `new`/`column`/`group_by`, and `AggregateSpec`'s own docs say conditions deliberately do not belong there. It is an ```` ```ignore ```` block, so nothing catches it.

### The decision I did not make

The local scan is coverage-honest — it aggregates what has been observed and climbs as hydration proceeds, and learn-6's `total rows` status value depends on exactly that. Pushing down changes what the number means: the same `sum(col)` becomes "total of everything" on one backend and "total of what we've seen" on another.

The original note says do not switch silently, and proposes surfacing it in the API (`sum` vs `sum_observed`). That is a product call, not a refactor, so this PR stops at documenting it.