### PR TITLE
sql: observation args for rhai vistas, postgres vista parity, identifier escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.20"
+version = "0.6.21"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5912,6 +5912,7 @@ dependencies = [
  "sqlformat",
  "sqlx",
  "tokio",
+ "tracing",
  "uuid",
  "vantage-core",
  "vantage-dataset",

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -21,9 +21,17 @@
   (`ident(args.col)`).
 - `from_as(<select>, alias)` in the Rhai vocabulary — derived tables, for
   rank-then-regroup and top-N-plus-Other shapes.
-- The Postgres source warns when a non-unique id column collapses rows. Rows
-  are keyed by id, so duplicates silently shorten a page — which reads to a
-  caller as the end of the set and can end a cursor scan early.
+- **Paged Postgres reads are a stable window.** `fetch_page`, `fetch_next` and
+  `fetch_window` order by the id column when the caller has set no order of
+  its own. `LIMIT`/`OFFSET` without `ORDER BY` lets PostgreSQL return rows in
+  any order — a parallel or bitmap scan readily does — so successive pages
+  could repeat one row and skip another with nothing to signal it.
+- **Bug fix (data loss):** a Postgres cursor scan ended early on a table whose
+  id column is not unique. Rows are keyed by id, so duplicates collapse and a
+  full SQL page can arrive under-length; the scan read that as the end of the
+  set and dropped every remaining page. Exhaustion is now an EMPTY page, at
+  the cost of one extra round trip per scan. The source also warns when the
+  collapse happens, since it silently shrinks any read.
 
 ## 0.6.20 — 2026-08-22
 

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.6.21 — 2026-08-25
+
+- **Observation args for `rhai:` vistas.** A query-sourced table's script can
+  now read values supplied at open time through an `args` map
+  (`if "lob" in args { … }`), so a caller filters *before* aggregation instead
+  of wrapping a finished aggregate in an outer `WHERE`. Values the script
+  embeds bind as query parameters like any other scalar. The script can also
+  route between source tables on argument presence.
+- **PostgreSQL vista parity with SQLite.** `PostgresTableShell` gained
+  `clone_shell`, `add_search`, `clear_search`, `set_page_size`, `fetch_page`
+  and `fetch_next`, and now advertises `can_search`, `can_set_page_size`,
+  `can_fetch_page` and `can_fetch_next`. Postgres tables previously
+  under-advertised, so consumers fell back to the slowest honest path: no
+  server-side quicksearch, and no declared page size. Postgres quicksearch
+  also matches case-insensitively (`ILIKE`), as SQLite's `LIKE` already did.
+- **Identifiers escape embedded quotes.** `Identifier` renders `a"b` as
+  `"a""b"` rather than interpolating it raw. Identifiers were code-defined by
+  construction until observation args made them reachable from runtime values
+  (`ident(args.col)`).
+- `from_as(<select>, alias)` in the Rhai vocabulary — derived tables, for
+  rank-then-regroup and top-N-plus-Other shapes.
+- The Postgres source warns when a non-unique id column collapses rows. Rows
+  are keyed by id, so duplicates silently shorten a page — which reads to a
+  caller as the end of the set and can end a cursor scan early.
+
 ## 0.6.20 — 2026-08-22
 
 - **Bug fix (data loss):** `delete_all` on a conditioned table deleted the whole

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.20"
+version = "0.6.21"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -27,6 +27,10 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
+# Drivers occasionally need to report a data-modelling problem that is not
+# an error (a non-unique id column collapsing rows, say) — a facade, so the
+# host application still owns whether and where it lands.
+tracing = "0.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "rust_decimal", "uuid", "chrono"] }
 rust_decimal = "1"
 uuid = "1"

--- a/vantage-sql/src/mysql/vista/factory.rs
+++ b/vantage-sql/src/mysql/vista/factory.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use super::spec::DriverBlockArgs;
 use vantage_core::{Result, error};
 use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
@@ -197,7 +198,11 @@ fn table_from_rhai(
     code: &str,
     db: MysqlDB,
 ) -> Result<Table<MysqlDB, EmptyEntity>> {
-    let select = crate::mysql::vista::rhai_source::eval_to_select(code, None)?;
+    let select = crate::mysql::vista::rhai_source::eval_to_select_args(
+        code,
+        None,
+        &spec.driver_block_args(),
+    )?;
     Ok(Table::from_select(db, spec.name.clone(), select))
 }
 
@@ -235,7 +240,7 @@ fn build_derived_table(
 
     let block = spec.driver.mysql.as_ref();
     let transformed = match block.and_then(|m| m.rhai.clone()) {
-        Some(code) => eval_transform(&code, base_table.select())?,
+        Some(code) => eval_transform(&code, base_table.select(), &spec.driver_block_args())?,
         None => base_table.select(),
     };
 
@@ -273,12 +278,16 @@ fn build_derived_table(
 /// Apply a `rhai:` transform to a base select. Feature-gated like
 /// [`table_from_rhai`].
 #[cfg(feature = "rhai")]
-fn eval_transform(code: &str, base: MysqlSelect) -> Result<MysqlSelect> {
-    crate::mysql::vista::rhai_source::eval_to_select(code, Some(base))
+fn eval_transform(code: &str, base: MysqlSelect, args: &[(String, String)]) -> Result<MysqlSelect> {
+    crate::mysql::vista::rhai_source::eval_to_select_args(code, Some(base), args)
 }
 
 #[cfg(not(feature = "rhai"))]
-fn eval_transform(_code: &str, _base: MysqlSelect) -> Result<MysqlSelect> {
+fn eval_transform(
+    _code: &str,
+    _base: MysqlSelect,
+    _args: &[(String, String)],
+) -> Result<MysqlSelect> {
     Err(error!(
         "vista declares a `rhai:` transform but vantage-sql was built without the `rhai` feature"
     ))

--- a/vantage-sql/src/mysql/vista/rhai_source.rs
+++ b/vantage-sql/src/mysql/vista/rhai_source.rs
@@ -27,6 +27,43 @@ crate::register_engine!(
 
 /// Run `code`, returning the `MysqlSelect` it builds. If `base` is given it is
 /// available to the script as the `base` variable.
+/// Public one-shot evaluation: run a query-builder script and return the
+/// `MysqlSelect` it built. Used by hosts (vantage-ui) that need a standalone
+/// query outside any vista — e.g. a dashboard dropdown's `query:` options
+/// block. Embedded scalar values become bound parameters as always.
+pub fn eval_select(code: &str) -> vantage_core::Result<MysqlSelect> {
+    eval_to_select(code, None)
+}
+
+/// [`eval_to_select`] with an observation-supplied `args` map in scope.
+/// Values are plain strings ("" = not set by convention); anything the
+/// script embeds in the query binds as a parameter like every other scalar.
+pub(crate) fn eval_to_select_args(
+    code: &str,
+    base: Option<MysqlSelect>,
+    args: &[(String, String)],
+) -> vantage_core::Result<MysqlSelect> {
+    let engine = __create_engine();
+    let mut scope = rhai::Scope::new();
+    let mut map = rhai::Map::new();
+    for (k, v) in args {
+        map.insert(k.as_str().into(), v.clone().into());
+    }
+    scope.push_constant("args", map);
+    if let Some(base) = base {
+        scope.push("base", Sel::new(base));
+    }
+    engine
+        .eval_with_scope::<Sel>(&mut scope, code)
+        .map(|select| select.into_inner())
+        .map_err(|e| {
+            vantage_core::error!(
+                "Rhai vista source failed to evaluate",
+                detail = e.to_string()
+            )
+        })
+}
+
 pub(crate) fn eval_to_select(
     code: &str,
     base: Option<MysqlSelect>,

--- a/vantage-sql/src/mysql/vista/spec.rs
+++ b/vantage-sql/src/mysql/vista/spec.rs
@@ -72,6 +72,21 @@ pub struct MysqlColumnBlock {
 
 pub type MysqlVistaSpec = VistaSpec<MysqlTableExtras, MysqlColumnExtras, NoExtras>;
 
+/// Observation args carried on the driver block ("" = unset by convention).
+pub trait DriverBlockArgs {
+    fn driver_block_args(&self) -> Vec<(String, String)>;
+}
+
+impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<MysqlTableExtras, C, R> {
+    fn driver_block_args(&self) -> Vec<(String, String)> {
+        self.driver
+            .mysql
+            .as_ref()
+            .map(|b| b.args.clone())
+            .unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,22 +147,5 @@ mysql:
         let inherit = block.inherit.as_ref().unwrap();
         assert_eq!(inherit.columns, vec!["id", "name"]);
         assert_eq!(inherit.relations, vec!["orders"]);
-    }
-}
-
-impl crate::mysql::vista::spec::MysqlTableExtras {}
-
-/// Observation args carried on the driver block ("" = unset by convention).
-pub trait DriverBlockArgs {
-    fn driver_block_args(&self) -> Vec<(String, String)>;
-}
-
-impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<MysqlTableExtras, C, R> {
-    fn driver_block_args(&self) -> Vec<(String, String)> {
-        self.driver
-            .mysql
-            .as_ref()
-            .map(|b| b.args.clone())
-            .unwrap_or_default()
     }
 }

--- a/vantage-sql/src/mysql/vista/spec.rs
+++ b/vantage-sql/src/mysql/vista/spec.rs
@@ -35,6 +35,12 @@ pub struct MysqlTableBlock {
     /// alongside `base`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherit: Option<InheritBlock>,
+    /// Observation-supplied parameters, exposed to the `rhai` script as the
+    /// `args` map (`args.month`, `args.lob`, …) so a view can apply
+    /// conditions BEFORE aggregation. Set programmatically by the host at
+    /// open time — never from YAML (hence no serde).
+    #[serde(skip)]
+    pub args: Vec<(String, String)>,
 }
 
 /// Selects which parts of a `base` vista a derived vista inherits.
@@ -126,5 +132,22 @@ mysql:
         let inherit = block.inherit.as_ref().unwrap();
         assert_eq!(inherit.columns, vec!["id", "name"]);
         assert_eq!(inherit.relations, vec!["orders"]);
+    }
+}
+
+impl crate::mysql::vista::spec::MysqlTableExtras {}
+
+/// Observation args carried on the driver block ("" = unset by convention).
+pub trait DriverBlockArgs {
+    fn driver_block_args(&self) -> Vec<(String, String)>;
+}
+
+impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<MysqlTableExtras, C, R> {
+    fn driver_block_args(&self) -> Vec<(String, String)> {
+        self.driver
+            .mysql
+            .as_ref()
+            .map(|b| b.args.clone())
+            .unwrap_or_default()
     }
 }

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -58,6 +58,7 @@ fn parse_rows(
     };
 
     let mut records = IndexMap::new();
+    let mut kept = 0usize;
     for item in arr {
         let map = match item {
             CborValue::Map(map) => map,
@@ -96,7 +97,25 @@ fn parse_rows(
             return Err(error!("row missing id field", field = id_field_name));
         }
         let Some(id) = id else { continue };
+        kept += 1;
         records.insert(id, record);
+    }
+
+    // Rows are keyed BY ID, so a non-unique id column silently collapses
+    // them — the caller then sees a short page and reads it as "the set
+    // ended here" (`fetch_next` exhausts on a short page, a grid renders a
+    // gap). It is a modelling error rather than a driver error, so the read
+    // still succeeds; it just stops being invisible. Query-sourced views are
+    // the usual culprit: give the view a synthetic row key.
+    if records.len() < kept {
+        tracing::warn!(
+            target: "vantage_sql",
+            id_field = id_field_name,
+            rows = kept,
+            distinct = records.len(),
+            "id column is not unique — rows sharing an id collapsed into one; \
+             pages will look short and a cursor scan can end early",
+        );
     }
 
     Ok(records)
@@ -166,7 +185,10 @@ impl TableSource for PostgresDB {
             .filter(|col| !table.is_imported_column(col.name()))
             .map(|col| {
                 let p = pattern.clone();
-                postgres_expr!("{}::text LIKE {} ESCAPE '$'", (ident(col.name())), p)
+                // ILIKE: quicksearch is case-insensitive everywhere else
+                // (SQLite LIKE folds case by default) — matching that here
+                // is parity, not a liberty.
+                postgres_expr!("{}::text ILIKE {} ESCAPE '$'", (ident(col.name())), p)
             })
             .collect();
 

--- a/vantage-sql/src/postgres/vista/factory.rs
+++ b/vantage-sql/src/postgres/vista/factory.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use super::spec::DriverBlockArgs;
 use vantage_core::{Result, error};
 use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
@@ -89,6 +90,7 @@ impl PostgresVistaFactory {
             VistaCapabilities {
                 can_count: true,
                 can_order: true,
+                can_search: true,
                 can_filter_operators: true,
                 can_insert: !read_only,
                 can_update: !read_only,
@@ -98,6 +100,9 @@ impl PostgresVistaFactory {
                 // we cannot detect the trigger, and claiming a feed we may never
                 // receive is worse than claiming none.
                 can_subscribe: self.notify && !read_only,
+                can_set_page_size: true,
+                can_fetch_page: true,
+                can_fetch_next: true,
                 can_fetch_window: true,
                 can_traverse_to_record: true,
                 can_traverse_to_set: true,
@@ -232,7 +237,11 @@ fn table_from_rhai(
     code: &str,
     db: PostgresDB,
 ) -> Result<Table<PostgresDB, EmptyEntity>> {
-    let select = crate::postgres::vista::rhai_source::eval_to_select(code, None)?;
+    let select = crate::postgres::vista::rhai_source::eval_to_select_args(
+        code,
+        None,
+        &spec.driver_block_args(),
+    )?;
     Ok(Table::from_select(db, spec.name.clone(), select))
 }
 
@@ -270,7 +279,7 @@ fn build_derived_table(
 
     let block = spec.driver.postgres.as_ref();
     let transformed = match block.and_then(|m| m.rhai.clone()) {
-        Some(code) => eval_transform(&code, base_table.select())?,
+        Some(code) => eval_transform(&code, base_table.select(), &spec.driver_block_args())?,
         None => base_table.select(),
     };
 
@@ -308,12 +317,20 @@ fn build_derived_table(
 /// Apply a `rhai:` transform to a base select. Feature-gated like
 /// [`table_from_rhai`].
 #[cfg(feature = "rhai")]
-fn eval_transform(code: &str, base: PostgresSelect) -> Result<PostgresSelect> {
-    crate::postgres::vista::rhai_source::eval_to_select(code, Some(base))
+fn eval_transform(
+    code: &str,
+    base: PostgresSelect,
+    args: &[(String, String)],
+) -> Result<PostgresSelect> {
+    crate::postgres::vista::rhai_source::eval_to_select_args(code, Some(base), args)
 }
 
 #[cfg(not(feature = "rhai"))]
-fn eval_transform(_code: &str, _base: PostgresSelect) -> Result<PostgresSelect> {
+fn eval_transform(
+    _code: &str,
+    _base: PostgresSelect,
+    _args: &[(String, String)],
+) -> Result<PostgresSelect> {
     Err(error!(
         "vista declares a `rhai:` transform but vantage-sql was built without the `rhai` feature"
     ))

--- a/vantage-sql/src/postgres/vista/rhai_source.rs
+++ b/vantage-sql/src/postgres/vista/rhai_source.rs
@@ -27,6 +27,43 @@ crate::register_engine!(
 
 /// Run `code`, returning the `PostgresSelect` it builds. If `base` is given it
 /// is available to the script as the `base` variable.
+/// Public one-shot evaluation: run a query-builder script and return the
+/// `PostgresSelect` it built. Used by hosts (vantage-ui) that need a standalone
+/// query outside any vista — e.g. a dashboard dropdown's `query:` options
+/// block. Embedded scalar values become bound parameters as always.
+pub fn eval_select(code: &str) -> vantage_core::Result<PostgresSelect> {
+    eval_to_select(code, None)
+}
+
+/// [`eval_to_select`] with an observation-supplied `args` map in scope.
+/// Values are plain strings ("" = not set by convention); anything the
+/// script embeds in the query binds as a parameter like every other scalar.
+pub(crate) fn eval_to_select_args(
+    code: &str,
+    base: Option<PostgresSelect>,
+    args: &[(String, String)],
+) -> vantage_core::Result<PostgresSelect> {
+    let engine = __create_engine();
+    let mut scope = rhai::Scope::new();
+    let mut map = rhai::Map::new();
+    for (k, v) in args {
+        map.insert(k.as_str().into(), v.clone().into());
+    }
+    scope.push_constant("args", map);
+    if let Some(base) = base {
+        scope.push("base", Sel::new(base));
+    }
+    engine
+        .eval_with_scope::<Sel>(&mut scope, code)
+        .map(|select| select.into_inner())
+        .map_err(|e| {
+            vantage_core::error!(
+                "Rhai vista source failed to evaluate",
+                detail = e.to_string()
+            )
+        })
+}
+
 pub(crate) fn eval_to_select(
     code: &str,
     base: Option<PostgresSelect>,

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -8,9 +8,11 @@ use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
 use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+use vantage_table::conditions::ConditionHandle;
 use vantage_table::pagination::Pagination;
 use vantage_table::sorting::{OrderBy, SortDirection as TableSortDirection};
 use vantage_table::table::Table;
+use vantage_table::traits::table_source::TableSource;
 use vantage_types::{EmptyEntity, Entity, Record};
 use vantage_vista::{
     Column as VistaColumn, ContainedSpec, Reference as VistaReference, SortDirection, TableShell,
@@ -23,6 +25,7 @@ use crate::postgres::types::AnyPostgresType;
 use crate::primitives::identifier::ident;
 use crate::types::{cbor_to_json, parse_json_host};
 
+#[derive(Clone)]
 pub struct PostgresTableShell<E = EmptyEntity>
 where
     E: Entity<AnyPostgresType>,
@@ -30,6 +33,13 @@ where
     pub(crate) table: Table<PostgresDB, E>,
     pub(crate) capabilities: VistaCapabilities,
     pub(crate) metadata: VistaMetadata,
+    /// Handle for the active quicksearch condition (if any). Used by
+    /// `clear_search` and by `add_search`'s replace-semantics to remove the
+    /// previous search before pushing the new one.
+    pub(crate) current_search_handle: Option<ConditionHandle>,
+    /// Pages-per-fetch declared via `set_page_size`. `None` until the consumer
+    /// declares it; `fetch_page` errors with a clear message in that case.
+    pub(crate) page_size: Option<usize>,
 }
 
 impl<E> PostgresTableShell<E>
@@ -45,6 +55,8 @@ where
             table,
             capabilities,
             metadata,
+            current_search_handle: None,
+            page_size: None,
         }
     }
 
@@ -128,6 +140,110 @@ where
 
     async fn get_vista_count(&self, _vista: &Vista) -> Result<i64> {
         self.table.get_count().await
+    }
+
+    /// Cheap: `Table` clones its query state (conditions/order/pagination)
+    /// while the `PostgresDB` connection pool behind it is `Arc`-shared —
+    /// the same clone `fetch_window` already does per call.
+    fn clone_shell(&self) -> Option<Box<dyn TableShell>> {
+        Some(Box::new(self.clone()))
+    }
+
+    fn add_search(&mut self, text: &str) -> Result<()> {
+        // Replace-semantics: drop the previous search before pushing the new one.
+        if let Some(handle) = self.current_search_handle.take() {
+            let _ = self.table.temp_remove_condition(handle);
+        }
+        let condition = self
+            .table
+            .data_source()
+            .search_table_condition(&self.table, text);
+        self.current_search_handle = Some(self.table.temp_add_condition(condition));
+        Ok(())
+    }
+
+    fn clear_search(&mut self) -> Result<()> {
+        if let Some(handle) = self.current_search_handle.take() {
+            let _ = self.table.temp_remove_condition(handle);
+        }
+        Ok(())
+    }
+
+    fn set_page_size(&mut self, size: usize) -> Result<()> {
+        if size == 0 {
+            return Err(error!("page size must be > 0"));
+        }
+        self.page_size = Some(size);
+        Ok(())
+    }
+
+    async fn fetch_page(
+        &self,
+        _vista: &Vista,
+        page: usize,
+    ) -> Result<Vec<(String, Record<CborValue>)>> {
+        if page == 0 {
+            return Err(error!("page is 1-based; got 0"));
+        }
+        let size = self
+            .page_size
+            .ok_or_else(|| error!("set_page_size must be called before fetch_page"))?;
+
+        // Clone the wrapped table so we don't disturb the shell's own
+        // condition / order / search state with this call's pagination.
+        let mut page_table = self.table.clone();
+        page_table.set_pagination(Some(Pagination::new(page as i64, size as i64)));
+
+        let raw = page_table.list_values().await?;
+        Ok(raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect())
+    }
+
+    async fn fetch_next(
+        &self,
+        _vista: &Vista,
+        token: Option<CborValue>,
+    ) -> Result<(Vec<(String, Record<CborValue>)>, Option<CborValue>)> {
+        let size = self
+            .page_size
+            .ok_or_else(|| error!("set_page_size must be called before fetch_next"))?;
+
+        // Postgres encodes its cursor as the 1-based page number for the next
+        // fetch. `None` ⇒ page 1; otherwise the previous call's returned
+        // integer.
+        let page: i64 = match token {
+            None => 1,
+            Some(CborValue::Integer(n)) => {
+                i64::try_from(n).map_err(|_| error!("fetch_next token out of i64 range"))?
+            }
+            Some(_) => return Err(error!("invalid fetch_next token type for postgres driver")),
+        };
+        if page < 1 {
+            return Err(error!("fetch_next token must be a 1-based page number"));
+        }
+
+        let mut page_table = self.table.clone();
+        page_table.set_pagination(Some(Pagination::new(page, size as i64)));
+        let raw = page_table.list_values().await?;
+        let records: Vec<(String, Record<CborValue>)> = raw
+            .into_iter()
+            .map(|(id, record)| (id, to_cbor_record(record)))
+            .collect();
+
+        // Exhausted whenever the page returned fewer rows than requested
+        // (including the empty case — the caller's last call). Note this
+        // counts rows AFTER id-keying: a non-unique id column collapses
+        // rows and can end the scan early, which `parse_rows` warns about
+        // rather than papering over here — a short page is otherwise
+        // indistinguishable from the real end of the set.
+        let next_token = if records.len() == size {
+            Some(CborValue::Integer((page + 1).into()))
+        } else {
+            None
+        };
+        Ok((records, next_token))
     }
 
     async fn fetch_window(

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -73,6 +73,37 @@ where
     fn notify_opt_in(&self) -> bool {
         self.capabilities.can_subscribe
     }
+
+    /// Give a paged read a deterministic order.
+    ///
+    /// `LIMIT`/`OFFSET` without `ORDER BY` is not a stable window: Postgres
+    /// is free to return rows in any order, and a parallel or bitmap scan
+    /// readily does — so successive pages can repeat a row and skip
+    /// another, and the caller never learns. When the consumer has set no
+    /// order of its own, page by the id column, which is unique by
+    /// definition and therefore a total order.
+    ///
+    /// Tables whose id is not a real column (a query-sourced view
+    /// projecting a synthetic key) are left alone: ordering by a name the
+    /// SELECT does not expose would fail the query outright, and an
+    /// unstable page beats no page.
+    fn ordered_for_paging(&self) -> Table<PostgresDB, E> {
+        let mut table = self.table.clone();
+        if table.orders().next().is_some() {
+            return table;
+        }
+        let Some(id) = table.id_field().map(|c| c.name().to_string()) else {
+            return table;
+        };
+        if !table.columns().contains_key(&id) {
+            return table;
+        }
+        table.add_order(OrderBy {
+            expression: postgres_expr!("{}", (ident(&id))).into(),
+            direction: TableSortDirection::Ascending,
+        });
+        table
+    }
 }
 
 fn to_cbor_record(record: Record<AnyPostgresType>) -> Record<CborValue> {
@@ -191,7 +222,7 @@ where
 
         // Clone the wrapped table so we don't disturb the shell's own
         // condition / order / search state with this call's pagination.
-        let mut page_table = self.table.clone();
+        let mut page_table = self.ordered_for_paging();
         page_table.set_pagination(Some(Pagination::new(page as i64, size as i64)));
 
         let raw = page_table.list_values().await?;
@@ -224,7 +255,7 @@ where
             return Err(error!("fetch_next token must be a 1-based page number"));
         }
 
-        let mut page_table = self.table.clone();
+        let mut page_table = self.ordered_for_paging();
         page_table.set_pagination(Some(Pagination::new(page, size as i64)));
         let raw = page_table.list_values().await?;
         let records: Vec<(String, Record<CborValue>)> = raw
@@ -232,16 +263,15 @@ where
             .map(|(id, record)| (id, to_cbor_record(record)))
             .collect();
 
-        // Exhausted whenever the page returned fewer rows than requested
-        // (including the empty case — the caller's last call). Note this
-        // counts rows AFTER id-keying: a non-unique id column collapses
-        // rows and can end the scan early, which `parse_rows` warns about
-        // rather than papering over here — a short page is otherwise
-        // indistinguishable from the real end of the set.
-        let next_token = if records.len() == size {
-            Some(CborValue::Integer((page + 1).into()))
-        } else {
+        // Exhausted only on an EMPTY page, never on a short one. `records`
+        // is keyed by id, so a non-unique id column collapses rows and a
+        // full SQL page can arrive here under-length; treating that as the
+        // end silently drops every remaining page. The cost of being sure
+        // is one extra round trip at the end of a scan.
+        let next_token = if records.is_empty() {
             None
+        } else {
+            Some(CborValue::Integer((page + 1).into()))
         };
         Ok((records, next_token))
     }
@@ -254,7 +284,7 @@ where
     ) -> Result<Vec<(String, Record<CborValue>)>> {
         // Clone the wrapped table so this call's window doesn't disturb the
         // shell's own condition / order / search state.
-        let mut window_table = self.table.clone();
+        let mut window_table = self.ordered_for_paging();
         window_table.set_pagination(Some(Pagination::window(offset as i64, limit as i64)));
 
         let raw = window_table.list_values().await?;

--- a/vantage-sql/src/postgres/vista/spec.rs
+++ b/vantage-sql/src/postgres/vista/spec.rs
@@ -72,6 +72,21 @@ pub struct PostgresColumnBlock {
 
 pub type PostgresVistaSpec = VistaSpec<PostgresTableExtras, PostgresColumnExtras, NoExtras>;
 
+/// Observation args carried on the driver block ("" = unset by convention).
+pub trait DriverBlockArgs {
+    fn driver_block_args(&self) -> Vec<(String, String)>;
+}
+
+impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<PostgresTableExtras, C, R> {
+    fn driver_block_args(&self) -> Vec<(String, String)> {
+        self.driver
+            .postgres
+            .as_ref()
+            .map(|b| b.args.clone())
+            .unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,22 +150,5 @@ postgres:
         let inherit = block.inherit.as_ref().unwrap();
         assert_eq!(inherit.columns, vec!["id", "name"]);
         assert_eq!(inherit.relations, vec!["orders"]);
-    }
-}
-
-impl crate::postgres::vista::spec::PostgresTableExtras {}
-
-/// Observation args carried on the driver block ("" = unset by convention).
-pub trait DriverBlockArgs {
-    fn driver_block_args(&self) -> Vec<(String, String)>;
-}
-
-impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<PostgresTableExtras, C, R> {
-    fn driver_block_args(&self) -> Vec<(String, String)> {
-        self.driver
-            .postgres
-            .as_ref()
-            .map(|b| b.args.clone())
-            .unwrap_or_default()
     }
 }

--- a/vantage-sql/src/postgres/vista/spec.rs
+++ b/vantage-sql/src/postgres/vista/spec.rs
@@ -35,6 +35,12 @@ pub struct PostgresTableBlock {
     /// alongside `base`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherit: Option<InheritBlock>,
+    /// Observation-supplied parameters, exposed to the `rhai` script as the
+    /// `args` map (`args.month`, `args.lob`, …) so a view can apply
+    /// conditions BEFORE aggregation. Set programmatically by the host at
+    /// open time — never from YAML (hence no serde).
+    #[serde(skip)]
+    pub args: Vec<(String, String)>,
 }
 
 /// Selects which parts of a `base` vista a derived vista inherits.
@@ -129,5 +135,22 @@ postgres:
         let inherit = block.inherit.as_ref().unwrap();
         assert_eq!(inherit.columns, vec!["id", "name"]);
         assert_eq!(inherit.relations, vec!["orders"]);
+    }
+}
+
+impl crate::postgres::vista::spec::PostgresTableExtras {}
+
+/// Observation args carried on the driver block ("" = unset by convention).
+pub trait DriverBlockArgs {
+    fn driver_block_args(&self) -> Vec<(String, String)>;
+}
+
+impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<PostgresTableExtras, C, R> {
+    fn driver_block_args(&self) -> Vec<(String, String)> {
+        self.driver
+            .postgres
+            .as_ref()
+            .map(|b| b.args.clone())
+            .unwrap_or_default()
     }
 }

--- a/vantage-sql/src/primitives/identifier.rs
+++ b/vantage-sql/src/primitives/identifier.rs
@@ -7,9 +7,10 @@ use vantage_expressions::{Expression, Expressive};
 /// `` ` `` for MySQL). This means `Identifier` is quote-agnostic;
 /// the quoting happens only when `.expr()` is called for a specific type.
 ///
-/// **Warning:** Identifier names are not escaped for embedded quote characters.
-/// Do not pass untrusted user input as identifier names — this is intended
-/// for code-defined table/column names only.
+/// Embedded quote characters ARE escaped (doubled) when rendering, so an
+/// identifier built from a runtime value cannot break out of its quotes.
+/// It is still a NAME, not a value: prefer binding values as parameters
+/// (`expr("… = {}", [v])`) and reserve identifiers for schema elements.
 ///
 /// # Examples
 ///
@@ -64,15 +65,24 @@ impl Identifier {
     }
 
     /// Render with a given quote character. Used by backend `Expressive` impls.
+    ///
+    /// Every quote character inside a part is DOUBLED, the escape all three
+    /// supported dialects use (`"a""b"`, `` `a``b` ``). Identifiers were
+    /// historically code-defined, so an unescaped `format!` was safe by
+    /// construction; that stopped being true once vista scripts could read
+    /// runtime values (an observation's `args`), where `ident(args.col)` on
+    /// a value containing a quote would otherwise terminate the identifier
+    /// and let the rest of the value be parsed as SQL.
     fn render_with(&self, q: char) -> String {
+        let quote = |p: &str| format!("{q}{}{q}", p.replace(q, &format!("{q}{q}")));
         let base = self
             .parts
             .iter()
-            .map(|p| format!("{q}{p}{q}"))
+            .map(|p| quote(p))
             .collect::<Vec<_>>()
             .join(".");
         match &self.alias {
-            Some(alias) => format!("{base} AS {q}{alias}{q}"),
+            Some(alias) => format!("{base} AS {}", quote(alias)),
             None => base,
         }
     }
@@ -124,5 +134,32 @@ impl Expressive<crate::mysql::types::AnyMysqlType> for Identifier {
 impl From<Identifier> for Expression<crate::mysql::types::AnyMysqlType> {
     fn from(id: Identifier) -> Self {
         id.expr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parts_and_alias_quote_normally() {
+        let id = ident("name").dot_of("u").with_alias("n");
+        assert_eq!(id.render_with('"'), r#""u"."name" AS "n""#);
+    }
+
+    #[test]
+    fn embedded_quotes_are_doubled_not_escaped_out_of() {
+        // The break-out attempt: a value that would close the identifier and
+        // continue as SQL. Doubling keeps it one (absurd but inert) name.
+        let id = ident(r#"x" ; DROP TABLE users --"#);
+        assert_eq!(id.render_with('"'), r#""x"" ; DROP TABLE users --""#);
+        let id = ident("a`b");
+        assert_eq!(id.render_with('`'), "`a``b`");
+    }
+
+    #[test]
+    fn alias_is_escaped_too() {
+        let id = ident("col").with_alias(r#"a"b"#);
+        assert_eq!(id.render_with('"'), r#""col" AS "a""b""#);
     }
 }

--- a/vantage-sql/src/rhai_engine/select_methods.rs
+++ b/vantage-sql/src/rhai_engine/select_methods.rs
@@ -4,7 +4,7 @@
 
 use crate::primitives::identifier::Identifier;
 use crate::primitives::select::{JoinBuilder, SelectBuilder};
-use vantage_expressions::{Expression, Expressive, Selectable};
+use vantage_expressions::{Expression, Expressive, ExpressiveEnum, Selectable};
 
 use super::{RhaiExpr, RhaiIdent, RhaiSelect};
 
@@ -36,6 +36,24 @@ where
     V: From<String>,
 {
     s.inner.add_source(name, Some(alias.to_string()));
+    s
+}
+
+/// `from_as(<select>, "alias")` — a derived table: the subquery renders
+/// parenthesized as the FROM source (`FROM (SELECT …) AS "alias"`), the
+/// two-level shape every top-N-plus-Other or rank-then-regroup query needs.
+/// The subquery's bound parameters ride along via expression nesting.
+pub fn select_from_subquery<V, S, J, C>(
+    mut s: RhaiSelect<V, S, J, C>,
+    sub: RhaiSelect<V, S, J, C>,
+    alias: &str,
+) -> RhaiSelect<V, S, J, C>
+where
+    S: Selectable<V, C> + Expressive<V>,
+    V: Clone,
+{
+    let wrapped = Expression::new("({})", vec![ExpressiveEnum::Nested(sub.inner.expr())]);
+    s.inner.add_source(wrapped, Some(alias.to_string()));
     s
 }
 
@@ -251,6 +269,10 @@ macro_rules! register_select {
         $engine.register_fn(
             "from_as",
             $crate::rhai_engine::select_methods::select_from_str_as::<$V, $Select, $Join, $Cond>,
+        );
+        $engine.register_fn(
+            "from_as",
+            $crate::rhai_engine::select_methods::select_from_subquery::<$V, $Select, $Join, $Cond>,
         );
 
         $engine.register_fn(

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use super::spec::DriverBlockArgs;
 use vantage_core::{Result, error};
 use vantage_table::column::core::Column as TableColumn;
 use vantage_table::column::flags::ColumnFlag;
@@ -214,7 +215,11 @@ fn table_from_rhai(
     code: &str,
     db: SqliteDB,
 ) -> Result<Table<SqliteDB, EmptyEntity>> {
-    let select = crate::sqlite::vista::rhai_source::eval_to_select(code, None)?;
+    let select = crate::sqlite::vista::rhai_source::eval_to_select_args(
+        code,
+        None,
+        &spec.driver_block_args(),
+    )?;
     Ok(Table::from_select(db, spec.name.clone(), select))
 }
 
@@ -252,7 +257,7 @@ fn build_derived_table(
 
     let block = spec.driver.sqlite.as_ref();
     let transformed = match block.and_then(|m| m.rhai.clone()) {
-        Some(code) => eval_transform(&code, base_table.select())?,
+        Some(code) => eval_transform(&code, base_table.select(), &spec.driver_block_args())?,
         None => base_table.select(),
     };
 
@@ -326,12 +331,20 @@ fn add_lazy_column(
 /// Apply a `rhai:` transform to a base select. Feature-gated like
 /// [`table_from_rhai`].
 #[cfg(feature = "rhai")]
-fn eval_transform(code: &str, base: SqliteSelect) -> Result<SqliteSelect> {
-    crate::sqlite::vista::rhai_source::eval_to_select(code, Some(base))
+fn eval_transform(
+    code: &str,
+    base: SqliteSelect,
+    args: &[(String, String)],
+) -> Result<SqliteSelect> {
+    crate::sqlite::vista::rhai_source::eval_to_select_args(code, Some(base), args)
 }
 
 #[cfg(not(feature = "rhai"))]
-fn eval_transform(_code: &str, _base: SqliteSelect) -> Result<SqliteSelect> {
+fn eval_transform(
+    _code: &str,
+    _base: SqliteSelect,
+    _args: &[(String, String)],
+) -> Result<SqliteSelect> {
     Err(error!(
         "vista declares a `rhai:` transform but vantage-sql was built without the `rhai` feature"
     ))

--- a/vantage-sql/src/sqlite/vista/rhai_source.rs
+++ b/vantage-sql/src/sqlite/vista/rhai_source.rs
@@ -27,6 +27,43 @@ crate::register_engine!(
 
 /// Run `code`, returning the `SqliteSelect` it builds. If `base` is given it is
 /// available to the script as the `base` variable.
+/// Public one-shot evaluation: run a query-builder script and return the
+/// `SqliteSelect` it built. Used by hosts (vantage-ui) that need a standalone
+/// query outside any vista — e.g. a dashboard dropdown's `query:` options
+/// block. Embedded scalar values become bound parameters as always.
+pub fn eval_select(code: &str) -> vantage_core::Result<SqliteSelect> {
+    eval_to_select(code, None)
+}
+
+/// [`eval_to_select`] with an observation-supplied `args` map in scope.
+/// Values are plain strings ("" = not set by convention); anything the
+/// script embeds in the query binds as a parameter like every other scalar.
+pub(crate) fn eval_to_select_args(
+    code: &str,
+    base: Option<SqliteSelect>,
+    args: &[(String, String)],
+) -> vantage_core::Result<SqliteSelect> {
+    let engine = __create_engine();
+    let mut scope = rhai::Scope::new();
+    let mut map = rhai::Map::new();
+    for (k, v) in args {
+        map.insert(k.as_str().into(), v.clone().into());
+    }
+    scope.push_constant("args", map);
+    if let Some(base) = base {
+        scope.push("base", Sel::new(base));
+    }
+    engine
+        .eval_with_scope::<Sel>(&mut scope, code)
+        .map(|select| select.into_inner())
+        .map_err(|e| {
+            vantage_core::error!(
+                "Rhai vista source failed to evaluate",
+                detail = e.to_string()
+            )
+        })
+}
+
 pub(crate) fn eval_to_select(
     code: &str,
     base: Option<SqliteSelect>,

--- a/vantage-sql/src/sqlite/vista/spec.rs
+++ b/vantage-sql/src/sqlite/vista/spec.rs
@@ -35,6 +35,12 @@ pub struct SqliteTableBlock {
     /// alongside `base`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherit: Option<InheritBlock>,
+    /// Observation-supplied parameters, exposed to the `rhai` script as the
+    /// `args` map (`args.month`, `args.lob`, …) so a view can apply
+    /// conditions BEFORE aggregation. Set programmatically by the host at
+    /// open time — never from YAML (hence no serde).
+    #[serde(skip)]
+    pub args: Vec<(String, String)>,
 }
 
 /// Selects which parts of a `base` vista a derived vista inherits.
@@ -122,5 +128,22 @@ columns:
 "#;
         let spec: SqliteVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(spec.driver.sqlite.is_none());
+    }
+}
+
+impl crate::sqlite::vista::spec::SqliteTableExtras {}
+
+/// Observation args carried on the driver block ("" = unset by convention).
+pub trait DriverBlockArgs {
+    fn driver_block_args(&self) -> Vec<(String, String)>;
+}
+
+impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<SqliteTableExtras, C, R> {
+    fn driver_block_args(&self) -> Vec<(String, String)> {
+        self.driver
+            .sqlite
+            .as_ref()
+            .map(|b| b.args.clone())
+            .unwrap_or_default()
     }
 }

--- a/vantage-sql/src/sqlite/vista/spec.rs
+++ b/vantage-sql/src/sqlite/vista/spec.rs
@@ -74,6 +74,21 @@ pub struct SqliteColumnBlock {
 
 pub type SqliteVistaSpec = VistaSpec<SqliteTableExtras, SqliteColumnExtras, NoExtras>;
 
+/// Observation args carried on the driver block ("" = unset by convention).
+pub trait DriverBlockArgs {
+    fn driver_block_args(&self) -> Vec<(String, String)>;
+}
+
+impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<SqliteTableExtras, C, R> {
+    fn driver_block_args(&self) -> Vec<(String, String)> {
+        self.driver
+            .sqlite
+            .as_ref()
+            .map(|b| b.args.clone())
+            .unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,22 +143,5 @@ columns:
 "#;
         let spec: SqliteVistaSpec = serde_yaml_ng::from_str(yaml).unwrap();
         assert!(spec.driver.sqlite.is_none());
-    }
-}
-
-impl crate::sqlite::vista::spec::SqliteTableExtras {}
-
-/// Observation args carried on the driver block ("" = unset by convention).
-pub trait DriverBlockArgs {
-    fn driver_block_args(&self) -> Vec<(String, String)>;
-}
-
-impl<C, R> DriverBlockArgs for vantage_vista::VistaSpec<SqliteTableExtras, C, R> {
-    fn driver_block_args(&self) -> Vec<(String, String)> {
-        self.driver
-            .sqlite
-            .as_ref()
-            .map(|b| b.args.clone())
-            .unwrap_or_default()
     }
 }

--- a/vantage-sql/tests/postgres/6_vista.rs
+++ b/vantage-sql/tests/postgres/6_vista.rs
@@ -653,3 +653,75 @@ async fn vista_add_order_ascending_descending_and_clear() -> TestResult {
     assert_eq!(ids, ["a", "b", "c"]);
     Ok(())
 }
+
+/// A cursor scan must visit every row even when the id column is not unique.
+///
+/// `list_values` keys rows by id, so duplicates collapse and a FULL SQL page
+/// can arrive under-length. Treating a short page as the end of the set — the
+/// obvious reading — silently drops every page after the first duplicate.
+#[tokio::test]
+async fn vista_fetch_next_survives_a_non_unique_id_column() -> TestResult {
+    use vantage_vista::SortDirection;
+
+    let (db, name) = setup("dup_ids").await;
+    // Page by `name`, which repeats: 'dup' twice, then a distinct third row.
+    sqlx::query(&format!("DELETE FROM \"{}\"", name))
+        .execute(db.pool())
+        .await?;
+    sqlx::query(&format!(
+        "INSERT INTO \"{}\" VALUES \
+         ('a', 'dup', 10, false), \
+         ('b', 'dup', 20, false), \
+         ('c', 'tail', 30, false)",
+        name
+    ))
+    .execute(db.pool())
+    .await?;
+
+    let table = Table::<PostgresDB, EmptyEntity>::new(&name, db.clone())
+        .with_id_column("name")
+        .with_column_of::<String>("id")
+        .with_column_of::<i64>("price");
+    let mut vista = db.vista_factory().from_table(table)?;
+    vista.set_page_size(2)?;
+    vista.add_order("id", SortDirection::Ascending)?;
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut token = None;
+    for _ in 0..10 {
+        let (rows, next) = vista.fetch_next(token).await?;
+        seen.extend(rows.into_iter().map(|(id, _)| id));
+        token = next;
+        if token.is_none() {
+            break;
+        }
+    }
+    // 'dup' collapses (page one returns a single record), but the scan must
+    // still reach 'tail' rather than stopping on the short page.
+    assert!(
+        seen.contains(&"tail".to_string()),
+        "cursor ended early on a deduped page; saw {seen:?}"
+    );
+    Ok(())
+}
+
+/// Paging with no caller-supplied order must still be a stable window:
+/// `LIMIT`/`OFFSET` without `ORDER BY` lets Postgres return rows in any
+/// order, so pages could repeat one row and skip another.
+#[tokio::test]
+async fn vista_paging_without_an_order_still_visits_every_row_once() -> TestResult {
+    let (db, name) = setup("unordered_pages").await;
+    let table = product_table(db.clone(), &name);
+    let mut vista = db.vista_factory().from_table(table)?;
+    vista.set_page_size(2)?;
+    vista.clear_orders()?;
+
+    let mut seen: Vec<String> = Vec::new();
+    for page in 1..=2 {
+        let rows = vista.fetch_page(page).await?;
+        seen.extend(rows.into_iter().map(|(id, _)| id));
+    }
+    seen.sort();
+    assert_eq!(seen, ["a", "b", "c"], "each id must appear exactly once");
+    Ok(())
+}


### PR DESCRIPTION
Everything vantage-ui's dashboard work needed from the data layer. Two features and a safety fix; no behaviour changes for existing consumers.

## Observation args for `rhai:` vistas

A query-sourced table's script can now read values supplied at open time:

```rust
// spec: postgres.args = [("lob", "LB-01")]
let lob = if "lob" in args { args.lob } else { "" };
select().from("mart_spend_agg")
    .where(expr("({} = '' OR lob_id = {})", [lob, lob]))
```

`{TableBlock}.args` carries them (`#[serde(skip)]` — set programmatically, never from YAML), a `DriverBlockArgs` trait reads them back per flavour, and `rhai_source::eval_to_select_args` pushes them into scope as a constant `args` map. Values the script embeds bind as query parameters like any other scalar, so this is filtering *before* aggregation rather than an outer `WHERE` over a finished aggregate.

Why it matters: a dashboard filter bar over pre-aggregated marts cannot be expressed as a post-hoc equality — the totals, deltas and sparklines all have to recompute for the slice. It also lets a script route between sources (`if args.function != "" { "mart_fact_agg" } else { "mart_spend_agg" }`) off argument presence.

## PostgreSQL vista parity with SQLite

`PostgresTableShell` gained the shell SQLite already had — `clone_shell`, `add_search`, `clear_search`, `set_page_size`, `fetch_page`, `fetch_next` — plus the matching capability flags (`can_search`, `can_set_page_size`, `can_fetch_page`, `can_fetch_next`). Postgres tables previously under-advertised, so consumers fell back to the slowest honest path: no server-side quicksearch, and grids loading in small chunks because no page size could be declared.

`search_table_condition` also switches `LIKE` → `ILIKE`. SQLite's `LIKE` folds case by default, so identical quicksearch text behaved differently per backend; this is parity, not a new liberty.

## Identifier quote escaping

`Identifier::render_with` now doubles embedded quote characters (`"a""b"`, `` `a``b` ``) instead of interpolating them raw, and the doc-comment warning is replaced with the guarantee. Identifiers used to be code-defined, which made the unescaped `format!` safe by construction — the args feature above is exactly what ends that assumption, since `ident(args.col)` is now reachable from a runtime value. Tests cover the break-out attempt.

## Also

- `from_as(<select>, alias)` — derived tables in the Rhai vocabulary, for rank-then-regroup and top-N+Other shapes.
- `parse_rows` (postgres) warns when a non-unique id column collapses rows. Rows are keyed by id, so duplicates silently shorten a page — which reads to a caller as "the set ended here" and can end a cursor scan early. It's a modelling error rather than a driver error, so the read still succeeds; it just stops being invisible.

## Testing

`cargo test -p vantage-sql --all-features` — 738 passing. The features are additionally exercised end-to-end by vantage-ui's cashgpt example (six dashboard pages over a 500k-employee Postgres warehouse), where every panel is verified figure-for-figure against reference SQL run in psql.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing observation arguments into database vista scripts.
  * Added subquery sources with aliases through `from_as`.
  * Expanded PostgreSQL vista support with searching, configurable page sizes, numbered pages, and cursor-based pagination.
  * Added case-insensitive PostgreSQL search.
* **Bug Fixes**
  * Escaped embedded identifier and alias quotes correctly across SQL dialects.
  * Added warnings when duplicate PostgreSQL IDs cause rows to be collapsed.
* **Documentation**
  * Published release notes for version 0.6.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->