### PR TITLE
fix: delete_all on a conditioned table deleted every row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.19"
+version = "0.6.20"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5923,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-table"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.20 — 2026-08-22
+
+- **Bug fix (data loss):** `delete_all` on a conditioned table deleted the whole
+  table. The SQLite, Postgres and MySQL sources built `DELETE FROM <table>` from
+  the table name alone and never read the table's conditions, so a caller that
+  narrowed a table and then deleted it lost every row. The conditions are now
+  applied, and an unconditioned table still truncates as before.
+
 ## 0.6.19 — 2026-08-16
 
 - The SQLite, Postgres and MySQL shells implement `preview_query`, returning the

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.19"
+version = "0.6.20"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -403,7 +403,14 @@ impl TableSource for MysqlDB {
     where
         E: Entity<Self::Value>,
     {
-        let delete = crate::mysql::statements::MysqlDelete::new(table.table_name());
+        // A conditioned table represents a SUBSET, so this deletes that subset.
+        // Dropping the conditions here would render `DELETE FROM t` and take
+        // the whole table — the caller asked to delete what the table stands
+        // for, and every read path already reads it as narrowed.
+        let mut delete = crate::mysql::statements::MysqlDelete::new(table.table_name());
+        for condition in table.conditions() {
+            delete = delete.with_condition(condition.clone());
+        }
         self.execute(&delete.expr()).await?;
         Ok(())
     }

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -403,10 +403,7 @@ impl TableSource for MysqlDB {
     where
         E: Entity<Self::Value>,
     {
-        // A conditioned table represents a SUBSET, so this deletes that subset.
-        // Dropping the conditions here would render `DELETE FROM t` and take
-        // the whole table — the caller asked to delete what the table stands
-        // for, and every read path already reads it as narrowed.
+        // A conditioned table is a subset — see the trait's contract.
         let mut delete = crate::mysql::statements::MysqlDelete::new(table.table_name());
         for condition in table.conditions() {
             delete = delete.with_condition(condition.clone());

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -433,10 +433,7 @@ impl TableSource for PostgresDB {
     where
         E: Entity<Self::Value>,
     {
-        // A conditioned table represents a SUBSET, so this deletes that subset.
-        // Dropping the conditions here would render `DELETE FROM t` and take
-        // the whole table — the caller asked to delete what the table stands
-        // for, and every read path already reads it as narrowed.
+        // A conditioned table is a subset — see the trait's contract.
         let mut delete = crate::postgres::statements::PostgresDelete::new(table.table_name());
         for condition in table.conditions() {
             delete = delete.with_condition(condition.clone());

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -433,7 +433,14 @@ impl TableSource for PostgresDB {
     where
         E: Entity<Self::Value>,
     {
-        let delete = crate::postgres::statements::PostgresDelete::new(table.table_name());
+        // A conditioned table represents a SUBSET, so this deletes that subset.
+        // Dropping the conditions here would render `DELETE FROM t` and take
+        // the whole table — the caller asked to delete what the table stands
+        // for, and every read path already reads it as narrowed.
+        let mut delete = crate::postgres::statements::PostgresDelete::new(table.table_name());
+        for condition in table.conditions() {
+            delete = delete.with_condition(condition.clone());
+        }
         self.execute(&delete.expr()).await?;
         Ok(())
     }

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -382,10 +382,7 @@ impl TableSource for SqliteDB {
     where
         E: Entity<Self::Value>,
     {
-        // A conditioned table represents a SUBSET, so this deletes that subset.
-        // Dropping the conditions here would render `DELETE FROM t` and take
-        // the whole table — the caller asked to delete what the table stands
-        // for, and every read path already reads it as narrowed.
+        // A conditioned table is a subset — see the trait's contract.
         let mut delete = crate::sqlite::statements::SqliteDelete::new(table.table_name());
         for condition in table.conditions() {
             delete = delete.with_condition(condition.clone());

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -382,7 +382,14 @@ impl TableSource for SqliteDB {
     where
         E: Entity<Self::Value>,
     {
-        let delete = crate::sqlite::statements::SqliteDelete::new(table.table_name());
+        // A conditioned table represents a SUBSET, so this deletes that subset.
+        // Dropping the conditions here would render `DELETE FROM t` and take
+        // the whole table — the caller asked to delete what the table stands
+        // for, and every read path already reads it as narrowed.
+        let mut delete = crate::sqlite::statements::SqliteDelete::new(table.table_name());
+        for condition in table.conditions() {
+            delete = delete.with_condition(condition.clone());
+        }
         self.execute(&delete.expr()).await?;
         Ok(())
     }

--- a/vantage-sql/tests/sqlite/4_editable_value_set.rs
+++ b/vantage-sql/tests/sqlite/4_editable_value_set.rs
@@ -139,3 +139,35 @@ async fn test_insert_return_id_value() {
         "hello world"
     );
 }
+
+// ── Conditioned deletes ────────────────────────────────────────────────────
+
+/// A conditioned table represents a SUBSET, so `delete_all` must delete that
+/// subset and nothing else. Reported from the field as total data loss: the
+/// condition was added, the delete ran, and every row went.
+#[tokio::test]
+async fn delete_all_on_a_conditioned_table_only_deletes_matching_rows() {
+    let (_db, mut table) = setup().await;
+    table.add_condition(vantage_sql::sqlite_expr!(
+        "{} = {}",
+        (table["name"]),
+        "Alpha"
+    ));
+
+    table.delete_all().await.unwrap();
+
+    // The condition names one row. The other must survive.
+    let survivors = Table::<SqliteDB, EmptyEntity>::new("item", _db.clone())
+        .with_id_column("id")
+        .with_column_of::<String>("name")
+        .with_column_of::<i64>("price")
+        .list_values()
+        .await
+        .unwrap();
+    assert!(
+        survivors.contains_key("b"),
+        "row 'b' did not match the condition but was deleted anyway — \
+         delete_all ignored the table's conditions and truncated the table",
+    );
+    assert_eq!(survivors.len(), 1, "only the matching row should have gone");
+}

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.17 — 2026-08-22
+
+- **Bug fix (data loss):** `delete_all` on a conditioned table deleted the whole
+  table. `delete_table_all_values` rendered a bare `DELETE <table>` and never
+  read the table's conditions, so a caller that narrowed a table and then
+  deleted it lost every row. The conditions are now applied.
+
 ## 0.6.16 — 2026-08-16
 
 - `SurrealTableShell` implements `preview_query`, returning the SurrealQL SELECT

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.16"
+version = "0.6.17"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -470,7 +470,14 @@ impl TableSource for SurrealDB {
     where
         E: Entity<Self::Value>,
     {
-        let delete = SurrealDelete::table(table.table_name());
+        // A conditioned table represents a SUBSET, so this deletes that subset.
+        // Dropping the conditions here would render a bare `DELETE <table>`
+        // and take everything — the caller asked to delete what the table
+        // stands for, and every read path already reads it as narrowed.
+        let mut delete = SurrealDelete::table(table.table_name());
+        for condition in table.conditions() {
+            delete = delete.with_condition(condition.clone());
+        }
         self.execute(&delete.expr()).await?;
         Ok(())
     }

--- a/vantage-surrealdb/src/surrealdb/impls/table_source.rs
+++ b/vantage-surrealdb/src/surrealdb/impls/table_source.rs
@@ -470,10 +470,7 @@ impl TableSource for SurrealDB {
     where
         E: Entity<Self::Value>,
     {
-        // A conditioned table represents a SUBSET, so this deletes that subset.
-        // Dropping the conditions here would render a bare `DELETE <table>`
-        // and take everything — the caller asked to delete what the table
-        // stands for, and every read path already reads it as narrowed.
+        // A conditioned table is a subset — see the trait's contract.
         let mut delete = SurrealDelete::table(table.table_name());
         for condition in table.conditions() {
             delete = delete.with_condition(condition.clone());

--- a/vantage-table/CHANGELOG.md
+++ b/vantage-table/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.17 — 2026-08-22
+
+- `TableSource::delete_table_all_values` documents that implementations must
+  honour `table.conditions()`. Four backends had built the statement from the
+  table name alone and truncated conditioned tables; the one-line doc it
+  replaces did not say otherwise.
+
 ## 0.6.16 — 2026-08-12
 
 - **Bug fix:** `get_ref_target_erased` replaces the typed

--- a/vantage-table/Cargo.toml
+++ b/vantage-table/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-table"
-version = "0.6.16"
+version = "0.6.17"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Table, Column, and operation traits for the Vantage data framework"

--- a/vantage-table/src/traits/table_source.rs
+++ b/vantage-table/src/traits/table_source.rs
@@ -231,7 +231,14 @@ pub trait TableSource: DataSource + Clone + 'static {
         E: Entity<Self::Value>,
         Self: Sized;
 
-    /// Delete all records (for WritableValueSet implementation)
+    /// Delete every record the table represents (for WritableValueSet).
+    ///
+    /// **Honour `table.conditions()`.** A conditioned table is a SUBSET, and
+    /// every read path already treats it as one, so deleting it must delete
+    /// that subset. An implementation that builds its statement from
+    /// `table_name()` alone silently truncates the table instead — the caller
+    /// narrowed to one row, and lost all of them. An unconditioned table
+    /// still deletes everything, which is the only case this looks like.
     async fn delete_table_all_values<E>(&self, table: &Table<Self, E>) -> Result<()>
     where
         E: Entity<Self::Value>,


### PR DESCRIPTION
Reported from the field on SQLite: a condition was added, the delete ran, and the whole table went. Reproduced, root-caused, and it is worse than reported — **four backends are affected, not one.**

## Root cause

`delete_table_all_values` built the statement from the table name alone and never read `table.conditions()`:

```rust
let delete = SqliteDelete::new(table.table_name());
self.execute(&delete.expr()).await?;
```

That renders `DELETE FROM item` — every row. The conditions were not mis-rendered or dropped downstream; they were never asked for.

The tell is that `delete_table_value` **directly above it** does apply `.with_condition(id_condition)`, and every read path (`list_table_values`, search, count) reads the table as narrowed. So a conditioned table is a subset everywhere except here.

## Affected

| Backend | Before | Status |
|---|---|---|
| SQLite | `DELETE FROM t` | **fixed** |
| Postgres | `DELETE FROM t` | **fixed** |
| MySQL | `DELETE FROM t` | **fixed** |
| SurrealDB | `DELETE t` | **fixed** |
| MongoDB | `delete_many(build_filter())` | already correct |
| redb | explicit `if table.conditions().count() > 0` branch | already correct |
| DynamoDB | `resolve_conditions(table.conditions())` | already correct |

So Postgres and MySQL were affected too, and MongoDB was not — the opposite of the guess in the report. Mongo, redb and DynamoDB each independently got this right, which is why it went unnoticed.

The Vista/diorama path is fixed by the same change: `delete_vista_all_values` calls `self.table.delete_all()`, and `add_eq_condition`/`add_op_condition` put conditions on that same table.

## Fix

Iterate `table.conditions()` into the delete builder. The builders already supported this — `with_condition` accumulates and renders `AND`-joined, and SurrealDB's render tests already covered multiple conditions. Nothing called it.

An unconditioned table still renders a bare `DELETE` and truncates, so the existing behaviour is unchanged.

## Test

`delete_all_on_a_conditioned_table_only_deletes_matching_rows` in `vantage-sql/tests/sqlite/4_editable_value_set.rs`. Two rows, a condition naming one, assert the other survives.

Confirmed failing before the fix:

```
row 'b' did not match the condition but was deleted anyway —
delete_all ignored the table's conditions and truncated the table
```

and passing after. Full SQLite suite: **192 passed, 0 failed.** `cargo clippy` clean, `cargo fmt` applied.

Postgres, MySQL and SurrealDB take the identical shape but their integration tests need live servers, so they are covered here by compilation and by the existing statement-render tests rather than by an executable regression test. Worth a second look if you want parity.

## Related, not fixed here

`delete_table_value` (delete-by-id) also ignores `table.conditions()` — it applies only the id predicate. On a table narrowed by, say, `tenant_id = 5`, deleting a known id from another tenant would succeed. Lower blast radius than this bug and a separate semantic call, so I left it alone rather than bundling it.

Bumps `vantage-sql` 0.6.19 → 0.6.20 and `vantage-surrealdb` 0.6.16 → 0.6.17 with changelog entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `delete_all` so deletes on filtered or conditioned tables affect only matching records.
  * Prevented unintended removal of all table data when conditions are present across SQLite, PostgreSQL, MySQL, and SurrealDB.
  * Unfiltered `delete_all` behavior remains unchanged.
* **Tests**
  * Added coverage confirming that non-matching records are preserved during conditioned deletes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->