### PR TITLE
Servo in Rhai, bulk import, and nested-insert record links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,6 +5746,7 @@ name = "vantage-diorama"
 version = "0.12.4"
 dependencies = [
  "async-trait",
+ "chrono",
  "ciborium",
  "cucumber",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5753,6 +5753,7 @@ dependencies = [
  "insta",
  "libc",
  "redb",
+ "rhai",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.23"
+version = "0.6.24"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -13,6 +13,12 @@
   `rhai` feature gives queries — `get`/`set`/`dirty`/`error`/`status`/
   `rejection`/`revert`, and `save()` running the flash via `block_on`
   under the established spawn_blocking posture, returning the settled id.
+- `import_values` returns the number of records actually inserted: on the
+  per-record path an id the master already holds is skipped (drivers'
+  inserts are idempotent, so the write alone can't tell), still ticking
+  `progress` but not the count. A re-run of the same set reports zero.
+- `rhai::dynamic_to_cbor` maps a chrono instant to the standard CBOR
+  datetime (tag 0, RFC 3339) — a host's `now()` lands as a datetime.
 - A failed default write now says why in its message (`write failed:
   <driver error>`) instead of a bare "default write failed" with the cause
   buried in a detail field nothing rendered — the string is what a form

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.12.4 — 2026-08-29
+
+- `Dio::import_values(records, progress)` — bulk import that takes the
+  master's native path when it advertises `can_import` (one write, one
+  `DatasetChanged`) and otherwise falls back to per-record optimistic
+  `flash_insert`s. The fallback stops at the first failure naming the row
+  and id — an import never half-lands silently — and `progress(done,
+  total)` ticks per landed record for UIs to surface.
+- New `rhai` feature: `Servo` as a first-class Rhai type
+  (`rhai::register_servo_onto`), the same treatment vantage-vista's
+  `rhai` feature gives queries — `get`/`set`/`dirty`/`error`/`status`/
+  `rejection`/`revert`, and `save()` running the flash via `block_on`
+  under the established spawn_blocking posture, returning the settled id.
+
 ## 0.12.3 — 2026-08-16
 
 - `DioShell` implements `preview_query`. A facade read hits the local cache, so

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -15,8 +15,10 @@
   under the established spawn_blocking posture, returning the settled id.
 - `import_values` returns the number of records actually inserted: on the
   per-record path an id the master already holds is skipped (drivers'
-  inserts are idempotent, so the write alone can't tell), still ticking
-  `progress` but not the count. A re-run of the same set reports zero.
+  inserts are idempotent, so the write alone can't tell), and `progress`
+  ticks per **completed row**, skipped ones included, so a progress bar
+  tracks the walk through the set rather than the write count. A re-run
+  of the same set reports zero inserted.
 - `rhai::dynamic_to_cbor` maps a chrono instant to the standard CBOR
   datetime (tag 0, RFC 3339) — a host's `now()` lands as a datetime.
 - A failed default write now says why in its message (`write failed:

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -13,6 +13,10 @@
   `rhai` feature gives queries — `get`/`set`/`dirty`/`error`/`status`/
   `rejection`/`revert`, and `save()` running the flash via `block_on`
   under the established spawn_blocking posture, returning the settled id.
+- A failed default write now says why in its message (`write failed:
+  <driver error>`) instead of a bare "default write failed" with the cause
+  buried in a detail field nothing rendered — the string is what a form
+  footer or a wizard error line shows the user.
 
 ## 0.12.3 — 2026-08-16
 

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1"
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
+rhai = { version = "1.25", optional = true }
 futures = "0.3"
 indexmap = "2"
 redb = "2.6"
@@ -29,6 +30,11 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync", "rt", "time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v7"] }
+
+[features]
+# Servo as a first-class Rhai type — the same treatment vantage-vista's
+# `rhai` feature gives queries. See `src/rhai.rs`.
+rhai = ["dep:rhai"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -50,3 +56,7 @@ futures = "0.3"
 [[test]]
 name = "bdd"
 harness = false
+
+[[test]]
+name = "rhai_servo"
+required-features = ["rhai"]

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -21,6 +21,9 @@ serde_json = "1"
 
 async-trait = "0.1"
 ciborium = { version = "0.2", features = ["std"] }
+# Rhai scripts hand `dynamic_to_cbor` chrono instants (`now()`), which
+# land as the standard CBOR datetime tag.
+chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 rhai = { version = "1.25", optional = true }
 futures = "0.3"
 indexmap = "2"
@@ -34,12 +37,13 @@ uuid = { version = "1", features = ["v7"] }
 [features]
 # Servo as a first-class Rhai type — the same treatment vantage-vista's
 # `rhai` feature gives queries. See `src/rhai.rs`.
-rhai = ["dep:rhai"]
+rhai = ["dep:rhai", "dep:chrono"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 tempfile = "3"
 # Diagnostic output in loader tests (`with_test_writer` + env filter).
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/vantage-diorama/src/dio/import.rs
+++ b/vantage-diorama/src/dio/import.rs
@@ -29,17 +29,29 @@ impl Dio {
     /// record runs through [`flash_insert`](Dio::flash_insert) — views
     /// see rows land one by one, exactly as if a user had entered them.
     ///
-    /// `progress(done, total)` fires after every record that lands (once,
-    /// with the full count, on the native path). The fallback **stops at
-    /// the first failure**: the error names the failing row and id, and
-    /// `progress` has already reported how many landed — an import that
-    /// stops at row 3,000 says so precisely, it never half-lands
-    /// silently.
+    /// `progress(done, total)` fires after every **completed row** —
+    /// including a row skipped because its id was already there, which
+    /// counts toward `done` but not toward the result — so a progress
+    /// bar tracks the walk through the file rather than the write count.
+    /// The native path reports once, with the full count. The fallback
+    /// **stops at the first failure**: the error names the failing row
+    /// and id, and `progress` has already reported how far the walk got
+    /// — an import that stops at row 3,000 says so precisely, it never
+    /// half-lands silently.
     ///
     /// Returns the number of records actually inserted. On the fallback
     /// path an id the master already holds is skipped — it still counts
     /// toward `progress`, never toward the result — so a re-run of the
     /// same set reports zero rather than claiming the set again.
+    ///
+    /// The skip is decided by a read before the write, so the count is
+    /// exact only against a table nobody else is writing: a racing
+    /// writer that creates one of these ids in between has its record
+    /// kept (the driver's insert is idempotent — nothing is
+    /// overwritten), but this import counts that row as its own. The
+    /// count is a report for a person, and no data turns on it; making
+    /// it exact needs an insert-if-absent the driver contract does not
+    /// have today.
     pub async fn import_values(
         &self,
         records: IndexMap<String, Record<CborValue>>,

--- a/vantage-diorama/src/dio/import.rs
+++ b/vantage-diorama/src/dio/import.rs
@@ -11,6 +11,8 @@
 //!
 //! [`VistaCapabilities::can_import`]: vantage_vista::VistaCapabilities::can_import
 
+use std::ops::ControlFlow;
+
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
@@ -18,6 +20,32 @@ use vantage_dataset::traits::ReadableValueSet as _;
 use vantage_types::Record;
 
 use crate::dio::{Dio, DioEvent};
+
+/// What an import did — the numbers a caller reports to a person.
+///
+/// Separate fields rather than one count because the difference matters
+/// to whoever reads it: "imported 0 of 500" reads like a failure, while
+/// "0 imported, 500 already there" is the expected answer to importing
+/// the same file twice, and a caller cannot derive the second from the
+/// first (a retry after a partial import would get it wrong).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ImportOutcome {
+    /// Records this import created.
+    pub inserted: usize,
+    /// Rows whose id the table already held. Their records were left
+    /// exactly as they were — an import never overwrites.
+    pub skipped: usize,
+    /// The caller stopped the walk (see the `progress` callback);
+    /// `inserted + skipped` is then how far it got, not the whole set.
+    pub cancelled: bool,
+}
+
+impl ImportOutcome {
+    /// Rows the walk reached, landed or skipped.
+    pub fn processed(&self) -> usize {
+        self.inserted + self.skipped
+    }
+}
 
 impl Dio {
     /// Store `records` (id → record) in the master.
@@ -30,46 +58,56 @@ impl Dio {
     /// see rows land one by one, exactly as if a user had entered them.
     ///
     /// `progress(done, total)` fires after every **completed row** —
-    /// including a row skipped because its id was already there, which
-    /// counts toward `done` but not toward the result — so a progress
-    /// bar tracks the walk through the file rather than the write count.
-    /// The native path reports once, with the full count. The fallback
-    /// **stops at the first failure**: the error names the failing row
-    /// and id, and `progress` has already reported how far the walk got
-    /// — an import that stops at row 3,000 says so precisely, it never
-    /// half-lands silently.
+    /// including a row skipped because its id was already there — so a
+    /// progress bar tracks the walk through the set rather than the
+    /// write count. Returning [`ControlFlow::Break`] stops the walk
+    /// before the next row: that is the **only** way to interrupt an
+    /// import, and it is why the callback is called per row rather than
+    /// per write. What already landed stays landed (each row is its own
+    /// write), and the outcome says `cancelled`. The native path is
+    /// atomic by contract, so it reports once, at the end, and cannot be
+    /// interrupted.
     ///
-    /// Returns the number of records actually inserted. On the fallback
-    /// path an id the master already holds is skipped — it still counts
-    /// toward `progress`, never toward the result — so a re-run of the
-    /// same set reports zero rather than claiming the set again.
+    /// The fallback **stops at the first failure**: the error names the
+    /// failing row and id, and `progress` has already reported how far
+    /// the walk got — an import that stops at row 3,000 says so
+    /// precisely, it never half-lands silently.
     ///
-    /// The skip is decided by a read before the write, so the count is
+    /// An id the master already holds is skipped, on either path (the
+    /// native contract requires the driver to count only what it newly
+    /// inserted). So a re-run of the same set reports zero inserted
+    /// rather than claiming the set again.
+    ///
+    /// The skip is decided by a read before the write, so the counts are
     /// exact only against a table nobody else is writing: a racing
     /// writer that creates one of these ids in between has its record
     /// kept (the driver's insert is idempotent — nothing is
     /// overwritten), but this import counts that row as its own. The
-    /// count is a report for a person, and no data turns on it; making
-    /// it exact needs an insert-if-absent the driver contract does not
-    /// have today.
+    /// counts are a report for a person, and no data turns on them;
+    /// making them exact needs an insert-if-absent the driver contract
+    /// does not have today.
     pub async fn import_values(
         &self,
         records: IndexMap<String, Record<CborValue>>,
-        mut progress: impl FnMut(usize, usize) + Send,
-    ) -> Result<usize> {
+        mut progress: impl FnMut(usize, usize) -> ControlFlow<()> + Send,
+    ) -> Result<ImportOutcome> {
         let total = records.len();
         let master = self.master();
 
         if master.capabilities().can_import {
-            let stored = master.import_values(&records).await?;
+            let inserted = master.import_values(&records).await?;
             // The master holds the set now; make the cache agree and
             // announce membership moved — once, not per row.
             for (id, record) in &records {
                 self.cache().insert_value(id, record).await?;
             }
             let _ = self.inner.event_bus.send(DioEvent::DatasetChanged);
-            progress(total, total);
-            return Ok(stored);
+            let _ = progress(total, total);
+            return Ok(ImportOutcome {
+                inserted,
+                skipped: total.saturating_sub(inserted),
+                cancelled: false,
+            });
         }
 
         let stopped_at = |index: usize, id: &str, e: vantage_core::VantageError| {
@@ -86,7 +124,7 @@ impl Dio {
                 detail = e.to_string()
             )
         };
-        let mut inserted = 0;
+        let mut outcome = ImportOutcome::default();
         for (index, (id, record)) in records.iter().enumerate() {
             // A driver's insert is idempotent — an existing id comes back
             // as the stored record, not an error — so the count would
@@ -97,14 +135,19 @@ impl Dio {
                 .await
                 .map_err(|e| stopped_at(index, id, e))?
                 .is_some();
-            if !exists {
+            if exists {
+                outcome.skipped += 1;
+            } else {
                 self.flash_insert(id.clone(), record.clone())
                     .await
                     .map_err(|e| stopped_at(index, id, e))?;
-                inserted += 1;
+                outcome.inserted += 1;
             }
-            progress(index + 1, total);
+            if progress(index + 1, total).is_break() {
+                outcome.cancelled = true;
+                break;
+            }
         }
-        Ok(inserted)
+        Ok(outcome)
     }
 }

--- a/vantage-diorama/src/dio/import.rs
+++ b/vantage-diorama/src/dio/import.rs
@@ -1,0 +1,80 @@
+//! Bulk import — one entry point that picks the master's native path or
+//! the per-record optimistic fallback.
+//!
+//! The split of responsibilities: [`VistaCapabilities::can_import`]
+//! answers *whether the master can take the whole set in one operation*
+//! (SQL COPY, Surreal batch insert — all-or-nothing by contract);
+//! [`Dio::import_values`] answers *how these records get in regardless* —
+//! native when advertised, otherwise record by record through the same
+//! optimistic flash path a form save uses, where partial progress is
+//! honest and reportable.
+//!
+//! [`VistaCapabilities::can_import`]: vantage_vista::VistaCapabilities::can_import
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::{Result, error};
+use vantage_types::Record;
+
+use crate::dio::{Dio, DioEvent};
+
+impl Dio {
+    /// Store `records` (id → record) in the master.
+    ///
+    /// When the master advertises `can_import`, the whole set goes down
+    /// in one driver-native operation, the cache absorbs the records,
+    /// and sceneries hear a single
+    /// [`DatasetChanged`](DioEvent::DatasetChanged). Otherwise each
+    /// record runs through [`flash_insert`](Dio::flash_insert) — views
+    /// see rows land one by one, exactly as if a user had entered them.
+    ///
+    /// `progress(done, total)` fires after every record that lands (once,
+    /// with the full count, on the native path). The fallback **stops at
+    /// the first failure**: the error names the failing row and id, and
+    /// `progress` has already reported how many landed — an import that
+    /// stops at row 3,000 says so precisely, it never half-lands
+    /// silently.
+    ///
+    /// Returns the number of records stored.
+    pub async fn import_values(
+        &self,
+        records: IndexMap<String, Record<CborValue>>,
+        mut progress: impl FnMut(usize, usize) + Send,
+    ) -> Result<usize> {
+        let total = records.len();
+        let master = self.master();
+
+        if master.capabilities().can_import {
+            let stored = master.import_values(&records).await?;
+            // The master holds the set now; make the cache agree and
+            // announce membership moved — once, not per row.
+            for (id, record) in &records {
+                self.cache().insert_value(id, record).await?;
+            }
+            let _ = self.inner.event_bus.send(DioEvent::DatasetChanged);
+            progress(total, total);
+            return Ok(stored);
+        }
+
+        for (index, (id, record)) in records.iter().enumerate() {
+            self.flash_insert(id.clone(), record.clone())
+                .await
+                .map_err(|e| {
+                    error!(
+                        format!(
+                            "import stopped at row {} of {} (id '{}'): {}",
+                            index + 1,
+                            total,
+                            id,
+                            e
+                        ),
+                        row = index + 1,
+                        id = id.clone(),
+                        detail = e.to_string()
+                    )
+                })?;
+            progress(index + 1, total);
+        }
+        Ok(total)
+    }
+}

--- a/vantage-diorama/src/dio/import.rs
+++ b/vantage-diorama/src/dio/import.rs
@@ -14,6 +14,7 @@
 use ciborium::Value as CborValue;
 use indexmap::IndexMap;
 use vantage_core::{Result, error};
+use vantage_dataset::traits::ReadableValueSet as _;
 use vantage_types::Record;
 
 use crate::dio::{Dio, DioEvent};
@@ -35,7 +36,10 @@ impl Dio {
     /// stops at row 3,000 says so precisely, it never half-lands
     /// silently.
     ///
-    /// Returns the number of records stored.
+    /// Returns the number of records actually inserted. On the fallback
+    /// path an id the master already holds is skipped — it still counts
+    /// toward `progress`, never toward the result — so a re-run of the
+    /// same set reports zero rather than claiming the set again.
     pub async fn import_values(
         &self,
         records: IndexMap<String, Record<CborValue>>,
@@ -56,25 +60,39 @@ impl Dio {
             return Ok(stored);
         }
 
+        let stopped_at = |index: usize, id: &str, e: vantage_core::VantageError| {
+            error!(
+                format!(
+                    "import stopped at row {} of {} (id '{}'): {}",
+                    index + 1,
+                    total,
+                    id,
+                    e
+                ),
+                row = index + 1,
+                id = id.to_string(),
+                detail = e.to_string()
+            )
+        };
+        let mut inserted = 0;
         for (index, (id, record)) in records.iter().enumerate() {
-            self.flash_insert(id.clone(), record.clone())
+            // A driver's insert is idempotent — an existing id comes back
+            // as the stored record, not an error — so the count would
+            // otherwise claim every row landed. Ask first; an id already
+            // present is skipped and not counted.
+            let exists = master
+                .get_value(id)
                 .await
-                .map_err(|e| {
-                    error!(
-                        format!(
-                            "import stopped at row {} of {} (id '{}'): {}",
-                            index + 1,
-                            total,
-                            id,
-                            e
-                        ),
-                        row = index + 1,
-                        id = id.clone(),
-                        detail = e.to_string()
-                    )
-                })?;
+                .map_err(|e| stopped_at(index, id, e))?
+                .is_some();
+            if !exists {
+                self.flash_insert(id.clone(), record.clone())
+                    .await
+                    .map_err(|e| stopped_at(index, id, e))?;
+                inserted += 1;
+            }
             progress(index + 1, total);
         }
-        Ok(total)
+        Ok(inserted)
     }
 }

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -31,8 +31,8 @@ use ciborium::Value as CborValue;
 use vantage_types::Record;
 
 pub use event_bus::DioEvent;
-pub use import::ImportOutcome;
 pub use hot_tier::HotTier;
+pub use import::ImportOutcome;
 pub use shell::DioShell;
 
 /// Stringify a scalar CBOR id for use inside a cache table name. Non-scalars

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -4,6 +4,7 @@ pub mod diagnostics;
 pub mod event_bus;
 pub mod hot_tier;
 pub mod impls;
+mod import;
 mod optimistic;
 pub(crate) mod pending;
 pub(crate) mod query_index;

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -31,6 +31,7 @@ use ciborium::Value as CborValue;
 use vantage_types::Record;
 
 pub use event_bus::DioEvent;
+pub use import::ImportOutcome;
 pub use hot_tier::HotTier;
 pub use shell::DioShell;
 

--- a/vantage-diorama/src/dio/shell.rs
+++ b/vantage-diorama/src/dio/shell.rs
@@ -81,6 +81,10 @@ impl DioShell {
             can_insert: write_caps.can_insert,
             can_update: write_caps.can_update,
             can_delete: write_caps.can_delete,
+            // Bulk import goes through `Dio::import_values`, which picks
+            // the master's native path or the per-record fallback itself —
+            // the facade never takes an import.
+            can_import: false,
             can_subscribe: true,
             can_invalidate: master_caps.can_invalidate || has_on_event,
             // Ordering is always available: the facade pushes it into the

--- a/vantage-diorama/src/dio/worker.rs
+++ b/vantage-diorama/src/dio/worker.rs
@@ -102,5 +102,9 @@ async fn default_write(dio: &Dio, flash: ChangeFlash) -> Result<Option<Record<Cb
         FlashKind::Delete => master.delete(need_id()?).await.map(|()| None),
         FlashKind::Clear => master.delete_all().await.map(|()| None),
     }
-    .map_err(|e| error!("default write failed", detail = e.to_string()))
+    // The cause rides IN the message: this string is what a form footer
+    // or a wizard error line shows the user, and "default write failed"
+    // alone turns a fixable input problem (a missing `int` the backend
+    // named precisely) into a dead end.
+    .map_err(|e| error!(format!("write failed: {e}")))
 }

--- a/vantage-diorama/src/dio/worker.rs
+++ b/vantage-diorama/src/dio/worker.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use ciborium::Value as CborValue;
 use tokio::sync::mpsc;
-use vantage_core::{Result, error};
+use vantage_core::{Context as _, Result, error};
 use vantage_dataset::traits::WritableValueSet;
 use vantage_types::Record;
 
@@ -102,9 +102,13 @@ async fn default_write(dio: &Dio, flash: ChangeFlash) -> Result<Option<Record<Cb
         FlashKind::Delete => master.delete(need_id()?).await.map(|()| None),
         FlashKind::Clear => master.delete_all().await.map(|()| None),
     }
-    // The cause rides IN the message: this string is what a form footer
-    // or a wizard error line shows the user, and "default write failed"
-    // alone turns a fixable input problem (a missing `int` the backend
-    // named precisely) into a dead end.
-    .map_err(|e| error!(format!("write failed: {e}")))
+    // Wrapped, not replaced. The cause has to reach two audiences: a
+    // form footer or wizard error line, which shows this string and for
+    // which "default write failed" alone turns a fixable input problem
+    // (a missing `int` the backend named precisely) into a dead end;
+    // and `FlashRejection::from_error`, which walks the SOURCE chain for
+    // the per-field errors a form highlights. `context` keeps both —
+    // `Display` renders "write failed: <driver error>" and the driver's
+    // error stays reachable underneath.
+    .context(error!("write failed"))
 }

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -9,6 +9,8 @@ pub mod dio;
 pub mod error;
 pub mod lens;
 pub mod ops;
+#[cfg(feature = "rhai")]
+pub mod rhai;
 pub mod scenery;
 pub mod servo;
 pub mod stats;

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -19,9 +19,7 @@ pub use augment::{Augmentation, BuildFn, Detail, Fetch, FetchFn, MergeRule, Sour
 pub use composition::Diorama;
 pub use debug::{DebugTap, ProcessStats, process_stats};
 pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
-pub use dio::{
-    Dio, DioEvent, DioShell, Generation, ImportOutcome, WeakDio, WriteCapabilities,
-};
+pub use dio::{Dio, DioEvent, DioShell, Generation, ImportOutcome, WeakDio, WriteCapabilities};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
     Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkQuery, ChunkRow,

--- a/vantage-diorama/src/lib.rs
+++ b/vantage-diorama/src/lib.rs
@@ -19,7 +19,9 @@ pub use augment::{Augmentation, BuildFn, Detail, Fetch, FetchFn, MergeRule, Sour
 pub use composition::Diorama;
 pub use debug::{DebugTap, ProcessStats, process_stats};
 pub use dio::diagnostics::{DioDiagnostics, SceneryDiagnostic};
-pub use dio::{Dio, DioEvent, DioShell, Generation, WeakDio, WriteCapabilities};
+pub use dio::{
+    Dio, DioEvent, DioShell, Generation, ImportOutcome, WeakDio, WriteCapabilities,
+};
 pub use error::{DioError, LensBuildError};
 pub use lens::{
     Activity, ActivitySignal, CacheBackend, CacheStatus, CacheTable, ChunkQuery, ChunkRow,

--- a/vantage-diorama/src/rhai.rs
+++ b/vantage-diorama/src/rhai.rs
@@ -43,10 +43,7 @@ pub fn register_servo_onto(engine: &mut Engine) {
 
     engine.register_fn(
         "set",
-        |servo: &mut Arc<Servo>,
-         field: &str,
-         value: Dynamic|
-         -> Result<(), Box<EvalAltResult>> {
+        |servo: &mut Arc<Servo>, field: &str, value: Dynamic| -> Result<(), Box<EvalAltResult>> {
             servo.set(field, dynamic_to_cbor(&value)?);
             Ok(())
         },
@@ -107,7 +104,10 @@ pub fn register_servo_onto(engine: &mut Engine) {
                     fields.insert(field.as_str().into(), Dynamic::from(message.clone()));
                 }
                 let mut map = RhaiMap::new();
-                map.insert("message".into(), Dynamic::from(rejection.message().to_string()));
+                map.insert(
+                    "message".into(),
+                    Dynamic::from(rejection.message().to_string()),
+                );
                 map.insert("fields".into(), Dynamic::from_map(fields));
                 Dynamic::from_map(map)
             }
@@ -158,9 +158,7 @@ pub fn cbor_to_dynamic(value: &CborValue) -> Dynamic {
         CborValue::Float(f) => Dynamic::from(*f),
         CborValue::Text(s) => Dynamic::from(s.clone()),
         CborValue::Bytes(b) => Dynamic::from_blob(b.clone()),
-        CborValue::Array(items) => {
-            Dynamic::from_array(items.iter().map(cbor_to_dynamic).collect())
-        }
+        CborValue::Array(items) => Dynamic::from_array(items.iter().map(cbor_to_dynamic).collect()),
         CborValue::Map(pairs) => {
             let mut map = RhaiMap::new();
             for (k, v) in pairs {
@@ -201,7 +199,10 @@ pub fn dynamic_to_cbor(value: &Dynamic) -> Result<CborValue, Box<EvalAltResult>>
     // a datetime type reads as one; the SurrealDB driver accepts it
     // beside its own compact tag 12.
     if let Some(dt) = value.clone().try_cast::<chrono::DateTime<chrono::Utc>>() {
-        return Ok(CborValue::Tag(0, Box::new(CborValue::Text(dt.to_rfc3339()))));
+        return Ok(CborValue::Tag(
+            0,
+            Box::new(CborValue::Text(dt.to_rfc3339())),
+        ));
     }
     if let Some(array) = value.clone().try_cast::<rhai::Array>() {
         let items = array
@@ -217,5 +218,9 @@ pub fn dynamic_to_cbor(value: &Dynamic) -> Result<CborValue, Box<EvalAltResult>>
             .collect::<Result<Vec<_>, Box<EvalAltResult>>>()?;
         return Ok(CborValue::Map(pairs));
     }
-    Err(format!("no CBOR representation for rhai type '{}'", value.type_name()).into())
+    Err(format!(
+        "no CBOR representation for rhai type '{}'",
+        value.type_name()
+    )
+    .into())
 }

--- a/vantage-diorama/src/rhai.rs
+++ b/vantage-diorama/src/rhai.rs
@@ -196,6 +196,13 @@ pub fn dynamic_to_cbor(value: &Dynamic) -> Result<CborValue, Box<EvalAltResult>>
     if let Some(blob) = value.clone().try_cast::<rhai::Blob>() {
         return Ok(CborValue::Bytes(blob));
     }
+    // An instant (a host's `now()`) travels as the standard CBOR
+    // datetime — tag 0 over RFC 3339 text — which every driver that has
+    // a datetime type reads as one; the SurrealDB driver accepts it
+    // beside its own compact tag 12.
+    if let Some(dt) = value.clone().try_cast::<chrono::DateTime<chrono::Utc>>() {
+        return Ok(CborValue::Tag(0, Box::new(CborValue::Text(dt.to_rfc3339()))));
+    }
     if let Some(array) = value.clone().try_cast::<rhai::Array>() {
         let items = array
             .iter()

--- a/vantage-diorama/src/rhai.rs
+++ b/vantage-diorama/src/rhai.rs
@@ -1,0 +1,214 @@
+//! Rhai scripting surface over [`Servo`] — the same treatment
+//! vantage-vista's `rhai` feature gives queries.
+//!
+//! [`register_servo_onto`] teaches an engine the `Servo` type; the host
+//! pushes an `Arc<Servo>` into scope (or returns one from another
+//! registered fn) and scripts drive the draft with the same vocabulary
+//! the Rust API has:
+//!
+//! ```rhai
+//! servo.set("name", "Coffee");
+//! if servo.is_dirty() {
+//!     let id = servo.save();       // flash + settle; the record's id
+//! }
+//! ```
+//!
+//! Rhai is synchronous; [`Servo::flash`] is async. `save()` runs the
+//! flash via `Handle::current().block_on(…)`, which is only legal on a
+//! thread with a runtime *context* but no async *frame* — the same
+//! contract as vantage-vista's fetch verbs (see
+//! `vantage-vista/src/rhai/runtime.rs`): evaluate scripts under
+//! `tokio::task::spawn_blocking`, never directly inside an async task.
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap};
+use vantage_types::Record;
+
+use crate::servo::{Servo, ServoStatus};
+
+/// Teach `engine` the `Servo` type and its methods. The host decides how
+/// a script *obtains* a servo — a scope variable, a registered lookup fn
+/// — this only covers what a script can do once it holds one.
+pub fn register_servo_onto(engine: &mut Engine) {
+    engine.register_type_with_name::<Arc<Servo>>("Servo");
+
+    engine.register_fn("get", |servo: &mut Arc<Servo>, field: &str| -> Dynamic {
+        servo
+            .get(field)
+            .map(|v| cbor_to_dynamic(&v))
+            .unwrap_or(Dynamic::UNIT)
+    });
+
+    engine.register_fn(
+        "set",
+        |servo: &mut Arc<Servo>,
+         field: &str,
+         value: Dynamic|
+         -> Result<(), Box<EvalAltResult>> {
+            servo.set(field, dynamic_to_cbor(&value)?);
+            Ok(())
+        },
+    );
+
+    engine.register_fn("id", |servo: &mut Arc<Servo>| -> Dynamic {
+        servo.id().map(Dynamic::from).unwrap_or(Dynamic::UNIT)
+    });
+
+    engine.register_fn("record", |servo: &mut Arc<Servo>| -> RhaiMap {
+        record_to_map(&servo.record())
+    });
+
+    engine.register_fn("baseline", |servo: &mut Arc<Servo>| -> Dynamic {
+        servo
+            .baseline()
+            .map(|r| Dynamic::from_map(record_to_map(&r)))
+            .unwrap_or(Dynamic::UNIT)
+    });
+
+    // The error *signal* (data ≠ baseline), not a failure — same name,
+    // same meaning as the Rust API.
+    engine.register_fn("error", |servo: &mut Arc<Servo>| -> RhaiMap {
+        record_to_map(&servo.error())
+    });
+
+    engine.register_fn("dirty", |servo: &mut Arc<Servo>, field: &str| -> bool {
+        servo.dirty(field)
+    });
+
+    engine.register_fn("is_dirty", |servo: &mut Arc<Servo>| -> bool {
+        servo.is_dirty()
+    });
+
+    engine.register_fn("revert", |servo: &mut Arc<Servo>, field: &str| {
+        servo.revert(field);
+    });
+
+    engine.register_fn("revert_all", |servo: &mut Arc<Servo>| {
+        servo.revert_all();
+    });
+
+    engine.register_fn("status", |servo: &mut Arc<Servo>| -> &'static str {
+        match servo.status() {
+            ServoStatus::Tracking => "tracking",
+            ServoStatus::Pending => "pending",
+            ServoStatus::Failed(_) => "failed",
+        }
+    });
+
+    // The last save's rejection: `()` unless status is failed, else a
+    // map of `message` plus per-field errors under `fields`.
+    engine.register_fn("rejection", |servo: &mut Arc<Servo>| -> Dynamic {
+        match servo.status() {
+            ServoStatus::Failed(rejection) => {
+                let mut fields = RhaiMap::new();
+                for (field, message) in rejection.field_errors() {
+                    fields.insert(field.as_str().into(), Dynamic::from(message.clone()));
+                }
+                let mut map = RhaiMap::new();
+                map.insert("message".into(), Dynamic::from(rejection.message().to_string()));
+                map.insert("fields".into(), Dynamic::from_map(fields));
+                Dynamic::from_map(map)
+            }
+            _ => Dynamic::UNIT,
+        }
+    });
+
+    // Actuate: flash the dirty fields and block until the write
+    // resolves. Returns the id the record settled under (`()` when
+    // nothing was dirty and no id is bound yet); a rejected write is a
+    // script error, with the draft surviving on the servo.
+    engine.register_fn(
+        "save",
+        |servo: &mut Arc<Servo>| -> Result<Dynamic, Box<EvalAltResult>> {
+            let handle = tokio::runtime::Handle::try_current().map_err(|_| {
+                Box::<EvalAltResult>::from(
+                    "servo save() needs a tokio runtime context (run the script via spawn_blocking)",
+                )
+            })?;
+            handle
+                .block_on(servo.flash())
+                .map_err(|e| Box::<EvalAltResult>::from(format!("save failed: {e}")))?;
+            Ok(servo.id().map(Dynamic::from).unwrap_or(Dynamic::UNIT))
+        },
+    );
+}
+
+fn record_to_map(record: &Record<CborValue>) -> RhaiMap {
+    let mut map = RhaiMap::new();
+    for (key, value) in record.iter() {
+        map.insert(key.as_str().into(), cbor_to_dynamic(value));
+    }
+    map
+}
+
+/// CBOR → Dynamic, lossy only where Rhai has no representation (a tag is
+/// unwrapped to its value, bytes become a blob).
+pub fn cbor_to_dynamic(value: &CborValue) -> Dynamic {
+    match value {
+        CborValue::Null => Dynamic::UNIT,
+        CborValue::Bool(b) => Dynamic::from(*b),
+        CborValue::Integer(i) => {
+            let wide: i128 = (*i).into();
+            i64::try_from(wide)
+                .map(Dynamic::from)
+                .unwrap_or_else(|_| Dynamic::from(wide as f64))
+        }
+        CborValue::Float(f) => Dynamic::from(*f),
+        CborValue::Text(s) => Dynamic::from(s.clone()),
+        CborValue::Bytes(b) => Dynamic::from_blob(b.clone()),
+        CborValue::Array(items) => {
+            Dynamic::from_array(items.iter().map(cbor_to_dynamic).collect())
+        }
+        CborValue::Map(pairs) => {
+            let mut map = RhaiMap::new();
+            for (k, v) in pairs {
+                if let CborValue::Text(key) = k {
+                    map.insert(key.as_str().into(), cbor_to_dynamic(v));
+                }
+            }
+            Dynamic::from_map(map)
+        }
+        CborValue::Tag(_, inner) => cbor_to_dynamic(inner),
+        _ => Dynamic::UNIT,
+    }
+}
+
+/// Dynamic → CBOR. Errors on types with no CBOR story (closures, custom
+/// types) — a script setting one on a servo is a bug worth naming.
+pub fn dynamic_to_cbor(value: &Dynamic) -> Result<CborValue, Box<EvalAltResult>> {
+    if value.is_unit() {
+        return Ok(CborValue::Null);
+    }
+    if let Some(b) = value.clone().try_cast::<bool>() {
+        return Ok(CborValue::Bool(b));
+    }
+    if let Some(i) = value.clone().try_cast::<i64>() {
+        return Ok(CborValue::Integer(i.into()));
+    }
+    if let Some(f) = value.clone().try_cast::<f64>() {
+        return Ok(CborValue::Float(f));
+    }
+    if let Some(s) = value.clone().try_cast::<String>() {
+        return Ok(CborValue::Text(s));
+    }
+    if let Some(blob) = value.clone().try_cast::<rhai::Blob>() {
+        return Ok(CborValue::Bytes(blob));
+    }
+    if let Some(array) = value.clone().try_cast::<rhai::Array>() {
+        let items = array
+            .iter()
+            .map(dynamic_to_cbor)
+            .collect::<Result<Vec<_>, _>>()?;
+        return Ok(CborValue::Array(items));
+    }
+    if let Some(map) = value.clone().try_cast::<RhaiMap>() {
+        let pairs = map
+            .iter()
+            .map(|(k, v)| Ok((CborValue::Text(k.to_string()), dynamic_to_cbor(v)?)))
+            .collect::<Result<Vec<_>, Box<EvalAltResult>>>()?;
+        return Ok(CborValue::Map(pairs));
+    }
+    Err(format!("no CBOR representation for rhai type '{}'", value.type_name()).into())
+}

--- a/vantage-diorama/tests/import.rs
+++ b/vantage-diorama/tests/import.rs
@@ -141,10 +141,13 @@ async fn fallback_stops_at_first_failure_and_names_the_row() -> Result<()> {
     let progress: Arc<Mutex<Vec<(usize, usize)>>> = Arc::default();
     let seen = progress.clone();
     let result = dio
-        .import_values(tag_records(&["t1", "t2", "t3", "t4", "t5"]), move |done, total| {
-            seen.lock().unwrap().push((done, total));
-            ControlFlow::Continue(())
-        })
+        .import_values(
+            tag_records(&["t1", "t2", "t3", "t4", "t5"]),
+            move |done, total| {
+                seen.lock().unwrap().push((done, total));
+                ControlFlow::Continue(())
+            },
+        )
         .await;
 
     let err = result.expect_err("row 3 fails");

--- a/vantage-diorama/tests/import.rs
+++ b/vantage-diorama/tests/import.rs
@@ -6,6 +6,7 @@
 //! an import that stops at row 3 says so, names the row, and leaves
 //! rows 1–2 legitimately stored.
 
+use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
 
 use ciborium::Value as CborValue;
@@ -57,14 +58,17 @@ async fn fallback_imports_every_record_and_reports_progress() -> Result<()> {
     let stored = dio
         .import_values(tag_records(&["t1", "t2", "t3"]), move |done, total| {
             seen.lock().unwrap().push((done, total));
+            ControlFlow::Continue(())
         })
         .await?;
 
-    assert_eq!(stored, 3);
+    assert_eq!(stored.inserted, 3);
+    assert_eq!(stored.skipped, 0);
+    assert!(!stored.cancelled);
     assert_eq!(
         *progress.lock().unwrap(),
         vec![(1, 3), (2, 3), (3, 3)],
-        "one tick per landed record"
+        "one tick per completed row"
     );
     let upstream = dio.master().list_values().await?;
     assert_eq!(upstream.len(), 3, "every record reached the master");
@@ -94,10 +98,16 @@ async fn fallback_skips_existing_ids_and_counts_only_inserts() -> Result<()> {
     let inserted = dio
         .import_values(tag_records(&["t1", "t2", "t3"]), move |done, total| {
             seen.lock().unwrap().push((done, total));
+            ControlFlow::Continue(())
         })
         .await?;
 
-    assert_eq!(inserted, 2);
+    assert_eq!(inserted.inserted, 2);
+    assert_eq!(
+        inserted.skipped, 1,
+        "the caller is told what it already had, not left to subtract"
+    );
+    assert_eq!(inserted.processed(), 3);
     assert_eq!(
         *progress.lock().unwrap(),
         vec![(1, 3), (2, 3), (3, 3)],
@@ -133,6 +143,7 @@ async fn fallback_stops_at_first_failure_and_names_the_row() -> Result<()> {
     let result = dio
         .import_values(tag_records(&["t1", "t2", "t3", "t4", "t5"]), move |done, total| {
             seen.lock().unwrap().push((done, total));
+            ControlFlow::Continue(())
         })
         .await;
 
@@ -158,6 +169,34 @@ async fn fallback_stops_at_first_failure_and_names_the_row() -> Result<()> {
     Ok(())
 }
 
+/// The progress callback is the stop button: an import is a long walk
+/// over the network, and `Break` has to end it at the row it reaches —
+/// what already landed stays landed, and the outcome admits it stopped.
+#[tokio::test]
+async fn breaking_from_progress_stops_the_walk() -> Result<()> {
+    let shell = MockShell::new();
+    let dio = dio_over(&shell).await?;
+
+    let outcome = dio
+        .import_values(tag_records(&["t1", "t2", "t3", "t4", "t5"]), |done, _| {
+            if done == 2 {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        })
+        .await?;
+
+    assert!(outcome.cancelled);
+    assert_eq!(outcome.inserted, 2);
+    assert!(shell.get_record("t2").is_some());
+    assert!(
+        shell.get_record("t3").is_none(),
+        "row 3 was never attempted"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn advertised_native_import_is_taken_at_its_word() -> Result<()> {
     // A shell that *claims* can_import but doesn't implement the op:
@@ -171,7 +210,7 @@ async fn advertised_native_import_is_taken_at_its_word() -> Result<()> {
     let dio = dio_over(&shell).await?;
 
     let err = dio
-        .import_values(tag_records(&["t1"]), |_, _| {})
+        .import_values(tag_records(&["t1"]), |_, _| ControlFlow::Continue(()))
         .await
         .expect_err("placeholder surfaces");
     assert!(

--- a/vantage-diorama/tests/import.rs
+++ b/vantage-diorama/tests/import.rs
@@ -79,6 +79,38 @@ async fn fallback_imports_every_record_and_reports_progress() -> Result<()> {
     Ok(())
 }
 
+/// An id the master already holds is skipped and NOT counted — the
+/// driver's idempotent insert would otherwise report it as landed, and
+/// a re-imported file would claim every row.
+#[tokio::test]
+async fn fallback_skips_existing_ids_and_counts_only_inserts() -> Result<()> {
+    let mut existing = tag_record("t2");
+    existing.insert("status".to_string(), text("registered"));
+    let shell = MockShell::new().with_record("t2", existing);
+    let dio = dio_over(&shell).await?;
+
+    let progress: Arc<Mutex<Vec<(usize, usize)>>> = Arc::default();
+    let seen = progress.clone();
+    let inserted = dio
+        .import_values(tag_records(&["t1", "t2", "t3"]), move |done, total| {
+            seen.lock().unwrap().push((done, total));
+        })
+        .await?;
+
+    assert_eq!(inserted, 2);
+    assert_eq!(
+        *progress.lock().unwrap(),
+        vec![(1, 3), (2, 3), (3, 3)],
+        "progress covers the skipped row too"
+    );
+    assert_eq!(
+        shell.get_record("t2").unwrap().get("status"),
+        Some(&text("registered")),
+        "the existing record is left as it was"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn fallback_stops_at_first_failure_and_names_the_row() -> Result<()> {
     let shell = MockShell::new();

--- a/vantage-diorama/tests/import.rs
+++ b/vantage-diorama/tests/import.rs
@@ -1,0 +1,150 @@
+//! `Dio::import_values` — the bulk path behind `tables.<t>.import(…)`.
+//!
+//! The capability split under test: `can_import` advertises a
+//! driver-native all-or-nothing batch; without it the Dio falls back to
+//! per-record optimistic inserts, where partial progress is honest —
+//! an import that stops at row 3 says so, names the row, and leaves
+//! rows 1–2 legitimately stored.
+
+use std::sync::{Arc, Mutex};
+
+use ciborium::Value as CborValue;
+use indexmap::IndexMap;
+use vantage_core::Result;
+use vantage_dataset::traits::ReadableValueSet;
+use vantage_diorama::{Dio, Lens};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaCapabilities, VistaMetadata, mocks::MockShell};
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.to_string())
+}
+
+fn tag_record(code: &str) -> Record<CborValue> {
+    let mut r = Record::new();
+    r.insert("id".to_string(), text(code));
+    r.insert("status".to_string(), text("unregistered"));
+    r
+}
+
+fn tag_records(codes: &[&str]) -> IndexMap<String, Record<CborValue>> {
+    codes
+        .iter()
+        .map(|code| (code.to_string(), tag_record(code)))
+        .collect()
+}
+
+fn tag_vista(shell: &MockShell) -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("status", "String"))
+        .with_id_column("id");
+    Vista::new("tags", Box::new(shell.clone().with_metadata(metadata)))
+}
+
+async fn dio_over(shell: &MockShell) -> Result<Dio> {
+    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
+    lens.make_dio(tag_vista(shell)).await
+}
+
+#[tokio::test]
+async fn fallback_imports_every_record_and_reports_progress() -> Result<()> {
+    let shell = MockShell::new();
+    let dio = dio_over(&shell).await?;
+
+    let progress: Arc<Mutex<Vec<(usize, usize)>>> = Arc::default();
+    let seen = progress.clone();
+    let stored = dio
+        .import_values(tag_records(&["t1", "t2", "t3"]), move |done, total| {
+            seen.lock().unwrap().push((done, total));
+        })
+        .await?;
+
+    assert_eq!(stored, 3);
+    assert_eq!(
+        *progress.lock().unwrap(),
+        vec![(1, 3), (2, 3), (3, 3)],
+        "one tick per landed record"
+    );
+    let upstream = dio.master().list_values().await?;
+    assert_eq!(upstream.len(), 3, "every record reached the master");
+    assert_eq!(
+        upstream.get("t2").unwrap().get("status"),
+        Some(&text("unregistered"))
+    );
+    assert!(
+        dio.cache().get_value("t3").await?.is_some(),
+        "records are visible through the cache"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn fallback_stops_at_first_failure_and_names_the_row() -> Result<()> {
+    let shell = MockShell::new();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(|_dio, flash| async move {
+                if flash.id() == Some("t3") {
+                    return Err(vantage_core::error!("route rejected the flash"));
+                }
+                Ok(())
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(tag_vista(&shell)).await?;
+
+    let progress: Arc<Mutex<Vec<(usize, usize)>>> = Arc::default();
+    let seen = progress.clone();
+    let result = dio
+        .import_values(tag_records(&["t1", "t2", "t3", "t4", "t5"]), move |done, total| {
+            seen.lock().unwrap().push((done, total));
+        })
+        .await;
+
+    let err = result.expect_err("row 3 fails");
+    let message = err.to_string();
+    assert!(
+        message.contains("row 3 of 5") && message.contains("t3"),
+        "the error names the failing row and id: {message}"
+    );
+    assert_eq!(
+        *progress.lock().unwrap(),
+        vec![(1, 5), (2, 5)],
+        "progress reported exactly what landed before the stop"
+    );
+    assert!(
+        dio.cache().get_value("t3").await?.is_none(),
+        "the failed row's optimistic stage was rolled back"
+    );
+    assert!(
+        dio.cache().get_value("t4").await?.is_none(),
+        "nothing after the failure was attempted"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn advertised_native_import_is_taken_at_its_word() -> Result<()> {
+    // A shell that *claims* can_import but doesn't implement the op:
+    // the Dio must route to the native path and surface the driver's
+    // Unimplemented placeholder — never silently fall back, which would
+    // hide a driver bug behind 5,000 working inserts.
+    let shell = MockShell::new().with_capabilities(VistaCapabilities {
+        can_import: true,
+        ..VistaCapabilities::default()
+    });
+    let dio = dio_over(&shell).await?;
+
+    let err = dio
+        .import_values(tag_records(&["t1"]), |_, _| {})
+        .await
+        .expect_err("placeholder surfaces");
+    assert!(
+        err.to_string().contains("import_vista_values"),
+        "the native path was attempted: {err}"
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/rhai_servo.rs
+++ b/vantage-diorama/tests/rhai_servo.rs
@@ -150,3 +150,34 @@ async fn rejected_save_is_a_script_error_and_the_draft_survives() -> Result<()> 
     );
     Ok(())
 }
+
+/// A chrono instant handed to a script (a host's `now()`) writes as the
+/// standard CBOR datetime — tag 0 over RFC 3339 — not as plain text.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_instant_writes_as_a_cbor_datetime() -> Result<()> {
+    let shell = MockShell::new();
+    let dio = dio_over(&shell).await?;
+    let servo = Arc::new(dio.servo_new(IdStrategy::FromRecord));
+    let stamp = chrono::Utc::now();
+
+    let servo_for_script = servo.clone();
+    let _ = tokio::task::spawn_blocking(move || {
+        let mut engine = Engine::new();
+        register_servo_onto(&mut engine);
+        let mut scope = Scope::new();
+        scope.push("servo", servo_for_script);
+        scope.push("stamp", stamp);
+        engine
+            .eval_with_scope::<Dynamic>(&mut scope, r#"servo.set("created", stamp)"#)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .expect("eval task")
+    .expect("script runs");
+
+    assert_eq!(
+        servo.get("created"),
+        Some(CborValue::Tag(0, Box::new(text(&stamp.to_rfc3339()))))
+    );
+    Ok(())
+}

--- a/vantage-diorama/tests/rhai_servo.rs
+++ b/vantage-diorama/tests/rhai_servo.rs
@@ -134,13 +134,20 @@ async fn rejected_save_is_a_script_error_and_the_draft_survives() -> Result<()> 
     .expect_err("the rejection surfaces as a script error");
     assert!(err.contains("save failed"), "{err}");
 
-    let status = eval(servo.clone(), r#"[servo.status(), servo.rejection().message]"#)
-        .await
-        .expect("status script runs");
+    let status = eval(
+        servo.clone(),
+        r#"[servo.status(), servo.rejection().message]"#,
+    )
+    .await
+    .expect("status script runs");
     let values = status.into_array().unwrap();
     assert_eq!(values[0].clone().into_string().unwrap(), "failed");
     assert!(
-        values[1].clone().into_string().unwrap().contains("rejected"),
+        values[1]
+            .clone()
+            .into_string()
+            .unwrap()
+            .contains("rejected"),
         "the rejection carries the route's message"
     );
     assert_eq!(

--- a/vantage-diorama/tests/rhai_servo.rs
+++ b/vantage-diorama/tests/rhai_servo.rs
@@ -1,0 +1,152 @@
+//! Servo driven from Rhai — the `rhai` feature's contract.
+//!
+//! Scripts evaluate under `spawn_blocking` (runtime context, no async
+//! frame), exactly the posture `save()` documents: it `block_on`s the
+//! servo's flash from inside the synchronous script.
+
+use std::sync::Arc;
+
+use ciborium::Value as CborValue;
+use rhai::{Dynamic, Engine, Scope};
+use vantage_core::Result;
+use vantage_diorama::rhai::register_servo_onto;
+use vantage_diorama::{Dio, IdStrategy, Lens, Servo};
+use vantage_types::Record;
+use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+fn text(s: &str) -> CborValue {
+    CborValue::Text(s.to_string())
+}
+
+fn tag_vista(shell: &MockShell) -> Vista {
+    let metadata = VistaMetadata::new()
+        .with_column(Column::new("id", "String").with_flag("id"))
+        .with_column(Column::new("status", "String"))
+        .with_id_column("id");
+    Vista::new("tags", Box::new(shell.clone().with_metadata(metadata)))
+}
+
+async fn dio_over(shell: &MockShell) -> Result<Dio> {
+    let lens = Arc::new(Lens::new().cache_in_memory().build().expect("build lens"));
+    lens.make_dio(tag_vista(shell)).await
+}
+
+/// Evaluate `script` with `servo` in scope, on a blocking thread.
+async fn eval(servo: Arc<Servo>, script: &'static str) -> std::result::Result<Dynamic, String> {
+    tokio::task::spawn_blocking(move || {
+        let mut engine = Engine::new();
+        register_servo_onto(&mut engine);
+        let mut scope = Scope::new();
+        scope.push("servo", servo);
+        engine
+            .eval_with_scope::<Dynamic>(&mut scope, script)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .expect("eval task")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn set_save_settles_a_new_record() -> Result<()> {
+    let shell = MockShell::new();
+    let dio = dio_over(&shell).await?;
+    let servo = Arc::new(dio.servo_new(IdStrategy::FromRecord));
+
+    let id = eval(
+        servo.clone(),
+        r#"
+            servo.set("id", "tag:AB12-CD34");
+            servo.set("status", "unregistered");
+            if !servo.is_dirty() { throw "draft should be dirty"; }
+            if !servo.dirty("status") { throw "field should be dirty"; }
+            servo.save()
+        "#,
+    )
+    .await
+    .expect("script runs");
+
+    assert_eq!(id.into_string().unwrap(), "tag:AB12-CD34");
+    assert_eq!(servo.id().as_deref(), Some("tag:AB12-CD34"));
+    assert_eq!(
+        shell.get_record("tag:AB12-CD34").unwrap().get("status"),
+        Some(&text("unregistered")),
+        "the record reached the master under the commanded id"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_error_status_read_the_draft() -> Result<()> {
+    let mut seeded = Record::new();
+    seeded.insert("id".to_string(), text("t1"));
+    seeded.insert("status".to_string(), text("registered"));
+    let shell = MockShell::new().with_record("t1", seeded.clone());
+    let dio = dio_over(&shell).await?;
+    dio.cache().insert_value("t1", &seeded).await?;
+    let servo = Arc::new(dio.servo("t1").await?);
+
+    let result = eval(
+        servo,
+        r#"
+            servo.set("status", "lost");
+            let e = servo.error();
+            [servo.get("status"), e.status, servo.status(), servo.baseline().status]
+        "#,
+    )
+    .await
+    .expect("script runs");
+
+    let values = result.into_array().unwrap();
+    assert_eq!(values[0].clone().into_string().unwrap(), "lost");
+    assert_eq!(values[1].clone().into_string().unwrap(), "lost");
+    assert_eq!(values[2].clone().into_string().unwrap(), "tracking");
+    assert_eq!(
+        values[3].clone().into_string().unwrap(),
+        "registered",
+        "baseline still reads the measurement"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejected_save_is_a_script_error_and_the_draft_survives() -> Result<()> {
+    let shell = MockShell::new();
+    let lens = Arc::new(
+        Lens::new()
+            .cache_in_memory()
+            .on_flash(|_dio, _flash| async move {
+                Err(vantage_core::error!("route rejected the flash"))
+            })
+            .build()
+            .expect("build lens"),
+    );
+    let dio = lens.make_dio(tag_vista(&shell)).await?;
+    let servo = Arc::new(dio.servo_new(IdStrategy::FromRecord));
+
+    let err = eval(
+        servo.clone(),
+        r#"
+            servo.set("id", "tag:XX99-YY88");
+            servo.save()
+        "#,
+    )
+    .await
+    .expect_err("the rejection surfaces as a script error");
+    assert!(err.contains("save failed"), "{err}");
+
+    let status = eval(servo.clone(), r#"[servo.status(), servo.rejection().message]"#)
+        .await
+        .expect("status script runs");
+    let values = status.into_array().unwrap();
+    assert_eq!(values[0].clone().into_string().unwrap(), "failed");
+    assert!(
+        values[1].clone().into_string().unwrap().contains("rejected"),
+        "the rejection carries the route's message"
+    );
+    assert_eq!(
+        servo.get("id"),
+        Some(text("tag:XX99-YY88")),
+        "the draft survives the rejection"
+    );
+    Ok(())
+}

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.24 — 2026-09-01
+
+- Nested insert: a bare **scalar** under a relation key links an existing
+  record — the value is stamped into the has-one reference's foreign-key
+  column, the same column a co-inserted child's id would land in. Before,
+  only a map (insert a child) or a list of maps was accepted, so
+  `bakery: <record id>` was rejected outright. A scalar on a has-many
+  relation is still an error.
+
 ## 0.6.23 — 2026-08-29
 
 - `TableShell::import_vista_values` + `VistaCapabilities.can_import`: a

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -8,6 +8,10 @@
   only a map (insert a child) or a list of maps was accepted, so
   `bakery: <record id>` was rejected outright. A scalar on a has-many
   relation is still an error.
+- Nested insert refuses a has-one relation given **both** a link and
+  child data (`bakery: <id>` beside `bakery.name:`, or a plain
+  `bakery_id:` beside a `bakery:` map). The child's insert would have
+  overwritten the link silently, creating a record nobody asked for.
 
 ## 0.6.23 — 2026-08-29
 

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.23 — 2026-08-29
+
+- `TableShell::import_vista_values` + `VistaCapabilities.can_import`: a
+  driver-native bulk load — one round-trip for a whole record set (SQL
+  COPY, Surreal batch insert), all-or-nothing by contract. Defaulted, not
+  required: a driver that stays silent honestly refuses, and consumers
+  fall back to per-record inserts where partial progress is reportable.
+  `Vista::import_values` forwards. No shipped driver advertises it yet.
+
 ## 0.6.22 — 2026-08-16
 
 - `TableShell::preview_query` renders the query a driver would send, without

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.22"
+version = "0.6.23"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.23"
+version = "0.6.24"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/capabilities.rs
+++ b/vantage-vista/src/capabilities.rs
@@ -18,6 +18,14 @@ pub struct VistaCapabilities {
     pub can_insert: bool,
     pub can_update: bool,
     pub can_delete: bool,
+    /// Driver-native bulk load via
+    /// [`import_vista_values`](crate::TableShell::import_vista_values) —
+    /// one round-trip for a whole record set (SQL COPY, Surreal batch
+    /// insert), as opposed to per-record `can_insert` calls. Consumers
+    /// that see `false` fall back to inserting record by record; the
+    /// flag never changes *whether* an import is possible, only whether
+    /// the driver can take it in one operation.
+    pub can_import: bool,
     /// The driver will *attempt* to push changes via
     /// [`watch_vista`](crate::TableShell::watch_vista) — see that method for the
     /// four promises a subscription makes. It is an attempt, not a guarantee of

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -154,6 +154,21 @@ impl Vista {
             })?;
             let foreign_key = reference.foreign_key.clone();
             match reference.kind {
+                // Inserting a child stamps its new id into the main row's
+                // foreign key, so a main row that ALREADY carries that
+                // column is two instructions in one record: link this
+                // existing row, and create a new one to link instead.
+                // Silently, the child would win. Refuse instead — whether
+                // the column arrived as a scalar under the relation name
+                // (`bakery: "bakery:x"`) or as the plain column
+                // (`bakery_id: "x"`), neither is a typo worth guessing at.
+                ReferenceKind::HasOne if main.get(&foreign_key).is_some() => {
+                    return Err(error!(
+                        "relation given both a record link and child data",
+                        relation = relation.as_str(),
+                        foreign_key = foreign_key.as_str()
+                    ));
+                }
                 ReferenceKind::HasOne => match payload {
                     Collected::Map(child) => has_one.push((relation, foreign_key, child)),
                     Collected::List(_) => {
@@ -366,6 +381,34 @@ mod tests {
         assert!(has_many.is_empty());
         assert!(main.get("bakery").is_none());
         assert_eq!(main.get("bakery_id"), Some(&text("bakery:hill_valley")));
+    }
+
+    /// Both forms of a has-one at once — link an existing row AND create
+    /// a child — is refused rather than resolved: the child insert would
+    /// silently overwrite the link.
+    #[test]
+    fn a_link_and_child_data_for_one_relation_is_an_error() {
+        let scalar_and_dotted = client_vista().classify_insert(&record(&[
+            ("bakery", text("bakery:hill_valley")),
+            ("bakery.name", text("New Bakery")),
+        ]));
+        let err = scalar_and_dotted.unwrap_err().to_string();
+        assert!(err.contains("both a record link and child data"), "{err}");
+
+        // Same conflict spelled with the plain foreign-key column.
+        let fk_and_map = client_vista().classify_insert(&record(&[
+            ("bakery_id", text("b1")),
+            ("bakery", map(&[("name", text("New Bakery"))])),
+        ]));
+        assert!(fk_and_map.is_err());
+
+        // Either form ALONE stays legal.
+        assert!(client_vista()
+            .classify_insert(&record(&[("bakery", text("bakery:hill_valley"))]))
+            .is_ok());
+        assert!(client_vista()
+            .classify_insert(&record(&[("bakery", map(&[("name", text("New"))]))]))
+            .is_ok());
     }
 
     #[test]

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -115,11 +115,25 @@ impl Vista {
                         }
                         collected.insert(key.clone(), Collected::List(children));
                     }
+                    // A scalar names an EXISTING record: link it by
+                    // stamping the foreign-key column — the same column a
+                    // co-inserted child's id would land in. The value's
+                    // shape (Text id, Tag record-id, integer key, null)
+                    // is the driver's to validate, like any plain field.
                     _ => {
-                        return Err(error!(
-                            "relation value must be a map (has-one) or a list of maps (has-many)",
-                            relation = key
-                        ));
+                        let Some(reference) = self.get_reference(key) else {
+                            return Err(error!(
+                                "relation has no insertable reference",
+                                relation = key
+                            ));
+                        };
+                        if reference.kind != ReferenceKind::HasOne {
+                            return Err(error!(
+                                "has-many relation takes a list of maps, not a scalar",
+                                relation = key
+                            ));
+                        }
+                        main.insert(reference.foreign_key.clone(), value.clone());
                     }
                 }
                 continue;
@@ -338,6 +352,26 @@ mod tests {
         assert_eq!(relation, "orders");
         assert_eq!(fk, "client_id");
         assert_eq!(children.len(), 2);
+    }
+
+    #[test]
+    fn bare_scalar_links_an_existing_record_via_the_foreign_key() {
+        let (main, has_one, has_many) = client_vista()
+            .classify_insert(&record(&[
+                ("name", text("John")),
+                ("bakery", text("bakery:hill_valley")),
+            ]))
+            .unwrap();
+        assert!(has_one.is_empty());
+        assert!(has_many.is_empty());
+        assert!(main.get("bakery").is_none());
+        assert_eq!(main.get("bakery_id"), Some(&text("bakery:hill_valley")));
+    }
+
+    #[test]
+    fn has_many_given_a_scalar_is_an_error() {
+        let err = client_vista().classify_insert(&record(&[("orders", text("order:1"))]));
+        assert!(err.is_err());
     }
 
     #[test]

--- a/vantage-vista/src/insert.rs
+++ b/vantage-vista/src/insert.rs
@@ -403,12 +403,16 @@ mod tests {
         assert!(fk_and_map.is_err());
 
         // Either form ALONE stays legal.
-        assert!(client_vista()
-            .classify_insert(&record(&[("bakery", text("bakery:hill_valley"))]))
-            .is_ok());
-        assert!(client_vista()
-            .classify_insert(&record(&[("bakery", map(&[("name", text("New"))]))]))
-            .is_ok());
+        assert!(
+            client_vista()
+                .classify_insert(&record(&[("bakery", text("bakery:hill_valley"))]))
+                .is_ok()
+        );
+        assert!(
+            client_vista()
+                .classify_insert(&record(&[("bakery", map(&[("name", text("New"))]))]))
+                .is_ok()
+        );
     }
 
     #[test]

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -202,12 +202,18 @@ pub trait TableShell: Send + Sync + 'static {
     // ---- Bulk import -------------------------------------------------------
 
     /// Store `records` (id → record) in one driver-native operation —
-    /// SQL COPY, Surreal batch insert — and return how many landed.
-    /// All-or-nothing is the contract: a driver that cannot make the
-    /// batch atomic must not advertise
-    /// [`can_import`](VistaCapabilities::can_import); the caller then
-    /// falls back to per-record inserts where partial progress is
-    /// honest and reportable.
+    /// SQL COPY, Surreal batch insert — and return how many were
+    /// **newly inserted**. An id the table already held counts zero,
+    /// whether the driver's batch skips it or upserts it: the number
+    /// travels to a user as "n records created", and the per-record
+    /// fallback in `Dio::import_values` counts the same way. A driver
+    /// that cannot tell new from existing must not advertise
+    /// [`can_import`](VistaCapabilities::can_import).
+    ///
+    /// All-or-nothing is the other half of the contract: a driver that
+    /// cannot make the batch atomic must not advertise it either; the
+    /// caller then falls back to per-record inserts where partial
+    /// progress is honest and reportable.
     async fn import_vista_values(
         &self,
         _vista: &Vista,

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -199,6 +199,23 @@ pub trait TableShell: Send + Sync + 'static {
         Err(self.default_error("insert_vista_return_id_value", "can_insert"))
     }
 
+    // ---- Bulk import -------------------------------------------------------
+
+    /// Store `records` (id → record) in one driver-native operation —
+    /// SQL COPY, Surreal batch insert — and return how many landed.
+    /// All-or-nothing is the contract: a driver that cannot make the
+    /// batch atomic must not advertise
+    /// [`can_import`](VistaCapabilities::can_import); the caller then
+    /// falls back to per-record inserts where partial progress is
+    /// honest and reportable.
+    async fn import_vista_values(
+        &self,
+        _vista: &Vista,
+        _records: &IndexMap<String, Record<CborValue>>,
+    ) -> Result<usize> {
+        Err(self.default_error("import_vista_values", "can_import"))
+    }
+
     // ---- Aggregates --------------------------------------------------------
 
     /// Default impl falls back to `list_vista_values` — drivers with native
@@ -646,6 +663,7 @@ pub trait TableShell: Send + Sync + 'static {
             "can_insert" => caps.can_insert,
             "can_update" => caps.can_update,
             "can_delete" => caps.can_delete,
+            "can_import" => caps.can_import,
             "can_subscribe" => caps.can_subscribe,
             "can_invalidate" => caps.can_invalidate,
             "can_order" => caps.can_order,

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -67,6 +67,17 @@ impl Vista {
         self.source.preview_query(self)
     }
 
+    /// Driver-native bulk load — see [`TableShell::import_vista_values`]
+    /// for the all-or-nothing contract. Gated by
+    /// [`can_import`](crate::VistaCapabilities::can_import); callers that
+    /// see `false` fall back to per-record inserts.
+    pub async fn import_values(
+        &self,
+        records: &indexmap::IndexMap<String, Record<CborValue>>,
+    ) -> Result<usize> {
+        self.source.import_vista_values(self, records).await
+    }
+
     // ---- metadata accessors -----------------------------------------------
     //
     // All schema accessors forward to the shell. Vista holds none of the

--- a/vantage-vista/src/vista.rs
+++ b/vantage-vista/src/vista.rs
@@ -67,8 +67,9 @@ impl Vista {
         self.source.preview_query(self)
     }
 
-    /// Driver-native bulk load — see [`TableShell::import_vista_values`]
-    /// for the all-or-nothing contract. Gated by
+    /// Driver-native bulk load, returning how many records were newly
+    /// inserted — see [`TableShell::import_vista_values`] for that
+    /// count's definition and the all-or-nothing contract. Gated by
     /// [`can_import`](crate::VistaCapabilities::can_import); callers that
     /// see `false` fall back to per-record inserts.
     pub async fn import_values(


### PR DESCRIPTION
## What

**vantage-diorama 0.12.4**

- **`rhai` feature** — `Servo` as a first-class Rhai type (`get`/`set`/`dirty`/`error`/`status`/`revert`/`save()`), the same treatment vantage-vista's `rhai` feature gives queries. Scripts evaluate under `spawn_blocking`; `save()` runs the flash via `block_on` and returns the settled id.
- **`Dio::import_values(records, progress)`** — driver-native bulk load when the master advertises `can_import`, otherwise per-record optimistic inserts that stop at the first failure naming the row and id. Returns `ImportOutcome { inserted, skipped, cancelled }`: an id the table already holds is skipped and its record left untouched (drivers' inserts are idempotent, so the write alone cannot tell), and the caller is told the count rather than having to subtract — which is wrong the moment a retry follows a partial import. The `progress` callback returns `ControlFlow`, which is how a long import is **stopped**: it is one operation to whatever is driving it, so the callback is the only place a caller gets a word in.
- `dynamic_to_cbor` maps a chrono instant to the standard CBOR datetime (tag 0, RFC 3339).
- A failed default write now carries the driver's cause in its message *and* keeps the source chain, so `FlashRejection::from_error` still recovers the per-field errors a form highlights.

**vantage-vista 0.6.24**

- `VistaCapabilities.can_import` + `TableShell::import_vista_values`, defaulted. The contract defines its count as **newly inserted** — a driver that cannot tell new from existing must not advertise the capability. No shipped driver does yet.
- Nested insert: a bare scalar under a has-one relation key links the existing record by stamping the foreign-key column. Before, only a map or a list of maps was accepted, so `bakery: <record id>` was rejected outright.
- Nested insert refuses a has-one given **both** a link and child data (`bakery: <id>` beside `bakery.name:`, or a plain `bakery_id:` beside a `bakery:` map) — the child's insert would silently overwrite the link, creating a record nobody asked for.

## Why

Backs `kind: wizard` in vantage-ui (atk4/vantage-ui#198): shared unsaved drafts driven from Rhai, a bulk write path with honest partial progress and a working stop button, and record links surviving an insert.

## Review

CodeRabbit's five findings are addressed: the source-chain regression, the conflicting has-one forms, the native import count's definition, and the progress wording. The remaining one — that the skip decision is a read before a write, so the counts are exact only against a table nobody else is writing — is documented at the call site rather than fixed: no data turns on the counts (the idempotent insert keeps a racing writer's record either way), and making them exact needs an insert-if-absent the driver contract does not have.

## Verification

`cargo test -p vantage-vista`; diorama compiled with tests and exercised end to end through the vantage-ui wizard against SurrealDB Cloud, including a cancelled mid-import.