### PR TITLE
Rhai unification: data layer on vantage-rhai hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-rhai"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "rhai",
  "schemars",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.21"
+version = "0.6.22"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6023,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5673,7 +5673,6 @@ dependencies = [
  "async-trait",
  "ciborium",
  "indexmap 2.14.0",
- "rhai",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -5682,6 +5681,7 @@ dependencies = [
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",
+ "vantage-rhai",
  "vantage-table",
  "vantage-types",
  "vantage-vista",
@@ -5754,7 +5754,6 @@ dependencies = [
  "insta",
  "libc",
  "redb",
- "rhai",
  "rstest",
  "serde",
  "serde_json",
@@ -5769,6 +5768,7 @@ dependencies = [
  "vantage-core",
  "vantage-csv",
  "vantage-dataset",
+ "vantage-rhai",
  "vantage-sql",
  "vantage-table",
  "vantage-types",
@@ -5897,7 +5897,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-rhai"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "rhai",
  "schemars",
@@ -5917,7 +5917,6 @@ dependencies = [
  "hex",
  "indexmap 2.14.0",
  "paste",
- "rhai",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -5930,6 +5929,7 @@ dependencies = [
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",
+ "vantage-rhai",
  "vantage-table",
  "vantage-types",
  "vantage-vista",
@@ -5950,7 +5950,6 @@ dependencies = [
  "indexmap 2.14.0",
  "md5",
  "paste",
- "rhai",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -5963,6 +5962,7 @@ dependencies = [
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",
+ "vantage-rhai",
  "vantage-table",
  "vantage-types",
  "vantage-vista",
@@ -6030,7 +6030,6 @@ dependencies = [
  "ciborium",
  "futures-core",
  "indexmap 2.14.0",
- "rhai",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -6038,6 +6037,7 @@ dependencies = [
  "tokio",
  "vantage-core",
  "vantage-dataset",
+ "vantage-rhai",
  "vantage-types",
 ]
 

--- a/plans/2026-09-05-rhai-unification-status.md
+++ b/plans/2026-09-05-rhai-unification-status.md
@@ -1,0 +1,54 @@
+# Rhai unification — live status
+
+Living status for the work in `/Users/rw/.claude/plans/ok-plan-out-the-woolly-twilight.md`
+(the approved plan; a copy of its phase structure is summarised here so this file stands on
+its own). **Update this file at every commit.** A chat session was lost on 2026-09-05 with
+~40 files uncommitted and no notes; this file exists so that cannot cost a day again.
+
+Branches: `rhai-unification` in vantage and in vantage-ui. Nothing ships between phases;
+one vantage release, then one vantage-ui release pinned to it.
+
+## Phase 1 — Loader, includes, serde_yaml_ng (vantage-ui) — DONE
+
+Commit `40f55cf` on vantage-ui `rhai-unification`: one loader in `ui-grammar`
+(`Document`, `load_document`, `validate_into`, `LazyLock` schema cache), `include.rs`
+(364 lines, `!include` with root confinement, cycles, cache), `Leaf.includes` + watcher
+reverse lookup, `config.rs` and both legacy bins deleted, `ShapedObserveRef::File` removed,
+`serde_yaml` gone (0 references). Tests: ui-grammar 20, inventory 6+6+30, catalog 1+1 pass.
+`cargo check --workspace` in vantage-ui currently fails only because the local vantage
+checkout (patched in) does not compile — see Phase 2.
+
+Not yet done from Phase 1: 1.6 docs (`# language=rhai` convention in scaffold READMEs and
+`rhai-expressions.md`). Folded into the final sweep.
+
+## Phase 2 — Data layer (vantage) — IN PROGRESS, uncommitted
+
+Mechanical part done in every crate: `rhai = "1.25"` → `vantage-rhai = { path }` under the
+`rhai` feature, all `rhai::` paths → `vantage_rhai::rhai::`. vantage-cmd's 1.21 pin is gone.
+
+| Crate | State |
+|---|---|
+| 2.1 vantage-vista | **Done.** `ConventionalVocab`, `ShellVocab`, `FetchVerbs`; `eval_*` take `&Host` + `Env`; `run_script`/`preview_script` on `Limits::background()` hosts; `lazy_value_closure` compiles once (`(&str) -> Result<LazyValueFn>`, both callers updated); `augment_source_closure` builds its host once; `convert.rs` public + arrays/maps, `dynamic_to_json` replaced by `vantage_rhai::to_json`; `TableShell::rhai_env` added. 60+4+5 tests. |
+| 2.2 vantage-sql | **Done.** `register_engine!` emits `SqlVocab` + a per-dialect `LazyLock<Host>` (`__host()`) and imports `rhai` into the invoking scope; `__create_engine` gone; `eval_to_select_args` uses `Env` (`args`, `base`) and `Block` (cached); `eval_to_select` collapsed onto it. Tests/example/smoke moved. `e6.err` fixture reworded to the host's `unknown name` message. 739 tests. |
+| 2.3 vantage-surrealdb | **Done.** `SurrealVocab`; `me` moved from an `on_var` hook to `surreal_env` / `TableShell::rhai_env` (the hook collided with the host's resolver hook); `register_surreal_engine!` emits `__host()`; traversal, modify and query-source sites on hosts, vendor-before-conventional order kept; tests for `me` + resolver coexistence and bounded scripts. 103 tests. Fixture runner: 16/18, the 2 mismatches (`v4_q07/08`, `'x'` vs `"x"` quoting) fail identically at HEAD — pre-existing drift, not this work. |
+| 2.4 vantage-cmd | **Done.** `CmdVocab { command, env, pass_path, base_dir }` is the security lock as a `Vocab`; `CompiledScript { script: Compiled<Block> }` on a `Limits::background()` host; `eval` builds an `Env`. 19 tests. |
+| 2.5 vantage-faker | **Done.** `FakerVocab(Arc<FakerCtx>)`; the effect compiles its script once (a script that does not parse never ticks) and runs the `Compiled<Block>` per tick under `spawn_blocking`; background limits. Its scalar CBOR converters stay (they tolerate rather than error; switching them to vista's is a behaviour change left for later). 44 tests. |
+| 2.6 vantage-diorama | **Done.** `ServoVocab`; `cbor_to_dynamic`/`record_to_map` re-exported from vista, `dynamic_to_cbor` keeps only the chrono-instant case and delegates the rest; `rhai` feature now pulls `vantage-vista/rhai`. Test moved onto a host. All suites pass. |
+| vantage-api-client | `lazy_value_closure` caller updated. Compiles. |
+| vantage-rhai | Grew during this phase (unpublished, part of the release): `Compiled<Block>` has `eval_as`/`eval_bool`; parse errors keep rhai's "Syntax error:" prefix. 50 tests, clippy clean. |
+
+**Phase 2 verification:** `Engine::new()` outside test modules exists only in
+`vantage-rhai/src/host.rs`; `set_max_expr_depths` / `on_var` only in `vantage-rhai`; no crate
+declares a direct `rhai` dependency except `vantage-rhai`.
+
+vantage-ui against this data layer: one break, `crates/backend/src/connect/relations.rs`
+`narrow_via_script` (old `eval_ref_script` signature) — patched minimally so the workspace
+builds; Phase 3.5 deletes it with `ReferenceFull.rhai`.
+
+**Incident 2026-09-05:** a `git stash` / `stash pop` used to check a fixture baseline stranded
+the whole tree in the stash (background cargo rewrote `Cargo.lock` between them). Recovered;
+lesson recorded in memory. Use a worktree for baselines, never a stash here.
+
+## Phase 3 — vantage-ui sites, dead slots, scenery direct reads — NOT STARTED
+
+## Sweep + release — NOT STARTED

--- a/plans/2026-09-05-rhai-unification-status.md
+++ b/plans/2026-09-05-rhai-unification-status.md
@@ -85,6 +85,62 @@ vantage-rhai grew again: `Compiled::engine()` / `Compiled::ast()` accessors; `ui
   vantage-github and faker-demo. `ui-grammar` has a schema test asserting
   `x-language: rhai` on the three slot definitions and a `$ref` from `ButtonParams.action`.
 
+## Review — 2026-09-06
+
+Two review agents over the branch diffs. The defect hunt died on a session rate limit
+before reporting, so the scanner sites were checked by hand instead: `template::split`
+only skips strings and comments **inside** a hole, so prose with an apostrophe or `//`
+outside one is untouched — the six replacements are behaviour-preserving apart from
+holes now being trimmed (`${ args.x }` resolves where it used to error) and two
+lenient-direction differences on malformed input (`extract_paths` yields no paths where
+it used to yield the ones before the break; `substitute_key` reports a malformed key as
+complete). Both are config errors either way. **Still unreviewed for defects:** slot
+typing at crate boundaries, the sed-rewritten example YAML, limits-vs-thread pairing.
+
+Fixed and staged in vantage-ui (29 files) + vantage:
+
+- **Five tracked docs still taught removed slots** — the sweep only covered the
+  `vantage-ui-builder` skill. The REST persistence skill's `lazy:` section and the
+  SurrealDB skill's `expr:` section are shipped agent resources that would have
+  generated unparseable YAML; also an `expr:` bullet in `decorating-columns.md` and an
+  `expressions:` line in two example table READMEs.
+- **`rhai-expressions.md` contradicted itself** — its slot table showed `when:` reading
+  scope through `${...}`, twenty lines above the section saying scripts read it directly.
+- **`resolve_env` mangled non-ASCII** — `out.push(bytes[i] as char)` turned `café` in a
+  datasource value into `cafÃ©`. Rewritten over `&str` slices.
+- **`vantage_rhai::ui_host()` / `background_host()`** — the vocabulary-free host existed
+  four times under three names in crates that could not share `ui-scope`'s. All five
+  sites now take the shared one; `ui_scope::ui_host()` is a re-export.
+- **The dead `columns` parameter** is gone from the four `body_eval` entry points and
+  their call sites, with the comment that promised its removal.
+- **`RowVocab` is now exercised through a real `Host`** by its own tests — one test
+  proving one host serves two rows and a write reaches the row the script was handed.
+- **`included_script_lands_in_the_slot`** asserts the script text, not just the body length.
+- **`FormatVocab` / `ClockVocab` are public**, so `unit`, `money`, `compact`,
+  `date_relative` and `thing_key` are reachable outside `view_dio`.
+- Comment hygiene: eight prose comments the path rewrite had lengthened (`rhai::Map` →
+  `vantage_rhai::rhai::Map`) reverted, with `use vantage_rhai::rhai;` added to the four
+  heaviest files; the `Arc<Mutex>`-not-`Rc<RefCell>` sync-bound note restored; refactor
+  narration and a stale bypass comment trimmed.
+
+### Review follow-ups not taken
+
+- Collapse the three byte-identical SQL dialect `rhai_source.rs` files into
+  `register_engine!` (222 lines carrying four lines of information).
+- Port the remaining 15 row tests off the `#[cfg(test)] register_row` shim onto hosts,
+  and delete the duplicate `registers_action_under_actions_namespace` with the
+  `register_actions_marker` shim.
+- File splits: `framework_page.rs` record gate (~180 lines, tests move with it) and its
+  grammar walkers; `table.rs` driver blocks.
+- `ShellVocab(&dyn TableShell)`; hoist `SqlVocab`/`__host` out of the macro; one
+  `scripted_host` on the surreal shell instead of two inline builds per call.
+- Naming: bare `host()` where a module has one, `<noun>_env` taking-and-extending
+  everywhere, `ActionsMarker` → `ActionsVocab`. Better as one rename commit.
+- `bridge.rs` keeps a third `dynamic_to_json` whose tests pin the *opposite* behaviour to
+  `vantage-rhai`'s (strict error vs Display fallback) — needs a semantics call.
+- Tests for the two `validate.rs` files, and the 23 example script blocks still missing
+  `# language=rhai`.
+
 ## Release — COMMITTED, PRs open, waiting on merge + publish
 
 Landed 2026-09-05 once the signer was unlocked: vantage PR #395 (`rhai-unification`),

--- a/plans/2026-09-05-rhai-unification-status.md
+++ b/plans/2026-09-05-rhai-unification-status.md
@@ -85,10 +85,16 @@ vantage-rhai grew again: `Compiled::engine()` / `Compiled::ast()` accessors; `ui
   vantage-github and faker-demo. `ui-grammar` has a schema test asserting
   `x-language: rhai` on the three slot definitions and a `$ref` from `ButtonParams.action`.
 
-## Release — PREPARED, waiting on commits
+## Release — COMMITTED, PRs open, waiting on merge + publish
 
-Done in the working trees (nothing committed: the 1Password SSH signer has been failing
-all day — every `git commit` hangs on it):
+Landed 2026-09-05 once the signer was unlocked: vantage PR #395 (`rhai-unification`),
+vantage-ui PR #200 (commits `677c0e5` checkpoint + `4b43859` second batch; the app
+manifest carries only its version hunk, the generated `bundles.rs` was amended out),
+vantage-ui-examples PR #37. Remaining: merge vantage → CD publishes (rhai first) → step 4
+below regenerates the vantage-ui lock → merge vantage-ui and the examples.
+
+Done in the working trees before that (the 1Password SSH signer had been failing all day —
+every `git commit` hung on it):
 
 - vantage-ui: no crate imports `rhai::` directly any more — 38 files now go through
   `vantage_rhai::rhai::` (actions, components, wizard, plugin-host) or `ui_scope::rhai::`

--- a/plans/2026-09-05-rhai-unification-status.md
+++ b/plans/2026-09-05-rhai-unification-status.md
@@ -49,6 +49,83 @@ builds; Phase 3.5 deletes it with `ReferenceFull.rhai`.
 the whole tree in the stash (background cargo rewrote `Cargo.lock` between them). Recovered;
 lesson recorded in memory. Use a worktree for baselines, never a stash here.
 
-## Phase 3 — vantage-ui sites, dead slots, scenery direct reads — NOT STARTED
+## Phase 3 — vantage-ui sites, dead slots, scenery direct reads — IN PROGRESS
 
-## Sweep + release — NOT STARTED
+Two commits' worth of work on vantage-ui `rhai-unification`, the first staged and waiting
+on a 1Password unlock to sign (index intact; the user's working `Cargo.lock` is preserved at
+`/tmp/vui_worklock` and restored after the commit lands).
+
+| Item | State |
+|---|---|
+| 3.5 six slots | **Done.** `expressions:`, `unit.rhai`, column `expr`/`lazy`, `references.rhai`, page column `render`/`copy` deleted end to end (inventory structs, schema column, grid cell/clipboard paths, loaders, `UiRelation.rhai`). `narrow_via_script` **stays**: `open_filtered` synthesizes a script through it for every scenery `.where()`. |
+| 3.2 actions crate | **Done.** `RowVocab` is stateless: field access is an indexer (`row.email` routes to it), so predicates and `args:` share one static `Limits::Ui` host + cache instead of an engine per row. `ActionsMarker` + `actions_env`, `RowRefVocab`, `TablesVocab` + `tables_map`; `evaluate`/`evaluate_lifecycle` build a per-catalog host. `evaluate_predicate_with_controls` deleted (no callers). 73 tests. |
+| 3.3 sites | **Done:** form submit, auth (`AuthVocab`), log filter (closure via `Compiled::engine()`/`ast()`), list text/label (**now `Template`** — YAML `text: '${ … }'`), view evaluator (`FormatVocab`+`ClockVocab`, scanner = `vantage_rhai::template::split`, per-hole rendering unchanged), projection + stat (shared `ui_scope::ui_host()`), wizard flow (3 sites; `step_env` in vantage-wizard), http body (`Expr` on a static host; `execute_http` lost its engine param), scripted narrowing. |
+| 3.6 scenery direct reads | **Done in code.** `SceneryVocab`; `eval_in(script, env)` discovers reads through the page frame; `substitute_scope_reads` deleted. `ObservationResolver` now receives `&Arc<ui_scope::Scope>` instead of a text callback; `scope_reader(frame)` serves `substitute_key`. The shaped cache keys on script + read values. **Example YAML not yet migrated** (`"${ns.value}"` inside scenery strings must become `ns.value`). |
+| 3.1 slot types | **Done.** `vantage-rhai` slots gained `Deref<Target = str>`, `AsRef<str>`, `Display`, `Default`, `PartialEq<str>` so a field can change kind without touching display-only readers; workspace dep enables the `schema` feature (`x-language: rhai` in every generated schema). Kinds: **`Expr`** — every `when:`/`condition:`, `RowAction.args.*`, `ProjectionDef.formula`, `FormFieldSpec.options`, `FormField.options`, `StreamSpec.filter`; **`Template`** — view-node text/value fields (`text`, `secondary`, `copy`, `label`, `value`, `unit`, `max`, `target`, `url`), `LabelParams.text`, `ProgressParams.*`, `ImageDef.src`, `ListParams.text/label`, `ViewMountDef.args.*`, `FinderParams.root`, `FormField.default`, `DialogSpec.{title,description,confirm_label,cancel_label}`, `StepSpec.title`; **`Block`** — `RowAction.action`, `ToolbarAction.action`, `ButtonParams.action`, `ToolbarSpec.action`, `WidgetDef.{on_ready,on_event}`, `FormDef.on_submit`, `ShapedObserveRef.script`, `SelectQueryBlock.rhai`, all driver-block scripts (`surreal.rhai/modify`, `sql.rhai`, `cmd.rhai/detail`, `faker.rhai`), `StepSpec.worker/workers.*`. Deliberately **left `String`** because their consumers never interpolate: select/chart/stat/csv/toolbar/filter labels, `ViewNode::List.empty`, `RecordViewDef.src`, `ViewMountDef.src`, `ParamDef.label`, `FormFieldSpec.default`, `FormDef.record` and `HttpSpec.url/headers` (scope-path / env templates, not Rhai). Runtime mirrors follow the slot (`Projection.formula`, `FormFieldRuntime`, formkit `FieldSpec`/`BlockSpec`, `ListFormat`); handoffs into the data layer's own specs convert with `to_string()`. |
+| 3.4 remaining `${}` scanners | **Done.** `substitute_key`, `resolve_args_template*`, catalog + ui-mount validators, `rhai_import::apply_template` and the action `shape.rs` interpolators all scan with `vantage_rhai::template::split` and keep their own lookup. `grep 'find("${")'` over `crates framework` is empty. `substitute_env` / `extract_env_vars` stay (process env, not scope). |
+
+vantage-rhai grew again: `Compiled::engine()` / `Compiled::ast()` accessors; `ui_scope::ui_host()`.
+
+## Examples + docs sweep — DONE (uncommitted in both repos)
+
+- vantage-ui-examples (`apps/cashgpt`, `periscope`, `space`): every scenery script reads
+  scope directly (`month.value`, `appsel.selected_id`, `"models_top" + topn.value`) — 107
+  lines across 10 pages, applied with one sed scoped to lines containing `scenery(`; the
+  eight framework-list `text:`/`label:` params are `${ … }` templates; `# language=rhai`
+  above every cashgpt table `rhai: |` block (68).
+- vantage-ui `examples/surreal-bakery`: the import wizard's worker is
+  `worker: !include import-products.rhai`; `# language=rhai` above the 16 inline bodies.
+- Skills docs: `rhai-expressions.md` rewritten (three kinds, `${ }`, direct scope reads,
+  `!include`, `# language=rhai`, bounded engines); `decorating-columns.md` loses the
+  `render:`/`copy:`/`unit.rhai` section; `expressions:` gone from `SKILL.md` and
+  `yaml-schemas.md`; `charts-and-dashboards.md` and `pages-and-components.md` show direct
+  reads. Vendored `apps/*/.agents/skills` copies are untracked in the examples repo.
+- Verification: `examples_validate` passes over the in-repo roots and, via
+  `VANTAGE_EXTRA_INVENTORIES`, over cashgpt, periscope, space, launch-control,
+  vantage-github and faker-demo. `ui-grammar` has a schema test asserting
+  `x-language: rhai` on the three slot definitions and a `$ref` from `ButtonParams.action`.
+
+## Release — PREPARED, waiting on commits
+
+Done in the working trees (nothing committed: the 1Password SSH signer has been failing
+all day — every `git commit` hangs on it):
+
+- vantage-ui: no crate imports `rhai::` directly any more — 38 files now go through
+  `vantage_rhai::rhai::` (actions, components, wizard, plugin-host) or `ui_scope::rhai::`
+  (app, backend). The `rhai` dependency is gone from the four manifests that are mine;
+  `crates/app/Cargo.toml` and `crates/backend/Cargo.toml` keep it because both carry the
+  user's uncommitted chtags work (and `crates/backend/tests/chtags_import.rs` uses
+  `rhai::Engine` directly), so the workspace `rhai` dep in the root `Cargo.toml` stays
+  until that lands. Re-pinned: rhai 0.6.2, vista 0.6.25, sql 0.6.22, surrealdb 0.6.18,
+  cmd 0.6.5, faker 0.6.15, diorama 0.12.5, api-client 0.6.13. App bumped to 0.38.0 via
+  `script/bump-version` (touches `crates/app/Cargo.toml` — stage that hunk only — and
+  `Info.plist`); `## Vantage 0.38` block written in `CHANGELOG.md`.
+- vantage: versions bumped and dated changelog entries written for the eight crates above
+  (sibling pins raised to the new versions).
+
+Verification: vantage-ui `cargo check --workspace --all-targets` clean (two pre-existing
+warnings), tests green in ui-grammar, inventory (+ `examples_validate` over every
+external app root), catalog, actions, components, backend, wizard, plugin-host,
+ui-component, ui-mount, ui-scope, and the app binary's own 116 tests. vantage-rhai 50
+tests, clippy clean.
+
+### Landing order (when the signer works again)
+
+1. vantage-ui: commit the staged checkpoint (index intact; `cp /tmp/vui_worklock
+   Cargo.lock` afterwards is no longer needed — the lock will be regenerated at step 4).
+   Then stage the rest **by explicit path**, never `git add -A`: exclude `Cargo.lock`,
+   `crates/backend/src/bundles.rs`, `crates/backend/tests/chtags_import.rs`, and stage only
+   the version hunk of `crates/app/Cargo.toml` (`git diff -- crates/app/Cargo.toml` →
+   `git apply --cached` the one hunk). Suggested message: "rhai unification: slot types,
+   one template scanner, scenery direct reads, wizard and http hosts, examples and docs,
+   0.38.0".
+2. vantage-ui-examples: commit the sweep (cashgpt/periscope/space pages + tables).
+3. vantage: commit `vantage-rhai` additions + bumps + changelogs + this file; merge; CD
+   publishes in order (vantage-rhai first).
+4. vantage-ui: once the crates are on crates.io, `cargo update -p vantage-rhai -p
+   vantage-vista -p vantage-sql -p vantage-surrealdb -p vantage-cmd -p vantage-faker -p
+   vantage-diorama -p vantage-api-client`, commit `Cargo.lock`, merge.
+
+Not done: runtime checks against a rebuilt app (MCP `list_logs` on page open,
+`preview_query` before/after direct reads, `perf_stats` on cashgpt `dashboard`, include
+hot reload of `import-products.rhai`, faker tick in `app-select-tester`).

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.13 — 2026-09-05
+
+- Follows vista 0.6.25: a lazy column's script compiles once through
+  `lazy_value_closure`, and a script that does not parse is reported when the
+  column is declared rather than on first read.
+
 ## 0.6.12 — 2026-08-16
 
 - `GraphqlApiTableShell` implements `preview_query`, returning the endpoint and

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.12"
+version = "0.6.13"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"
@@ -29,7 +29,7 @@ vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/vantage-api-client/src/rest/vista/factory.rs
+++ b/vantage-api-client/src/rest/vista/factory.rs
@@ -251,7 +251,8 @@ impl RestApiVistaFactory {
 /// The REST carrier is already CBOR, so no per-value conversion is needed.
 #[cfg(feature = "rhai")]
 fn add_lazy_column(table: &mut Table<RestApi, EmptyEntity>, name: &str, code: &str) -> Result<()> {
-    let script = vantage_vista::lazy_value_closure(code.to_string());
+    // Compiles once, here: a script that does not parse fails the table build.
+    let script = vantage_vista::lazy_value_closure(code)?;
     table.add_lazy_expression(
         name,
         Arc::new(move |record| {

--- a/vantage-cmd/CHANGELOG.md
+++ b/vantage-cmd/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.6.5 — 2026-09-05
+
+- Scripts run on a `vantage-rhai` host. The direct `rhai = "1.21"` pin — the
+  last 1.21 anywhere in the family — is replaced by `vantage-rhai`, so the
+  engine version is the one every other crate uses.
+- `CmdVocab { command, env, pass_path, base_dir }` is the security lock as a
+  `Vocab`: `run(args)` can only ever spawn the configured command with the
+  configured environment. `CompiledScript` compiles the script once on a
+  bounded (`Limits::background()`) host; each evaluation binds `conditions`,
+  `columns`, `limit`, `offset`, `id_column`, `id` and `row` through an `Env`.
+
 ## 0.6.4 — 2026-08-16
 
 - `CmdTableShell` implements `preview_query`. A cmd table's argv is assembled

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-cmd"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-rhai"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "rhai",
  "serde",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-cmd/Cargo.lock
+++ b/vantage-cmd/Cargo.lock
@@ -21,7 +21,6 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -461,25 +460,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "wasip2",
  "wasip3",
 ]
@@ -864,12 +851,6 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1451,7 +1432,6 @@ dependencies = [
  "async-trait",
  "ciborium",
  "indexmap",
- "rhai",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -1461,6 +1441,7 @@ dependencies = [
  "vantage-core",
  "vantage-dataset",
  "vantage-expressions",
+ "vantage-rhai",
  "vantage-table",
  "vantage-types",
  "vantage-vista",
@@ -1511,8 +1492,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vantage-rhai"
+version = "0.6.1"
+dependencies = [
+ "rhai",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "vantage-table"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1559,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.22"
+version = "0.6.24"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -25,7 +25,7 @@ vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
 
 # Rhai builds the argv and parses the output. "serde" gives us the
 # serde_json::Value <-> Dynamic bridge used by `parse_json`.
-rhai = { version = "1.21", features = ["serde", "sync"] }
+vantage-rhai = { version = "0.6", path = "../vantage-rhai" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/vantage-cmd/Cargo.toml
+++ b/vantage-cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-cmd"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -21,11 +21,11 @@ vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde
 vantage-expressions = { version = "0.6", path = "../vantage-expressions" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista" }
 
 # Rhai builds the argv and parses the output. "serde" gives us the
 # serde_json::Value <-> Dynamic bridge used by `parse_json`.
-vantage-rhai = { version = "0.6", path = "../vantage-rhai" }
+vantage-rhai = { version = "0.6.2", path = "../vantage-rhai" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -8,11 +8,12 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use vantage_rhai::rhai;
 
 use indexmap::IndexMap;
-use rhai::{Dynamic, Engine, EvalAltResult, Map, Position, Scope};
 use serde_json::Value as JsonValue;
 use vantage_core::{Result, error};
+use vantage_rhai::rhai::{Dynamic, Engine, EvalAltResult, Map, Position, Scope};
 
 use crate::condition::CmdCondition;
 use crate::exec::run_command;

--- a/vantage-cmd/src/rhai_engine.rs
+++ b/vantage-cmd/src/rhai_engine.rs
@@ -8,12 +8,13 @@
 
 use std::path::Path;
 use std::sync::Arc;
-use vantage_rhai::rhai;
 
 use indexmap::IndexMap;
 use serde_json::Value as JsonValue;
 use vantage_core::{Result, error};
-use vantage_rhai::rhai::{Dynamic, Engine, EvalAltResult, Map, Position, Scope};
+use vantage_rhai::rhai;
+use vantage_rhai::rhai::{Dynamic, Engine, EvalAltResult, Map, Position};
+use vantage_rhai::{Block, Compiled, Env, Host, Limits, Vocab};
 
 use crate::condition::CmdCondition;
 use crate::exec::run_command;
@@ -50,23 +51,28 @@ fn dynamic_to_arg(d: Dynamic) -> String {
     }
 }
 
-/// A rhai script with its `Engine` and parsed `AST` built once and reused
-/// for every evaluation. The locked `command`/`env` are baked into the
-/// engine's `run` binding at construction, so a [`CompiledScript`] is
-/// specific to one table's script + command + env.
-///
-/// Requires rhai's `sync` feature so `Engine`/`AST` are `Send + Sync` and
-/// the compiled script can be cached on the (clone-shared) [`Cmd`] and
-/// evaluated across `spawn_blocking` threads.
+/// The `cmd` vocabulary — `parse_json`, `parse_jsonl`, and `run` — with the
+/// locked `command`/`env` baked into `run` at construction, so a script only
+/// ever supplies argv. That is the security lock, and it is why this is a
+/// value (one per table's script + command + env) rather than a static.
+pub(crate) struct CmdVocab {
+    pub command: String,
+    pub env: IndexMap<String, String>,
+    pub pass_path: bool,
+    pub base_dir: Option<Arc<Path>>,
+}
+
+/// A script compiled once, on a host carrying its [`CmdVocab`], and reused
+/// for every evaluation. Cached on the (clone-shared) [`Cmd`] and evaluated
+/// across `spawn_blocking` threads — `vantage-rhai` builds rhai with `sync`,
+/// so the compiled script is `Send + Sync`.
 pub(crate) struct CompiledScript {
-    engine: Engine,
-    ast: rhai::AST,
+    script: Compiled<Block>,
 }
 
 impl CompiledScript {
-    /// Build the engine (registering `run`/`parse_json`/`parse_jsonl`) and
-    /// compile `script` to an `AST`. Both are done once; [`eval`](Self::eval)
-    /// reuses them.
+    /// Build the host (background limits, the vocabulary) and compile
+    /// `script` on it. Both are done once; [`eval`](Self::eval) reuses them.
     pub(crate) fn compile(
         command: String,
         env: IndexMap<String, String>,
@@ -74,8 +80,30 @@ impl CompiledScript {
         base_dir: Option<Arc<Path>>,
         script: &str,
     ) -> Result<Self> {
-        let mut engine = Engine::new();
-        engine.set_max_expr_depths(256, 256);
+        let host = Host::builder(Limits::background())
+            .vocab(CmdVocab {
+                command,
+                env,
+                pass_path,
+                base_dir,
+            })
+            .build();
+        let script = host.compile_uncached(&Block::from(script)).map_err(|e| {
+            error!(
+                "command rhai script failed to compile",
+                detail = e.to_string()
+            )
+        })?;
+        Ok(Self { script })
+    }
+}
+
+impl Vocab for CmdVocab {
+    fn register(&self, engine: &mut Engine) {
+        let command = self.command.clone();
+        let env = self.env.clone();
+        let pass_path = self.pass_path;
+        let base_dir = self.base_dir.clone();
 
         // parse_json(string) -> Dynamic
         engine.register_fn(
@@ -139,32 +167,25 @@ impl CompiledScript {
                 Ok(map)
             },
         );
-
-        let ast = engine.compile(script).map_err(|e| {
-            error!(
-                "command rhai script failed to compile",
-                detail = e.to_string()
-            )
-        })?;
-
-        Ok(Self { engine, ast })
     }
+}
 
-    /// Evaluate the compiled script with the `ctx` variables seeded into a
-    /// fresh scope, returning the rows the script produced as JSON objects.
+impl CompiledScript {
+    /// Evaluate the compiled script with the `ctx` variables in scope,
+    /// returning the rows the script produced as JSON objects.
     pub(crate) fn eval(&self, ctx: QueryContext) -> Result<Vec<JsonValue>> {
-        let mut scope = Scope::new();
-        scope.push_dynamic("conditions", conditions_dynamic(&ctx.conditions)?);
-        scope.push_dynamic("columns", to_dynamic(&ctx.columns)?);
-        scope.push_dynamic("limit", opt_int(ctx.limit));
-        scope.push_dynamic("offset", opt_int(ctx.offset));
-        scope.push_dynamic("id_column", opt_string(ctx.id_column));
-        scope.push_dynamic("id", opt_string(ctx.id));
-        scope.push_dynamic("row", to_dynamic(&ctx.row)?);
+        let env = Env::new()
+            .var("conditions", conditions_dynamic(&ctx.conditions)?)
+            .var("columns", to_dynamic(&ctx.columns)?)
+            .var("limit", opt_int(ctx.limit))
+            .var("offset", opt_int(ctx.offset))
+            .var("id_column", opt_string(ctx.id_column))
+            .var("id", opt_string(ctx.id))
+            .var("row", to_dynamic(&ctx.row)?);
 
         let result: Dynamic = self
-            .engine
-            .eval_ast_with_scope(&mut scope, &self.ast)
+            .script
+            .eval(&env)
             .map_err(|e| error!("command rhai script failed", detail = e.to_string()))?;
 
         if !result.is_array() {

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.12.5 — 2026-09-05
+
+- `ServoVocab` registers the servo surface (`form.field`, `form.save()`) as
+  a `vantage-rhai` `Vocab`; `register_servo_onto` stays as a shim.
+- The CBOR ↔ `Dynamic` converters are vista's: `cbor_to_dynamic` and
+  `record_to_map` are re-exported, and `dynamic_to_cbor` keeps only the
+  chrono-instant case before delegating. The `rhai` feature pulls
+  `vantage-vista/rhai` accordingly.
+
 ## 0.12.4 — 2026-08-29
 
 - `Dio::import_values(records, progress)` — bulk import that takes the

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -36,8 +36,10 @@ uuid = { version = "1", features = ["v7"] }
 
 [features]
 # Servo as a first-class Rhai type — the same treatment vantage-vista's
-# `rhai` feature gives queries. See `src/rhai.rs`.
-rhai = ["dep:vantage-rhai", "dep:chrono"]
+# `rhai` feature gives queries. See `src/rhai.rs`. Pulls vista's `rhai`
+# for the shared CBOR ⇄ Dynamic converters, so a value round-trips the same
+# way in a servo script as in a vista script.
+rhai = ["dep:vantage-rhai", "dep:chrono", "vantage-vista/rhai"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.12.4"
+version = "0.12.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types" }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista" }
 vantage-vista-factory = { version = "0.6", path = "../vantage-vista-factory" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
@@ -24,7 +24,7 @@ ciborium = { version = "0.2", features = ["std"] }
 # Rhai scripts hand `dynamic_to_cbor` chrono instants (`now()`), which
 # land as the standard CBOR datetime tag.
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
-vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
+vantage-rhai = { version = "0.6.2", path = "../vantage-rhai", optional = true }
 futures = "0.3"
 indexmap = "2"
 redb = "2.6"

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -24,7 +24,7 @@ ciborium = { version = "0.2", features = ["std"] }
 # Rhai scripts hand `dynamic_to_cbor` chrono instants (`now()`), which
 # land as the standard CBOR datetime tag.
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
-rhai = { version = "1.25", optional = true }
+vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
 futures = "0.3"
 indexmap = "2"
 redb = "2.6"
@@ -37,7 +37,7 @@ uuid = { version = "1", features = ["v7"] }
 [features]
 # Servo as a first-class Rhai type — the same treatment vantage-vista's
 # `rhai` feature gives queries. See `src/rhai.rs`.
-rhai = ["dep:rhai", "dep:chrono"]
+rhai = ["dep:vantage-rhai", "dep:chrono"]
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/vantage-diorama/src/rhai.rs
+++ b/vantage-diorama/src/rhai.rs
@@ -21,9 +21,10 @@
 //! `tokio::task::spawn_blocking`, never directly inside an async task.
 
 use std::sync::Arc;
+use vantage_rhai::rhai;
 
 use ciborium::Value as CborValue;
-use rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap};
+use vantage_rhai::rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap};
 use vantage_types::Record;
 
 use crate::servo::{Servo, ServoStatus};

--- a/vantage-diorama/src/rhai.rs
+++ b/vantage-diorama/src/rhai.rs
@@ -44,7 +44,7 @@ impl Vocab for ServoVocab {
 }
 
 /// Teach `engine` the `Servo` type and its methods. Prefer [`ServoVocab`] on
-/// a host; this is what it registers.
+/// a host — this is the registration behind it.
 pub fn register_servo_onto(engine: &mut Engine) {
     engine.register_type_with_name::<Arc<Servo>>("Servo");
 

--- a/vantage-diorama/src/rhai.rs
+++ b/vantage-diorama/src/rhai.rs
@@ -21,17 +21,30 @@
 //! `tokio::task::spawn_blocking`, never directly inside an async task.
 
 use std::sync::Arc;
-use vantage_rhai::rhai;
 
 use ciborium::Value as CborValue;
+use vantage_rhai::Vocab;
 use vantage_rhai::rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap};
-use vantage_types::Record;
+// One converter for the whole data layer: a record id renders as `table:id`
+// in a servo script exactly as it does in a vista script.
+pub use vantage_vista::{cbor_to_dynamic, record_to_map};
 
 use crate::servo::{Servo, ServoStatus};
 
-/// Teach `engine` the `Servo` type and its methods. The host decides how
-/// a script *obtains* a servo — a scope variable, a registered lookup fn
-/// — this only covers what a script can do once it holds one.
+/// The `Servo` type and its methods as a [`Vocab`]. The host decides how a
+/// script *obtains* a servo — an [`Env`](vantage_rhai::Env) variable, a
+/// registered lookup fn — this only covers what a script can do once it
+/// holds one.
+pub struct ServoVocab;
+
+impl Vocab for ServoVocab {
+    fn register(&self, engine: &mut Engine) {
+        register_servo_onto(engine);
+    }
+}
+
+/// Teach `engine` the `Servo` type and its methods. Prefer [`ServoVocab`] on
+/// a host; this is what it registers.
 pub fn register_servo_onto(engine: &mut Engine) {
     engine.register_type_with_name::<Arc<Servo>>("Servo");
 
@@ -136,92 +149,19 @@ pub fn register_servo_onto(engine: &mut Engine) {
     );
 }
 
-fn record_to_map(record: &Record<CborValue>) -> RhaiMap {
-    let mut map = RhaiMap::new();
-    for (key, value) in record.iter() {
-        map.insert(key.as_str().into(), cbor_to_dynamic(value));
-    }
-    map
-}
-
-/// CBOR → Dynamic, lossy only where Rhai has no representation (a tag is
-/// unwrapped to its value, bytes become a blob).
-pub fn cbor_to_dynamic(value: &CborValue) -> Dynamic {
-    match value {
-        CborValue::Null => Dynamic::UNIT,
-        CborValue::Bool(b) => Dynamic::from(*b),
-        CborValue::Integer(i) => {
-            let wide: i128 = (*i).into();
-            i64::try_from(wide)
-                .map(Dynamic::from)
-                .unwrap_or_else(|_| Dynamic::from(wide as f64))
-        }
-        CborValue::Float(f) => Dynamic::from(*f),
-        CborValue::Text(s) => Dynamic::from(s.clone()),
-        CborValue::Bytes(b) => Dynamic::from_blob(b.clone()),
-        CborValue::Array(items) => Dynamic::from_array(items.iter().map(cbor_to_dynamic).collect()),
-        CborValue::Map(pairs) => {
-            let mut map = RhaiMap::new();
-            for (k, v) in pairs {
-                if let CborValue::Text(key) = k {
-                    map.insert(key.as_str().into(), cbor_to_dynamic(v));
-                }
-            }
-            Dynamic::from_map(map)
-        }
-        CborValue::Tag(_, inner) => cbor_to_dynamic(inner),
-        _ => Dynamic::UNIT,
-    }
-}
-
-/// Dynamic → CBOR. Errors on types with no CBOR story (closures, custom
-/// types) — a script setting one on a servo is a bug worth naming.
+/// Dynamic → CBOR. An instant (a host's `now()`) travels as the standard
+/// CBOR datetime — tag 0 over RFC 3339 text — which every driver that has a
+/// datetime type reads as one; the SurrealDB driver accepts it beside its
+/// own compact tag 12. That case is diorama's (it owns `chrono` under the
+/// `rhai` feature); everything else is vista's one converter, which errors
+/// on types with no CBOR story — a script setting a closure on a servo is a
+/// bug worth naming.
 pub fn dynamic_to_cbor(value: &Dynamic) -> Result<CborValue, Box<EvalAltResult>> {
-    if value.is_unit() {
-        return Ok(CborValue::Null);
-    }
-    if let Some(b) = value.clone().try_cast::<bool>() {
-        return Ok(CborValue::Bool(b));
-    }
-    if let Some(i) = value.clone().try_cast::<i64>() {
-        return Ok(CborValue::Integer(i.into()));
-    }
-    if let Some(f) = value.clone().try_cast::<f64>() {
-        return Ok(CborValue::Float(f));
-    }
-    if let Some(s) = value.clone().try_cast::<String>() {
-        return Ok(CborValue::Text(s));
-    }
-    if let Some(blob) = value.clone().try_cast::<rhai::Blob>() {
-        return Ok(CborValue::Bytes(blob));
-    }
-    // An instant (a host's `now()`) travels as the standard CBOR
-    // datetime — tag 0 over RFC 3339 text — which every driver that has
-    // a datetime type reads as one; the SurrealDB driver accepts it
-    // beside its own compact tag 12.
     if let Some(dt) = value.clone().try_cast::<chrono::DateTime<chrono::Utc>>() {
         return Ok(CborValue::Tag(
             0,
             Box::new(CborValue::Text(dt.to_rfc3339())),
         ));
     }
-    if let Some(array) = value.clone().try_cast::<rhai::Array>() {
-        let items = array
-            .iter()
-            .map(dynamic_to_cbor)
-            .collect::<Result<Vec<_>, _>>()?;
-        return Ok(CborValue::Array(items));
-    }
-    if let Some(map) = value.clone().try_cast::<RhaiMap>() {
-        let pairs = map
-            .iter()
-            .map(|(k, v)| Ok((CborValue::Text(k.to_string()), dynamic_to_cbor(v)?)))
-            .collect::<Result<Vec<_>, Box<EvalAltResult>>>()?;
-        return Ok(CborValue::Map(pairs));
-    }
-    Err(format!(
-        "no CBOR representation for rhai type '{}'",
-        value.type_name()
-    )
-    .into())
+    vantage_vista::dynamic_to_cbor(value.clone())
 }

--- a/vantage-diorama/tests/rhai_servo.rs
+++ b/vantage-diorama/tests/rhai_servo.rs
@@ -7,10 +7,10 @@
 use std::sync::Arc;
 
 use ciborium::Value as CborValue;
-use rhai::{Dynamic, Engine, Scope};
 use vantage_core::Result;
 use vantage_diorama::rhai::register_servo_onto;
 use vantage_diorama::{Dio, IdStrategy, Lens, Servo};
+use vantage_rhai::rhai::{Dynamic, Engine, Scope};
 use vantage_types::Record;
 use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
 

--- a/vantage-diorama/tests/rhai_servo.rs
+++ b/vantage-diorama/tests/rhai_servo.rs
@@ -8,11 +8,20 @@ use std::sync::Arc;
 
 use ciborium::Value as CborValue;
 use vantage_core::Result;
-use vantage_diorama::rhai::register_servo_onto;
+use vantage_diorama::rhai::ServoVocab;
 use vantage_diorama::{Dio, IdStrategy, Lens, Servo};
-use vantage_rhai::rhai::{Dynamic, Engine, Scope};
+use vantage_rhai::rhai::Dynamic;
+use vantage_rhai::{Block, Env, Host, Limits};
 use vantage_types::Record;
 use vantage_vista::{Column, Vista, VistaMetadata, mocks::MockShell};
+
+/// The host every script here runs on: background limits (a blocking
+/// thread), the servo vocabulary.
+fn host() -> Host {
+    Host::builder(Limits::background())
+        .vocab(ServoVocab)
+        .build()
+}
 
 fn text(s: &str) -> CborValue {
     CborValue::Text(s.to_string())
@@ -34,12 +43,9 @@ async fn dio_over(shell: &MockShell) -> Result<Dio> {
 /// Evaluate `script` with `servo` in scope, on a blocking thread.
 async fn eval(servo: Arc<Servo>, script: &'static str) -> std::result::Result<Dynamic, String> {
     tokio::task::spawn_blocking(move || {
-        let mut engine = Engine::new();
-        register_servo_onto(&mut engine);
-        let mut scope = Scope::new();
-        scope.push("servo", servo);
-        engine
-            .eval_with_scope::<Dynamic>(&mut scope, script)
+        host()
+            .compile(&Block::from(script))
+            .and_then(|s| s.eval(&Env::new().var("servo", Dynamic::from(servo))))
             .map_err(|e| e.to_string())
     })
     .await
@@ -169,13 +175,15 @@ async fn an_instant_writes_as_a_cbor_datetime() -> Result<()> {
 
     let servo_for_script = servo.clone();
     let _ = tokio::task::spawn_blocking(move || {
-        let mut engine = Engine::new();
-        register_servo_onto(&mut engine);
-        let mut scope = Scope::new();
-        scope.push("servo", servo_for_script);
-        scope.push("stamp", stamp);
-        engine
-            .eval_with_scope::<Dynamic>(&mut scope, r#"servo.set("created", stamp)"#)
+        host()
+            .compile(&Block::from(r#"servo.set("created", stamp)"#))
+            .and_then(|s| {
+                s.eval(
+                    &Env::new()
+                        .var("servo", Dynamic::from(servo_for_script))
+                        .var("stamp", Dynamic::from(stamp)),
+                )
+            })
             .map_err(|e| e.to_string())
     })
     .await

--- a/vantage-faker/CHANGELOG.md
+++ b/vantage-faker/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.15 — 2026-09-05
+
+- The `rhai` effect compiles its mutation script **once**, when the effect
+  starts, and runs the compiled script per tick on a bounded `vantage-rhai`
+  host — before, a fresh engine was built on every tick, up to 50 Hz. A
+  script that does not parse now fails at start instead of on every tick.
+- `FakerVocab(Arc<FakerCtx>)` carries the verbs as a `Vocab`.
+
 ## 0.6.14 — 2026-08-16
 
 - The shaped and live-folder shells implement `preview_query`. Shaping forwards

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -21,7 +21,6 @@ checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -798,25 +797,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
 ]
 
@@ -1132,6 +1119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,12 +1350,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1487,9 +1477,11 @@ checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
 dependencies = [
  "ahash 0.8.12",
  "bitflags",
+ "no-std-compat",
  "num-traits",
  "once_cell",
  "rhai_codegen",
+ "serde",
  "smallvec",
  "smartstring",
  "thin-vec",
@@ -1711,6 +1703,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smart-default"
@@ -1730,6 +1725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
+ "serde",
  "static_assertions",
  "version_check",
 ]
@@ -1749,6 +1745,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -1868,6 +1870,9 @@ name = "thin-vec"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "thiserror"
@@ -2139,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2183,7 +2188,6 @@ dependencies = [
  "cucumber",
  "fake",
  "indexmap",
- "rhai",
  "serde_json",
  "tempfile",
  "tokio",
@@ -2192,14 +2196,25 @@ dependencies = [
  "vantage-core",
  "vantage-dataset",
  "vantage-diorama",
+ "vantage-rhai",
  "vantage-types",
  "vantage-vista",
  "vantage-vista-factory",
 ]
 
 [[package]]
+name = "vantage-rhai"
+version = "0.6.1"
+dependencies = [
+ "rhai",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "vantage-table"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2246,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.22"
+version = "0.6.24"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2304,15 +2319,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2550,12 +2556,6 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wyz"

--- a/vantage-faker/Cargo.lock
+++ b/vantage-faker/Cargo.lock
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-faker"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "async-trait",
  "ciborium",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-rhai"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "rhai",
  "serde",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.24"
+version = "0.6.25"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -36,12 +36,12 @@ fake = "5"
 
 # `effect: rhai` — scripted mutation loops. Same rhai as vantage-vista's
 # scripting feature, kept optional so the default build stays light.
-rhai = { version = "1.25", optional = true }
+vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
 
 tracing = "0.1"
 
 [features]
-rhai = ["dep:rhai"]
+rhai = ["dep:vantage-rhai"]
 
 [dev-dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }

--- a/vantage-faker/Cargo.toml
+++ b/vantage-faker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-faker"
-version = "0.6.14"
+version = "0.6.15"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -17,7 +17,7 @@ readme = "README.md"
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista" }
 vantage-diorama = { version = "0.12", path = "../vantage-diorama" }
 # `TableShell::preview_query` answers with a driver-shaped JSON value.
 serde_json = "1"
@@ -36,7 +36,7 @@ fake = "5"
 
 # `effect: rhai` — scripted mutation loops. Same rhai as vantage-vista's
 # scripting feature, kept optional so the default build stays light.
-vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
+vantage-rhai = { version = "0.6.2", path = "../vantage-rhai", optional = true }
 
 tracing = "0.1"
 

--- a/vantage-faker/src/rhai_effect.rs
+++ b/vantage-faker/src/rhai_effect.rs
@@ -20,11 +20,12 @@
 
 use std::sync::Arc;
 use std::time::Duration;
+use vantage_rhai::rhai;
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
-use rhai::{Dynamic, Engine, Map as RhaiMap};
 use tokio::time::interval;
+use vantage_rhai::rhai::{Dynamic, Engine, Map as RhaiMap};
 use vantage_types::Record;
 
 use crate::effect::{FakerCtx, FakerEffect};

--- a/vantage-faker/src/rhai_effect.rs
+++ b/vantage-faker/src/rhai_effect.rs
@@ -11,21 +11,24 @@
 //! `patch(id, #{…})`, `insert(#{…})`, `delete(id)` mutate and broadcast;
 //! `fake(kind)`, `rand_int(a,b)`, `rand_float(a,b)`, `pick(array)` generate.
 //!
-//! A Rhai `Engine` is not `Send`, so each tick's evaluation runs inside
-//! `spawn_blocking` with a fresh engine — for the scripts these scenarios
-//! carry (a handful of statements at ≤50 ticks/s) construction cost is
-//! noise. A script that fails stops the loop after logging once: a static
-//! script that failed will fail every tick, and a sim whose data stops
-//! moving is a louder, cheaper signal than an error log at 50 Hz.
+//! The script compiles once, on a [`vantage_rhai::Host`] carrying the verbs
+//! as [`FakerVocab`] under the background limit profile; each tick's
+//! evaluation runs inside `spawn_blocking` against that compiled script (a
+//! runaway loop in a tick used to hang a blocking thread forever). A script
+//! that fails stops the loop after logging once: a static script that failed
+//! will fail every tick, and a sim whose data stops moving is a louder,
+//! cheaper signal than an error log at 50 Hz. A script that does not even
+//! compile stops it before the first tick.
 
 use std::sync::Arc;
 use std::time::Duration;
-use vantage_rhai::rhai;
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
 use tokio::time::interval;
+use vantage_rhai::rhai;
 use vantage_rhai::rhai::{Dynamic, Engine, Map as RhaiMap};
+use vantage_rhai::{Block, Compiled, Env, Host, Limits, Vocab};
 use vantage_types::Record;
 
 use crate::effect::{FakerCtx, FakerEffect};
@@ -50,14 +53,20 @@ impl FakerEffect for RhaiEffect {
     }
 
     async fn run(&self, ctx: Arc<FakerCtx>) {
+        // Compile once. A script that does not parse never ticks.
+        let script = match compile_effect(&ctx, &self.script) {
+            Ok(script) => Arc::new(script),
+            Err(e) => {
+                tracing::error!(error = %e, "rhai faker effect failed to compile; not starting its mutation loop");
+                return;
+            }
+        };
         let mut ticker = interval(self.interval);
         let mut tick: i64 = 0;
         loop {
             ticker.tick().await;
-            let script = self.script.clone();
-            let tick_ctx = ctx.clone();
-            let result =
-                tokio::task::spawn_blocking(move || run_tick(&tick_ctx, &script, tick)).await;
+            let script = script.clone();
+            let result = tokio::task::spawn_blocking(move || run_compiled(&script, tick)).await;
             match result {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
@@ -74,15 +83,39 @@ impl FakerEffect for RhaiEffect {
     }
 }
 
-/// One evaluation: fresh engine, verbs bound to `ctx`, `tick` in scope.
-fn run_tick(ctx: &Arc<FakerCtx>, script: &str, tick: i64) -> std::result::Result<(), String> {
-    let mut engine = Engine::new();
-    register_verbs(&mut engine, ctx);
-    let mut scope = rhai::Scope::new();
-    scope.push("tick", tick);
-    engine
-        .run_with_scope(&mut scope, script)
+/// The mutation verbs, bound to one store, as a [`Vocab`].
+pub struct FakerVocab(pub Arc<FakerCtx>);
+
+impl Vocab for FakerVocab {
+    fn register(&self, engine: &mut Engine) {
+        register_verbs(engine, &self.0);
+    }
+}
+
+/// Build the host and compile `script` on it, once per effect.
+fn compile_effect(
+    ctx: &Arc<FakerCtx>,
+    script: &str,
+) -> std::result::Result<Compiled<Block>, String> {
+    let host = Host::builder(Limits::background())
+        .vocab(FakerVocab(ctx.clone()))
+        .build();
+    host.compile_uncached(&Block::from(script))
         .map_err(|e| e.to_string())
+}
+
+/// One evaluation of the compiled script with `tick` in scope.
+fn run_compiled(script: &Compiled<Block>, tick: i64) -> std::result::Result<(), String> {
+    script
+        .run(&Env::new().var("tick", tick))
+        .map_err(|e| e.to_string())
+}
+
+/// Compile and run once — the test path. The effect loop compiles once and
+/// runs many.
+#[cfg(test)]
+fn run_tick(ctx: &Arc<FakerCtx>, script: &str, tick: i64) -> std::result::Result<(), String> {
+    run_compiled(&compile_effect(ctx, script)?, tick)
 }
 
 fn register_verbs(engine: &mut Engine, ctx: &Arc<FakerCtx>) {

--- a/vantage-rhai/CHANGELOG.md
+++ b/vantage-rhai/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.6.2 — 2026-09-05
+
+Additions made while the data layer and vantage-ui moved onto the host.
+
+- `Compiled<Block>` gains the value methods (`eval`, `eval_as`, `eval_bool`)
+  next to `run`: a script whose last statement is its answer no longer needs
+  to be re-typed as an expression.
+- `Compiled::engine()` and `Compiled::ast()` expose the compiled pair for
+  the one caller shape the host cannot express — evaluating to a `FnPtr`
+  once and calling it per line (a log filter).
+- The slot types (`Expr`, `Template`, `Block`) implement `Deref<Target =
+  str>`, `AsRef<str>`, `Display`, `Default`, `PartialEq<str>` and
+  `PartialEq<&str>`, so a YAML field can change from `Option<String>` to
+  the slot without touching readers that only display or compare it. The
+  kind still matters where it counts: `Host::compile` takes the typed slot.
+- Parse errors keep rhai's `Syntax error:` prefix in `Display`, matching
+  the fixtures downstream crates assert against.
+
 ## 0.6.1 — 2026-09-04
 
 Review fixes, all with regression tests.

--- a/vantage-rhai/Cargo.toml
+++ b/vantage-rhai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-rhai"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "One Rhai host for every Vantage YAML script slot: slot types, limits, vocab/resolver traits, discovery, template scanner"

--- a/vantage-rhai/src/compiled.rs
+++ b/vantage-rhai/src/compiled.rs
@@ -315,6 +315,8 @@ macro_rules! value_methods {
 
 value_methods!(Expr);
 value_methods!(Template);
+// A script's final expression is its value, so the typed accessors apply.
+value_methods!(Block);
 
 impl Compiled<Template> {
     /// No holes: a static value.
@@ -327,13 +329,10 @@ impl Compiled<Template> {
 }
 
 impl Compiled<Block> {
+    /// Run for effect; the final value (if any) is discarded. `eval` returns
+    /// it instead, unit when the script ends on a statement.
     pub fn run(&self, env: &Env) -> Result<()> {
         self.eval_dynamic(env).map(|_| ())
-    }
-
-    /// The script's final expression value, unit when there is none.
-    pub fn eval(&self, env: &Env) -> Result<Dynamic> {
-        self.eval_dynamic(env)
     }
 }
 

--- a/vantage-rhai/src/compiled.rs
+++ b/vantage-rhai/src/compiled.rs
@@ -218,6 +218,26 @@ impl<S: Slot> Compiled<S> {
         &self.src
     }
 
+    /// The engine this slot was compiled on. For callers that hand a value
+    /// back to rhai themselves — a closure's `FnPtr::call` needs the engine
+    /// and the AST that defined it.
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    /// The one compiled AST behind an `Expr` or `Block` (or a template that is
+    /// a single hole). `None` for a template with text around its holes, which
+    /// has one AST per hole and no single script to hand out.
+    pub fn ast(&self) -> Option<&AST> {
+        match &self.pieces {
+            Pieces::One(ast) => Some(ast),
+            Pieces::Parts(parts) => match parts.as_slice() {
+                [TPart::Hole { ast, .. }] => Some(ast),
+                _ => None,
+            },
+        }
+    }
+
     /// Dotted paths read through the resolver during discovery. Empty until
     /// `discover` has run.
     pub fn read_set(&self) -> &BTreeSet<String> {

--- a/vantage-rhai/src/error.rs
+++ b/vantage-rhai/src/error.rs
@@ -33,11 +33,14 @@ impl RhaiError {
         }
     }
 
+    /// Classify a compile error. The message keeps rhai's own "Syntax error:"
+    /// prefix, which `Engine::eval` used to add and which a separate compile
+    /// step does not — so an author sees the same words either way.
     pub fn from_parse(src: &str, err: ParseError) -> Self {
         RhaiError::Syntax(Located::new(
             src,
             err.position(),
-            err.err_type().to_string(),
+            format!("Syntax error: {}", err.err_type()),
         ))
     }
 
@@ -78,9 +81,12 @@ impl RhaiError {
                 path: name,
                 src: src_s,
             },
-            EvalAltResult::ErrorParsing(err_type, pos) => {
-                RhaiError::Syntax(Located::at(src, pos, err_type.to_string(), remap))
-            }
+            EvalAltResult::ErrorParsing(err_type, pos) => RhaiError::Syntax(Located::at(
+                src,
+                pos,
+                format!("Syntax error: {err_type}"),
+                remap,
+            )),
             other => {
                 let pos = other.position();
                 // `to_string()` already embeds the position; keep the message

--- a/vantage-rhai/src/host.rs
+++ b/vantage-rhai/src/host.rs
@@ -1,7 +1,7 @@
 //! A configured engine plus a bounded AST cache. Built once per owner, shared.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 
 use rhai::{AST, Engine};
 
@@ -77,6 +77,28 @@ pub struct Host {
     engine: Arc<Engine>,
     limits: Limits,
     cache: AstCache,
+}
+
+/// The shared vocabulary-free host for work the UI thread waits on — a
+/// projection formula, a list row's template, an action argument. Every such
+/// site wants the same object, so they share one AST cache rather than each
+/// keeping a private copy of the same compiled scripts.
+///
+/// Take a host of your own ([`Host::builder`]) as soon as you need a verb;
+/// this one has none, deliberately, so nothing can come to depend on a
+/// vocabulary another caller registered.
+pub fn ui_host() -> &'static Host {
+    static HOST: LazyLock<Host> = LazyLock::new(|| Host::builder(Limits::Ui).build());
+    &HOST
+}
+
+/// The vocabulary-free host's background twin: same absence of verbs, the
+/// larger budget. For scripts that run off the UI thread — inside a fetch,
+/// per stream line — where a runaway must still be stopped rather than
+/// waited on.
+pub fn background_host() -> &'static Host {
+    static HOST: LazyLock<Host> = LazyLock::new(|| Host::builder(Limits::background()).build());
+    &HOST
 }
 
 impl Host {

--- a/vantage-rhai/src/lib.rs
+++ b/vantage-rhai/src/lib.rs
@@ -29,7 +29,7 @@ pub mod template;
 
 pub use compiled::{Compiled, Env, Slot};
 pub use error::{Located, Result, RhaiError};
-pub use host::{AST_CACHE_BOUND, Host, HostBuilder, Mode, Vocab};
+pub use host::{AST_CACHE_BOUND, Host, HostBuilder, Mode, Vocab, background_host, ui_host};
 pub use json::{from_json, to_json};
 pub use limits::{BACKGROUND_MAX_OPERATIONS, Limits, UI_MAX_OPERATIONS};
 pub use resolver::{Lookup, Resolver};

--- a/vantage-rhai/src/slot.rs
+++ b/vantage-rhai/src/slot.rs
@@ -6,9 +6,21 @@ use serde::{Deserialize, Serialize};
 macro_rules! slot {
     ($(#[$doc:meta])* $name:ident, $desc:literal) => {
         $(#[$doc])*
-        #[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+        #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
         #[serde(transparent)]
         pub struct $name(String);
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
 
         impl $name {
             pub fn src(&self) -> &str {
@@ -26,6 +38,30 @@ macro_rules! slot {
         impl From<String> for $name {
             fn from(s: String) -> Self {
                 Self(s)
+            }
+        }
+
+        // A slot reads as its source text wherever a `&str` is wanted, so a
+        // struct field can change from `Option<String>` to `Option<$name>`
+        // without touching the sites that only display or compare it. The
+        // kind still matters where it counts: `Host::compile` takes the
+        // typed slot, never a bare string.
+        impl std::ops::Deref for $name {
+            type Target = str;
+            fn deref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
             }
         }
 

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.6.22 — 2026-09-05
+
+- The `rhai` feature runs on a `vantage-rhai` host: `register_engine!` emits
+  a `SqlVocab` for the dialect plus one lazily built, bounded host
+  (`__host()`), and `__create_engine` is gone. Query-source scripts compile
+  through the host's cache — a table's script parses once, not per build.
+- `eval_to_select_args` binds `args` and `base` through an `Env`;
+  `eval_to_select` delegates to it. The `rhai` crate is reached as
+  `vantage_sql::rhai_engine::rhai` (re-exported from `vantage-rhai`), so a
+  consumer no longer needs its own `rhai` dependency to match versions.
+- An unknown identifier in a script now reads "unknown name `x`" (the host's
+  message) rather than rhai's variable-not-found text.
+
 ## 0.6.21 — 2026-08-25
 
 - **Observation args for `rhai:` vistas.** A query-sourced table's script can

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -15,7 +15,7 @@ sqlite = ["sqlx/sqlite"]
 postgres = ["sqlx/postgres"]
 mysql = ["sqlx/mysql"]
 vista = ["dep:vantage-vista"]
-rhai = ["dep:rhai", "vantage-vista?/rhai"]
+rhai = ["dep:vantage-rhai", "vantage-vista?/rhai"]
 
 [dependencies]
 vantage-core = { version = "0.6", path = "../vantage-core" }
@@ -42,7 +42,7 @@ ciborium = "0.2"
 hex = "0.4"
 indexmap = { version = "2.14.0", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
-rhai = { version = "1.25", optional = true }
+vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.21"
+version = "0.6.22"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
@@ -25,7 +25,7 @@ paste = "1.0"
 
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-table = { version = "0.6", path = "../vantage-table" }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista", optional = true }
 async-trait = "0.1"
 # Drivers occasionally need to report a data-modelling problem that is not
 # an error (a non-unique id column collapsing rows, say) — a facade, so the
@@ -42,12 +42,12 @@ ciborium = "0.2"
 hex = "0.4"
 indexmap = { version = "2.14.0", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
-vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
+vantage-rhai = { version = "0.6.2", path = "../vantage-rhai", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 serde_yaml_ng = "0.10"
-vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista" }
 sqlformat = "0.3"
 
 # The name must be unique across the workspace: cargo writes every

--- a/vantage-sql/examples/rhai_test.rs
+++ b/vantage-sql/examples/rhai_test.rs
@@ -9,6 +9,7 @@
 use std::fs;
 use std::path::Path;
 use std::process;
+use vantage_rhai::{Block, Env, RhaiError};
 
 fn format_sql(sql: &str) -> String {
     let options = sqlformat::FormatOptions {
@@ -39,8 +40,8 @@ mod sqlite_engine {
 
     pub type Select = RhaiSelect<AnySqliteType, SqliteSelect, SqliteSelectJoin, SqliteCondition>;
 
-    pub fn create() -> rhai::Engine {
-        __create_engine()
+    pub fn host() -> &'static vantage_rhai::Host {
+        __host()
     }
 }
 
@@ -62,8 +63,8 @@ mod postgres_engine {
     pub type Select =
         RhaiSelect<AnyPostgresType, PostgresSelect, PostgresSelectJoin, PostgresCondition>;
 
-    pub fn create() -> rhai::Engine {
-        __create_engine()
+    pub fn host() -> &'static vantage_rhai::Host {
+        __host()
     }
 }
 
@@ -84,8 +85,8 @@ mod mysql_engine {
 
     pub type Select = RhaiSelect<AnyMysqlType, MysqlSelect, MysqlSelectJoin, MysqlCondition>;
 
-    pub fn create() -> rhai::Engine {
-        __create_engine()
+    pub fn host() -> &'static vantage_rhai::Host {
+        __host()
     }
 }
 
@@ -123,22 +124,25 @@ fn main() {
 
         #[cfg(feature = "sqlite")]
         run_test(&mut pass, &mut fail, "sqlite", name, &code, fix, |e| {
-            sqlite_engine::create()
-                .eval::<sqlite_engine::Select>(e)
+            sqlite_engine::host()
+                .compile(&Block::from(e))
+                .and_then(|s| s.eval_as::<sqlite_engine::Select>(&Env::new()))
                 .map(|s| s.inner.preview())
         });
 
         #[cfg(feature = "postgres")]
         run_test(&mut pass, &mut fail, "postgres", name, &code, fix, |e| {
-            postgres_engine::create()
-                .eval::<postgres_engine::Select>(e)
+            postgres_engine::host()
+                .compile(&Block::from(e))
+                .and_then(|s| s.eval_as::<postgres_engine::Select>(&Env::new()))
                 .map(|s| s.inner.preview())
         });
 
         #[cfg(feature = "mysql")]
         run_test(&mut pass, &mut fail, "mysql", name, &code, fix, |e| {
-            mysql_engine::create()
-                .eval::<mysql_engine::Select>(e)
+            mysql_engine::host()
+                .compile(&Block::from(e))
+                .and_then(|s| s.eval_as::<mysql_engine::Select>(&Env::new()))
                 .map(|s| s.inner.preview())
         });
     }
@@ -158,7 +162,7 @@ fn run_test<F>(
     fix: bool,
     eval: F,
 ) where
-    F: Fn(&str) -> Result<String, Box<rhai::EvalAltResult>>,
+    F: Fn(&str) -> Result<String, RhaiError>,
 {
     let base = test_dir();
     let common_sql = base.join(format!("common/{}.sql", name));

--- a/vantage-sql/src/mysql/vista/rhai_source.rs
+++ b/vantage-sql/src/mysql/vista/rhai_source.rs
@@ -6,8 +6,8 @@
 //! *transform* an existing query rather than build one from scratch.
 //!
 //! `register_engine!` expands to a full engine toolkit (conversion helpers,
-//! type aliases); a vista source only needs `__create_engine` + `eval`, so the
-//! unused generated items are allowed here.
+//! type aliases); a vista source only needs `__host` + `Sel`, so the unused
+//! generated items are allowed here.
 #![allow(dead_code)]
 
 // NOTE: do not `use vantage_core::Result` here — `register_engine!` expands to
@@ -18,6 +18,7 @@ use crate::mysql::AnyMysqlType;
 use crate::mysql::statements::MysqlSelect;
 use crate::mysql::statements::select::join::MysqlSelectJoin;
 
+// `register_engine!` imports `rhai` into this scope.
 crate::register_engine!(
     value: AnyMysqlType,
     select: MysqlSelect,
@@ -43,18 +44,19 @@ pub(crate) fn eval_to_select_args(
     base: Option<MysqlSelect>,
     args: &[(String, String)],
 ) -> vantage_core::Result<MysqlSelect> {
-    let engine = __create_engine();
-    let mut scope = rhai::Scope::new();
     let mut map = rhai::Map::new();
     for (k, v) in args {
         map.insert(k.as_str().into(), v.clone().into());
     }
-    scope.push_constant("args", map);
+    let mut env = vantage_rhai::Env::new().var("args", rhai::Dynamic::from_map(map));
     if let Some(base) = base {
-        scope.push("base", Sel::new(base));
+        env = env.var("base", rhai::Dynamic::from(Sel::new(base)));
     }
-    engine
-        .eval_with_scope::<Sel>(&mut scope, code)
+    // Statements, not a lone expression: a `let` in an existing `rhai:` block
+    // keeps working, and the final expression is the select.
+    __host()
+        .compile(&vantage_rhai::Block::from(code))
+        .and_then(|script| script.eval_as::<Sel>(&env))
         .map(|select| select.into_inner())
         .map_err(|e| {
             vantage_core::error!(
@@ -68,19 +70,5 @@ pub(crate) fn eval_to_select(
     code: &str,
     base: Option<MysqlSelect>,
 ) -> vantage_core::Result<MysqlSelect> {
-    let engine = __create_engine();
-    let evaluated = match base {
-        Some(base) => {
-            let mut scope = rhai::Scope::new();
-            scope.push("base", Sel::new(base));
-            engine.eval_with_scope::<Sel>(&mut scope, code)
-        }
-        None => engine.eval::<Sel>(code),
-    };
-    evaluated.map(|select| select.into_inner()).map_err(|e| {
-        vantage_core::error!(
-            "Rhai vista source failed to evaluate",
-            detail = e.to_string()
-        )
-    })
+    eval_to_select_args(code, base, &[])
 }

--- a/vantage-sql/src/postgres/vista/rhai_source.rs
+++ b/vantage-sql/src/postgres/vista/rhai_source.rs
@@ -6,8 +6,8 @@
 //! *transform* an existing query rather than build one from scratch.
 //!
 //! `register_engine!` expands to a full engine toolkit (conversion helpers,
-//! type aliases); a vista source only needs `__create_engine` + `eval`, so the
-//! unused generated items are allowed here.
+//! type aliases); a vista source only needs `__host` + `Sel`, so the unused
+//! generated items are allowed here.
 #![allow(dead_code)]
 
 // NOTE: do not `use vantage_core::Result` here — `register_engine!` expands to
@@ -18,6 +18,7 @@ use crate::postgres::AnyPostgresType;
 use crate::postgres::statements::PostgresSelect;
 use crate::postgres::statements::select::join::PostgresSelectJoin;
 
+// `register_engine!` imports `rhai` into this scope.
 crate::register_engine!(
     value: AnyPostgresType,
     select: PostgresSelect,
@@ -43,18 +44,19 @@ pub(crate) fn eval_to_select_args(
     base: Option<PostgresSelect>,
     args: &[(String, String)],
 ) -> vantage_core::Result<PostgresSelect> {
-    let engine = __create_engine();
-    let mut scope = rhai::Scope::new();
     let mut map = rhai::Map::new();
     for (k, v) in args {
         map.insert(k.as_str().into(), v.clone().into());
     }
-    scope.push_constant("args", map);
+    let mut env = vantage_rhai::Env::new().var("args", rhai::Dynamic::from_map(map));
     if let Some(base) = base {
-        scope.push("base", Sel::new(base));
+        env = env.var("base", rhai::Dynamic::from(Sel::new(base)));
     }
-    engine
-        .eval_with_scope::<Sel>(&mut scope, code)
+    // Statements, not a lone expression: a `let` in an existing `rhai:` block
+    // keeps working, and the final expression is the select.
+    __host()
+        .compile(&vantage_rhai::Block::from(code))
+        .and_then(|script| script.eval_as::<Sel>(&env))
         .map(|select| select.into_inner())
         .map_err(|e| {
             vantage_core::error!(
@@ -68,19 +70,5 @@ pub(crate) fn eval_to_select(
     code: &str,
     base: Option<PostgresSelect>,
 ) -> vantage_core::Result<PostgresSelect> {
-    let engine = __create_engine();
-    let evaluated = match base {
-        Some(base) => {
-            let mut scope = rhai::Scope::new();
-            scope.push("base", Sel::new(base));
-            engine.eval_with_scope::<Sel>(&mut scope, code)
-        }
-        None => engine.eval::<Sel>(code),
-    };
-    evaluated.map(|select| select.into_inner()).map_err(|e| {
-        vantage_core::error!(
-            "Rhai vista source failed to evaluate",
-            detail = e.to_string()
-        )
-    })
+    eval_to_select_args(code, base, &[])
 }

--- a/vantage-sql/src/rhai_engine/constructors.rs
+++ b/vantage-sql/src/rhai_engine/constructors.rs
@@ -5,9 +5,10 @@
 
 use crate::primitives::fx::Fx;
 use crate::primitives::identifier::{Identifier, ident as make_ident};
-use rhai::Array;
 use std::fmt::{Debug, Display};
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_rhai::rhai;
+use vantage_rhai::rhai::Array;
 
 use super::{RhaiExpr, RhaiIdent};
 

--- a/vantage-sql/src/rhai_engine/convert.rs
+++ b/vantage-sql/src/rhai_engine/convert.rs
@@ -1,7 +1,8 @@
 //! Type conversion helpers for Rhai ↔ Rust interop.
 
-use rhai::Dynamic;
 use vantage_expressions::Order;
+use vantage_rhai::rhai;
+use vantage_rhai::rhai::Dynamic;
 
 pub fn parse_order(dir: &str) -> Result<Order, Box<rhai::EvalAltResult>> {
     match dir.to_lowercase().as_str() {

--- a/vantage-sql/src/rhai_engine/dialect_functions.rs
+++ b/vantage-sql/src/rhai_engine/dialect_functions.rs
@@ -2,8 +2,9 @@
 //!
 //! These functions generate the correct SQL syntax for each database backend.
 
+use vantage_rhai::rhai;
 use std::fmt::{Debug, Display};
-use rhai::Array;
+use vantage_rhai::rhai::Array;
 use vantage_expressions::{Expressive, ExpressiveEnum, Expression};
 use crate::primitives::identifier::Identifier;
 use super::{RhaiExpr, RhaiIdent};

--- a/vantage-sql/src/rhai_engine/mod.rs
+++ b/vantage-sql/src/rhai_engine/mod.rs
@@ -5,6 +5,11 @@
 //! etc.) each generate a piece of the engine. They share type aliases
 //! defined once by `register_engine!` in the same expansion scope.
 
+// Public so `register_engine!` can name the host crate through `$crate` from
+// any invocation site (a test, an example) without that site depending on it.
+pub use vantage_rhai;
+pub use vantage_rhai::rhai;
+
 #[macro_use]
 pub mod types;
 #[macro_use]
@@ -35,6 +40,12 @@ macro_rules! register_engine {
         cond: $Cond:ty
         $(,)?
     ) => {
+        // The sub-macros below name `rhai::` bare, so the expansion brings the
+        // host crate's rhai into the invoking scope. Callers must not import
+        // it themselves.
+        #[allow(unused_imports)]
+        use $crate::rhai_engine::rhai;
+
         // ── Shared type aliases ─────────────────────────────────────
         type Expr = $crate::vantage_expressions::Expression<$V>;
         type Sel = $crate::rhai_engine::RhaiSelect<$V, $Select, $Join, $Cond>;
@@ -43,14 +54,12 @@ macro_rules! register_engine {
         type Win = $crate::rhai_engine::RhaiWindow<$V>;
         type Cas = $crate::rhai_engine::RhaiCase<$V>;
 
-        // Register the full SQL vocabulary onto an existing engine. Split out of
-        // `__create_engine` so the same registrations can later be layered onto
-        // vantage-vista's conventional engine for scripted reference traversal
-        // (mirrors SurrealDB's `register_surreal_onto`). Wiring a per-shell
-        // target resolver is the follow-up that flips SQL's
-        // `can_build_ref_via_script` on; until then this only backs
-        // `__create_engine`.
-        fn __register_engine_onto(engine: &mut rhai::Engine) {
+        // Register the full SQL vocabulary onto an existing engine. The same
+        // registrations can be layered onto vantage-vista's conventional
+        // vocabulary for scripted reference traversal (mirrors SurrealDB's
+        // `register_surreal_onto`). Wiring a per-shell target resolver is the
+        // follow-up that flips SQL's `can_build_ref_via_script` on.
+        fn __register_engine_onto(engine: &mut $crate::rhai_engine::rhai::Engine) {
             $crate::register_types!(engine, value: $V, select: $Select, join: $Join, cond: $Cond);
             $crate::register_convert!(value: $V);
             $crate::register_constructors!(engine, value: $V);
@@ -61,14 +70,30 @@ macro_rules! register_engine {
 
             // Future phases:
             // $crate::register_aggregates!(engine, value: $V);
-
-            engine.set_max_expr_depths(256, 256);
         }
 
-        fn __create_engine() -> rhai::Engine {
-            let mut engine = rhai::Engine::new();
-            __register_engine_onto(&mut engine);
-            engine
+        /// This dialect's SQL vocabulary as a [`Vocab`](vantage_rhai::Vocab).
+        pub struct SqlVocab;
+
+        impl $crate::rhai_engine::vantage_rhai::Vocab for SqlVocab {
+            fn register(&self, engine: &mut $crate::rhai_engine::rhai::Engine) {
+                __register_engine_onto(engine);
+            }
+        }
+
+        /// One shared host per dialect: background limits (query scripts run
+        /// while a table builds, never on a UI thread), `SqlVocab`, built once.
+        /// Query-source scripts repeat per table, so compile through its cache.
+        fn __host() -> &'static $crate::rhai_engine::vantage_rhai::Host {
+            static HOST: std::sync::LazyLock<$crate::rhai_engine::vantage_rhai::Host> =
+                std::sync::LazyLock::new(|| {
+                    $crate::rhai_engine::vantage_rhai::Host::builder(
+                        $crate::rhai_engine::vantage_rhai::Limits::background(),
+                    )
+                    .vocab(SqlVocab)
+                    .build()
+                });
+            &HOST
         }
     };
 }

--- a/vantage-sql/src/rhai_engine/operators.rs
+++ b/vantage-sql/src/rhai_engine/operators.rs
@@ -4,8 +4,9 @@
 //! RhaiExpr, RhaiIdent, or scalar values.
 
 use crate::primitives::identifier::Identifier;
-use rhai::Dynamic;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_rhai::rhai;
+use vantage_rhai::rhai::Dynamic;
 
 use super::{RhaiExpr, RhaiIdent};
 

--- a/vantage-sql/src/rhai_engine/select_methods.rs
+++ b/vantage-sql/src/rhai_engine/select_methods.rs
@@ -5,6 +5,7 @@
 use crate::primitives::identifier::Identifier;
 use crate::primitives::select::{JoinBuilder, SelectBuilder};
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum, Selectable};
+use vantage_rhai::rhai;
 
 use super::{RhaiExpr, RhaiIdent, RhaiSelect};
 

--- a/vantage-sql/src/rhai_engine/window_case.rs
+++ b/vantage-sql/src/rhai_engine/window_case.rs
@@ -8,6 +8,7 @@ use crate::primitives::identifier::Identifier;
 use crate::primitives::select::window::Window;
 use std::fmt::{Debug, Display};
 use vantage_expressions::Expressive;
+use vantage_rhai::rhai;
 
 use super::{RhaiCase, RhaiExpr, RhaiIdent, RhaiWindow};
 

--- a/vantage-sql/src/sqlite/vista/factory.rs
+++ b/vantage-sql/src/sqlite/vista/factory.rs
@@ -301,7 +301,8 @@ fn build_derived_table(
 /// (`AnySqliteType::untyped`).
 #[cfg(feature = "rhai")]
 fn add_lazy_column(table: &mut Table<SqliteDB, EmptyEntity>, name: &str, code: &str) -> Result<()> {
-    let script = vantage_vista::lazy_value_closure(code.to_string());
+    // Compiles once, here: a script that does not parse fails the table build.
+    let script = vantage_vista::lazy_value_closure(code)?;
     table.add_lazy_expression(
         name,
         Arc::new(move |record| {

--- a/vantage-sql/src/sqlite/vista/rhai_source.rs
+++ b/vantage-sql/src/sqlite/vista/rhai_source.rs
@@ -6,8 +6,8 @@
 //! *transform* an existing query rather than build one from scratch.
 //!
 //! `register_engine!` expands to a full engine toolkit (conversion helpers,
-//! type aliases); a vista source only needs `__create_engine` + `eval`, so the
-//! unused generated items are allowed here.
+//! type aliases); a vista source only needs `__host` + `Sel`, so the unused
+//! generated items are allowed here.
 #![allow(dead_code)]
 
 // NOTE: do not `use vantage_core::Result` here — `register_engine!` expands to
@@ -18,6 +18,7 @@ use crate::sqlite::AnySqliteType;
 use crate::sqlite::statements::SqliteSelect;
 use crate::sqlite::statements::select::join::SqliteSelectJoin;
 
+// `register_engine!` imports `rhai` into this scope.
 crate::register_engine!(
     value: AnySqliteType,
     select: SqliteSelect,
@@ -43,18 +44,19 @@ pub(crate) fn eval_to_select_args(
     base: Option<SqliteSelect>,
     args: &[(String, String)],
 ) -> vantage_core::Result<SqliteSelect> {
-    let engine = __create_engine();
-    let mut scope = rhai::Scope::new();
     let mut map = rhai::Map::new();
     for (k, v) in args {
         map.insert(k.as_str().into(), v.clone().into());
     }
-    scope.push_constant("args", map);
+    let mut env = vantage_rhai::Env::new().var("args", rhai::Dynamic::from_map(map));
     if let Some(base) = base {
-        scope.push("base", Sel::new(base));
+        env = env.var("base", rhai::Dynamic::from(Sel::new(base)));
     }
-    engine
-        .eval_with_scope::<Sel>(&mut scope, code)
+    // Statements, not a lone expression: a `let` in an existing `rhai:` block
+    // keeps working, and the final expression is the select.
+    __host()
+        .compile(&vantage_rhai::Block::from(code))
+        .and_then(|script| script.eval_as::<Sel>(&env))
         .map(|select| select.into_inner())
         .map_err(|e| {
             vantage_core::error!(
@@ -68,19 +70,5 @@ pub(crate) fn eval_to_select(
     code: &str,
     base: Option<SqliteSelect>,
 ) -> vantage_core::Result<SqliteSelect> {
-    let engine = __create_engine();
-    let evaluated = match base {
-        Some(base) => {
-            let mut scope = rhai::Scope::new();
-            scope.push("base", Sel::new(base));
-            engine.eval_with_scope::<Sel>(&mut scope, code)
-        }
-        None => engine.eval::<Sel>(code),
-    };
-    evaluated.map(|select| select.into_inner()).map_err(|e| {
-        vantage_core::error!(
-            "Rhai vista source failed to evaluate",
-            detail = e.to_string()
-        )
-    })
+    eval_to_select_args(code, base, &[])
 }

--- a/vantage-sql/tests/rhai-tests/common/e6.err
+++ b/vantage-sql/tests/rhai-tests/common/e6.err
@@ -1,1 +1,1 @@
-Variable not found: u
+unknown name `u`

--- a/vantage-sql/tests/rhai_smoke.rs
+++ b/vantage-sql/tests/rhai_smoke.rs
@@ -3,11 +3,13 @@
 #[cfg(feature = "rhai")]
 mod rhai_smoke {
     use vantage_expressions::Expressive;
+    use vantage_rhai::{Block, Env, Host};
     use vantage_sql::condition::SqliteCondition;
     use vantage_sql::sqlite::statements::SqliteSelect;
     use vantage_sql::sqlite::statements::select::join::SqliteSelectJoin;
     use vantage_sql::sqlite::types::AnySqliteType;
 
+    // `register_engine!` imports `rhai` into this scope.
     vantage_sql::register_engine!(
         value: AnySqliteType,
         select: SqliteSelect,
@@ -15,20 +17,20 @@ mod rhai_smoke {
         cond: SqliteCondition,
     );
 
-    pub fn create_engine() -> rhai::Engine {
-        __create_engine()
+    pub fn host() -> &'static Host {
+        __host()
     }
 
     fn eval_rhai(code: &str) -> rhai::Dynamic {
-        let engine = create_engine();
-        engine
-            .eval(code)
+        host()
+            .compile(&Block::from(code))
+            .and_then(|script| script.eval(&Env::new()))
             .unwrap_or_else(|e| panic!("rhai eval failed: {e}"))
     }
 
     #[test]
-    fn engine_creates() {
-        let _engine = create_engine();
+    fn host_builds() {
+        let _host = host();
     }
 
     #[test]

--- a/vantage-sql/tests/rhai_tests.rs
+++ b/vantage-sql/tests/rhai_tests.rs
@@ -22,9 +22,9 @@ mod sqlite_tests {
     fn eval_rhai_file(path: &str) -> Select {
         let code = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("Failed to read {}: {}", path, e));
-        let engine = __create_engine();
-        engine
-            .eval::<Select>(&code)
+        __host()
+            .compile(&vantage_rhai::Block::from(code.as_str()))
+            .and_then(|script| script.eval_as::<Select>(&vantage_rhai::Env::new()))
             .unwrap_or_else(|e| panic!("Rhai eval failed for {}: {}", path, e))
     }
 
@@ -62,9 +62,9 @@ mod postgres_tests {
     fn eval_rhai_file(path: &str) -> Select {
         let code = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("Failed to read {}: {}", path, e));
-        let engine = __create_engine();
-        engine
-            .eval::<Select>(&code)
+        __host()
+            .compile(&vantage_rhai::Block::from(code.as_str()))
+            .and_then(|script| script.eval_as::<Select>(&vantage_rhai::Env::new()))
             .unwrap_or_else(|e| panic!("Rhai eval failed for {}: {}", path, e))
     }
 
@@ -101,9 +101,9 @@ mod mysql_tests {
     fn eval_rhai_file(path: &str) -> Select {
         let code = std::fs::read_to_string(path)
             .unwrap_or_else(|e| panic!("Failed to read {}: {}", path, e));
-        let engine = __create_engine();
-        engine
-            .eval::<Select>(&code)
+        __host()
+            .compile(&vantage_rhai::Block::from(code.as_str()))
+            .and_then(|script| script.eval_as::<Select>(&vantage_rhai::Env::new()))
             .unwrap_or_else(|e| panic!("Rhai eval failed for {}: {}", path, e))
     }
 

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.18 — 2026-09-05
+
+- The `rhai` feature runs on `vantage-rhai` hosts: `SurrealVocab` is the
+  vendor vocabulary, `register_surreal_engine!` emits a lazily built,
+  bounded host (`__host()`), and the query-source, traversal and `modify`
+  sites all evaluate through it. Registration order is kept — vendor first,
+  then vista's conventional verbs — so `table("x")` still yields a Vista.
+- `me` is bound through `surreal_env(env)` / `TableShell::rhai_env` instead
+  of an `engine.on_var` hook. The hook collided with the host's own resolver
+  (rhai keeps the last `on_var`), so one of them silently stopped working;
+  a test now checks that `me.field` resolves while a resolver records reads
+  on the same host.
+- `set_max_expr_depths` is gone from the registration path; limits are the
+  host's.
+
 ## 0.6.17 — 2026-08-22
 
 - **Bug fix (data loss):** `delete_all` on a conditioned table deleted the whole

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.17"
+version = "0.6.18"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"
@@ -26,7 +26,7 @@ vantage-expressions = { version = "0.6", path = "../vantage-expressions", featur
 vantage-table = { version = "0.6", path = "../vantage-table" }
 vantage-dataset = { version = "0.6", path = "../vantage-dataset" }
 vantage-types = { version = "0.6", path = "../vantage-types", features = ["serde"] }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista", optional = true }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista", optional = true }
 surreal-client = { version = "0.6", path = "../surreal-client" }
 
 async-stream = "0.3"
@@ -44,7 +44,7 @@ serde_path_to_error = "0.1"
 rust_decimal = { version = "1.42", optional = true }
 uuid = { version = "1.23", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
-vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
+vantage-rhai = { version = "0.6.2", path = "../vantage-rhai", optional = true }
 
 # Disable all tests except queries.rs during 0.3 migration
 [[test]]
@@ -93,7 +93,7 @@ bakery_model3 = { path = "../bakery_model3" }
 futures = "0.3"
 serde_yaml_ng = "0.10"
 tokio = { version = "1.52", features = ["full"] }
-vantage-vista = { version = "0.6.22", path = "../vantage-vista" }
+vantage-vista = { version = "0.6.25", path = "../vantage-vista" }
 
 [[example]]
 name = "expr"

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -17,7 +17,7 @@ vista = ["dep:vantage-vista"]
 # reference traversal, so it pulls in the vista layer and its conventional
 # engine. Keeping them coupled means `register_rhai_extensions` always has the
 # `vantage-vista` rhai vocabulary to layer onto.
-rhai = ["dep:rhai", "vista", "vantage-vista/rhai"]
+rhai = ["dep:vantage-rhai", "vista", "vantage-vista/rhai"]
 
 [dependencies]
 async-trait = "0.1"
@@ -44,7 +44,7 @@ serde_path_to_error = "0.1"
 rust_decimal = { version = "1.42", optional = true }
 uuid = { version = "1.23", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
-rhai = { version = "1.25", optional = true }
+vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
 
 # Disable all tests except queries.rs during 0.3 migration
 [[test]]

--- a/vantage-surrealdb/examples/rhai_test.rs
+++ b/vantage-surrealdb/examples/rhai_test.rs
@@ -10,7 +10,8 @@ use std::fs;
 use std::path::Path;
 use std::process;
 
-use vantage_surrealdb::rhai_engine::RhaiSelect;
+use vantage_rhai::{Block, Env};
+use vantage_surrealdb::rhai_engine::{RhaiSelect, surreal_env};
 
 vantage_surrealdb::register_surreal_engine!();
 
@@ -36,7 +37,8 @@ fn main() {
         .collect();
     entries.sort_by_key(|e| e.file_name());
 
-    let engine = __create_engine();
+    let host = __host();
+    let env = surreal_env(Env::new());
 
     let mut pass = 0u32;
     let mut fail = 0u32;
@@ -52,7 +54,10 @@ fn main() {
         let has_surql = surql_path.exists();
         let has_err = err_path.exists();
 
-        let result = engine.eval::<RhaiSelect>(&code).map(|s| s.preview());
+        let result = host
+            .compile(&Block::from(code.as_str()))
+            .and_then(|script| script.eval_as::<RhaiSelect>(&env))
+            .map(|s| s.preview());
 
         // --fix mode: generate missing files
         if fix {

--- a/vantage-surrealdb/src/rhai_engine/constructors.rs
+++ b/vantage-surrealdb/src/rhai_engine/constructors.rs
@@ -5,8 +5,9 @@ use crate::Expr;
 use crate::identifier::Identifier;
 use crate::primitives;
 use crate::sum::Fx;
-use rhai::{Array, FnPtr, NativeCallContext};
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_rhai::rhai;
+use vantage_rhai::rhai::{Array, FnPtr, NativeCallContext};
 
 use super::operators::to_expr;
 use super::types::RhaiCase;

--- a/vantage-surrealdb/src/rhai_engine/convert.rs
+++ b/vantage-surrealdb/src/rhai_engine/convert.rs
@@ -1,6 +1,7 @@
 //! Conversion helpers for Rhai ↔ Rust interop.
 
 use vantage_expressions::Order;
+use vantage_rhai::rhai;
 
 /// Create a Rhai runtime error.
 pub fn rhai_err(msg: impl Into<String>) -> Box<rhai::EvalAltResult> {

--- a/vantage-surrealdb/src/rhai_engine/mod.rs
+++ b/vantage-surrealdb/src/rhai_engine/mod.rs
@@ -4,6 +4,8 @@
 //! Registers wrapper types, constructors, operators, and select builder
 //! methods into a Rhai engine.
 
+use vantage_rhai::rhai;
+
 #[cfg(feature = "rhai")]
 pub mod constructors;
 #[cfg(feature = "rhai")]
@@ -18,15 +20,41 @@ pub mod types;
 #[cfg(feature = "rhai")]
 pub use types::{RhaiCase, RhaiExpr, RhaiIdent, RhaiSelect};
 
+/// The SurrealDB query-building vocabulary as a [`vantage_rhai::Vocab`].
+/// Register it *before* vantage-vista's `ConventionalVocab` so the
+/// conventional `table(name) -> Vista` wins over this vocabulary's `table`
+/// alias for `ident` (which stays reachable as `ident(...)`).
+#[cfg(feature = "rhai")]
+pub struct SurrealVocab;
+
+#[cfg(feature = "rhai")]
+impl vantage_rhai::Vocab for SurrealVocab {
+    fn register(&self, engine: &mut rhai::Engine) {
+        register_surreal_onto(engine);
+    }
+}
+
+/// The per-evaluation half of the vocabulary: `me`, the current-record
+/// anchor, as a scope variable. It used to be an `on_var` hook on the engine,
+/// which collided with the host's own resolver hook (rhai keeps only the last
+/// one installed); a variable composes.
+#[cfg(feature = "rhai")]
+pub fn surreal_env(env: vantage_rhai::Env) -> vantage_rhai::Env {
+    env.var("me", rhai::Dynamic::from(RhaiExpr(crate::primitives::me())))
+}
+
 /// Register the full SurrealDB query-building vocabulary onto `engine`.
 ///
 /// Shared by two entry points:
-/// - the [`register_surreal_engine!`](crate::register_surreal_engine) macro, whose `__create_engine` wraps this
-///   in a fresh `Engine` (back-compat for the standalone Rhai tests/examples and
-///   the `rhai:` vista source);
+/// - [`SurrealVocab`], the form a [`vantage_rhai::Host`] takes (the `rhai:`
+///   vista source, the standalone Rhai tests/examples via
+///   [`register_surreal_engine!`](crate::register_surreal_engine));
 /// - `SurrealTableShell::register_rhai_extensions`, which layers it on top of
 ///   vantage-vista's conventional `Vista` verbs so a reference build-script can
 ///   use `ident`/`==`/`fx`/graph syntax and `with_condition`.
+///
+/// Prefer [`SurrealVocab`] on a host; this is what it registers. Limits and
+/// `me` are the host's and [`surreal_env`]'s business, not this function's.
 #[cfg(feature = "rhai")]
 pub fn register_surreal_onto(engine: &mut rhai::Engine) {
     use crate::AnySurrealType as AST;
@@ -314,27 +342,16 @@ pub fn register_surreal_onto(engine: &mut rhai::Engine) {
         engine.register_fn("fold", crate::rhai_engine::constructors::fn_fold);
         engine.register_fn("filter", crate::rhai_engine::constructors::fn_filter);
 
-        // `me` — the current-record anchor, available as a bare constant.
-        // `on_var` is marked volatile (not deprecated) by rhai; silence the lint.
-        #[allow(deprecated)]
-        {
-            engine.on_var(|name, _index, _context| {
-                if name == "me" {
-                    Ok(Some(rhai::Dynamic::from(Ex(crate::primitives::me()))))
-                } else {
-                    Ok(None)
-                }
-            });
-        }
-
         // ── Clone ─────────────────────────────────────────────
         engine.register_fn("clone", |e: Ex| -> Ex { e });
         engine.register_fn("clone", |id: Id| -> Id { id });
-
-        engine.set_max_expr_depths(256, 256);
     }
 }
 
+/// Bring the SurrealDB Rhai toolkit into scope: the `AST`/`Ex`/`Id`/`Sel`
+/// aliases and `__host()`, one shared [`vantage_rhai::Host`] carrying
+/// [`SurrealVocab`] under the background limit profile. Evaluate with
+/// `__host().compile(..)` and an `Env` from [`surreal_env`] so `me` resolves.
 #[cfg(feature = "rhai")]
 #[macro_export]
 macro_rules! register_surreal_engine {
@@ -344,10 +361,13 @@ macro_rules! register_surreal_engine {
         use $crate::AnySurrealType as AST;
         use $crate::rhai_engine::types::{RhaiExpr as Ex, RhaiIdent as Id, RhaiSelect as Sel};
 
-        fn __create_engine() -> rhai::Engine {
-            let mut engine = rhai::Engine::new();
-            $crate::rhai_engine::register_surreal_onto(&mut engine);
-            engine
+        fn __host() -> &'static vantage_rhai::Host {
+            static HOST: std::sync::LazyLock<vantage_rhai::Host> = std::sync::LazyLock::new(|| {
+                vantage_rhai::Host::builder(vantage_rhai::Limits::background())
+                    .vocab($crate::rhai_engine::SurrealVocab)
+                    .build()
+            });
+            &HOST
         }
     };
 }

--- a/vantage-surrealdb/src/rhai_engine/mod.rs
+++ b/vantage-surrealdb/src/rhai_engine/mod.rs
@@ -53,7 +53,7 @@ pub fn surreal_env(env: vantage_rhai::Env) -> vantage_rhai::Env {
 ///   vantage-vista's conventional `Vista` verbs so a reference build-script can
 ///   use `ident`/`==`/`fx`/graph syntax and `with_condition`.
 ///
-/// Prefer [`SurrealVocab`] on a host; this is what it registers. Limits and
+/// Prefer [`SurrealVocab`] on a host — this is the registration behind it. Limits and
 /// `me` are the host's and [`surreal_env`]'s business, not this function's.
 #[cfg(feature = "rhai")]
 pub fn register_surreal_onto(engine: &mut rhai::Engine) {

--- a/vantage-surrealdb/src/rhai_engine/operators.rs
+++ b/vantage-surrealdb/src/rhai_engine/operators.rs
@@ -5,8 +5,9 @@
 
 use crate::AnySurrealType;
 use crate::Expr;
-use rhai::Dynamic;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_rhai::rhai;
+use vantage_rhai::rhai::Dynamic;
 
 use super::{RhaiExpr, RhaiIdent};
 

--- a/vantage-surrealdb/src/rhai_engine/select_methods.rs
+++ b/vantage-surrealdb/src/rhai_engine/select_methods.rs
@@ -3,6 +3,7 @@
 use crate::identifier::Identifier;
 use crate::statements::select::select_target::SelectTarget;
 use vantage_expressions::{Expression, Expressive, ExpressiveEnum};
+use vantage_rhai::rhai;
 
 use super::{RhaiExpr, RhaiIdent, RhaiSelect};
 

--- a/vantage-surrealdb/src/vista/factory.rs
+++ b/vantage-surrealdb/src/vista/factory.rs
@@ -2,6 +2,8 @@
 //! `VistaFactory` trait impl. SurrealDB advertises full read/write/count.
 
 use std::sync::Arc;
+#[cfg(feature = "rhai")]
+use vantage_rhai::{Host, Limits};
 
 use vantage_core::{Result, error};
 use vantage_table::column::core::Column as TableColumn;
@@ -177,8 +179,9 @@ impl VistaFactory for SurrealVistaFactory {
 impl SurrealVistaFactory {
     /// Run a `surreal: { modify }` script against an already-built vista,
     /// layering SurrealDB's expression vocabulary plus the conventional verbs
-    /// onto a fresh engine. `table(name)` inside the script resolves through the
-    /// factory's spec resolver (if attached); `self` is the built vista.
+    /// onto a host. `table(name)` inside the script resolves through the
+    /// factory's spec resolver (if attached); `self` is the built vista, `me`
+    /// comes from the shell.
     fn apply_modify(&self, vista: Vista, code: &str) -> Result<Vista> {
         let db = self.db.clone();
         let resolver = self.resolver.clone();
@@ -195,10 +198,11 @@ impl SurrealVistaFactory {
 
         // Vendor vocab first, conventional second (so `table` resolves a Vista,
         // not SurrealDB's `ident` alias — same ordering as scripted traversal).
-        let mut engine = rhai::Engine::new();
-        vista.source.register_rhai_extensions(&mut engine);
-        vantage_vista::register_conventional_onto(&mut engine, target_resolver);
-        vantage_vista::eval_modify_script(&engine, code, vista)
+        let host = Host::builder(Limits::background())
+            .vocab(vantage_vista::ShellVocab(&vista))
+            .vocab(vantage_vista::ConventionalVocab(target_resolver))
+            .build();
+        vantage_vista::eval_modify_script(&host, code, vista)
     }
 }
 

--- a/vantage-surrealdb/src/vista/rhai_source.rs
+++ b/vantage-surrealdb/src/vista/rhai_source.rs
@@ -83,8 +83,6 @@ mod tests {
 
     #[test]
     fn me_is_in_scope_as_a_variable() {
-        // `me` used to be an `on_var` hook on the engine; it is now pushed by
-        // `surreal_env`, so it resolves on the shared host like any variable.
         assert!(eval_to_expr("me").is_ok());
         assert!(eval_to_expr("me[\"name\"]").is_ok());
         let err = eval_to_expr("nope").unwrap_err();

--- a/vantage-surrealdb/src/vista/rhai_source.rs
+++ b/vantage-surrealdb/src/vista/rhai_source.rs
@@ -1,18 +1,23 @@
 //! Evaluate a Rhai script into a `SurrealSelect` for use as a vista source.
 //!
-//! Uses the same engine the standalone Rhai tests use (`register_surreal_engine!`).
-//! When `base` is supplied it is seeded into scope as `base` (a `RhaiSelect`
-//! wrapping the source table's select) so scripts can *transform* an existing
-//! query rather than build one from scratch.
+//! Uses the same host the standalone Rhai tests use (`register_surreal_engine!`):
+//! built once, background limits, the full vendor vocabulary. When `base` is
+//! supplied it is pushed as the `base` variable (a `RhaiSelect` wrapping the
+//! source table's select) so scripts can *transform* an existing query rather
+//! than build one from scratch. `me` is always in scope.
 //!
-//! `register_surreal_engine!` expands to a full engine toolkit; a vista source
-//! only needs `__create_engine` + `eval`, so the unused generated items are
-//! allowed here.
-// `register_surreal_engine!` brings several type aliases and helper closures
-// into scope; a vista source only needs `Sel` + `__create_engine`, so the
-// unused remainder of the generated toolkit is allowed here.
+//! Scripts compile as statements (`Block`), the same shape `Engine::eval`
+//! accepted before, so a `let` in an existing `rhai:` block keeps working; the
+//! final expression is the value.
+// `register_surreal_engine!` brings several type aliases into scope; a vista
+// source only needs `Sel`/`Ex`/`Id` + `__host`, so the unused remainder of the
+// generated toolkit is allowed here.
 #![allow(dead_code, unused_imports, unused_variables)]
 
+use vantage_rhai::rhai;
+use vantage_rhai::{Block, Env};
+
+use crate::rhai_engine::surreal_env;
 use crate::statements::SurrealSelect;
 
 crate::register_surreal_engine!();
@@ -23,21 +28,22 @@ pub(crate) fn eval_to_select(
     code: &str,
     base: Option<SurrealSelect>,
 ) -> vantage_core::Result<SurrealSelect> {
-    let engine = __create_engine();
-    let evaluated = match base {
-        Some(base) => {
-            let mut scope = rhai::Scope::new();
-            scope.push("base", Sel { inner: base });
-            engine.eval_with_scope::<Sel>(&mut scope, code)
-        }
-        None => engine.eval::<Sel>(code),
-    };
-    evaluated.map(|select| select.into_inner()).map_err(|e| {
-        vantage_core::error!(
-            "Rhai vista source failed to evaluate",
-            detail = e.to_string()
-        )
-    })
+    let mut env = surreal_env(Env::new());
+    if let Some(base) = base {
+        env = env.var("base", rhai::Dynamic::from(Sel { inner: base }));
+    }
+    __host()
+        .compile(&Block::from(code))
+        .and_then(|script| script.eval(&env))
+        .map_err(|e| {
+            vantage_core::error!(
+                "Rhai vista source failed to evaluate",
+                detail = e.to_string()
+            )
+        })?
+        .try_cast::<Sel>()
+        .map(|select| select.into_inner())
+        .ok_or_else(|| vantage_core::error!("Rhai vista source must evaluate to a select"))
 }
 
 /// Run `code`, returning the expression it builds — the vocabulary is the
@@ -46,13 +52,15 @@ pub(crate) fn eval_to_select(
 /// expression, `ident("x")` alone an identifier) so both shapes work.
 pub(crate) fn eval_to_expr(code: &str) -> vantage_core::Result<crate::Expr> {
     use vantage_expressions::Expressive as _;
-    let engine = __create_engine();
-    let value = engine.eval::<rhai::Dynamic>(code).map_err(|e| {
-        vantage_core::error!(
-            "Rhai column expression failed to evaluate",
-            detail = e.to_string()
-        )
-    })?;
+    let value = __host()
+        .compile(&Block::from(code))
+        .and_then(|script| script.eval(&surreal_env(Env::new())))
+        .map_err(|e| {
+            vantage_core::error!(
+                "Rhai column expression failed to evaluate",
+                detail = e.to_string()
+            )
+        })?;
     if value.is::<Ex>() {
         return Ok(value.cast::<Ex>().into_inner());
     }
@@ -63,4 +71,68 @@ pub(crate) fn eval_to_expr(code: &str) -> vantage_core::Result<crate::Expr> {
         "Rhai column expression must evaluate to an expression or identifier",
         got = value.type_name()
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vantage_rhai::{Expr, Lookup, Resolver};
+
+    use super::*;
+
+    #[test]
+    fn me_is_in_scope_as_a_variable() {
+        // `me` used to be an `on_var` hook on the engine; it is now pushed by
+        // `surreal_env`, so it resolves on the shared host like any variable.
+        assert!(eval_to_expr("me").is_ok());
+        assert!(eval_to_expr("me[\"name\"]").is_ok());
+        let err = eval_to_expr("nope").unwrap_err();
+        assert!(err.to_string().contains("nope"), "{err}");
+    }
+
+    #[test]
+    fn me_coexists_with_a_host_resolver() {
+        // The reason `me` moved: the old hook replaced the host's resolver hook
+        // (rhai keeps only the last `on_var`). Both must work in one script.
+        struct Ns;
+        impl Resolver for Ns {
+            fn resolve(&self, path: &str) -> Lookup {
+                match path {
+                    "app" => Lookup::Namespace,
+                    "app.n" => Lookup::Leaf(rhai::Dynamic::from(2_i64)),
+                    _ => Lookup::Unknown,
+                }
+            }
+        }
+        let env = surreal_env(Env::new().resolver(Arc::new(Ns)));
+
+        let read = __host()
+            .compile(&Expr::from("app.n"))
+            .unwrap()
+            .discover(&env)
+            .unwrap();
+        assert_eq!(read.eval(&env).unwrap().as_int().unwrap(), 2);
+        assert!(
+            read.read_set().contains("app.n"),
+            "resolver reads are recorded"
+        );
+
+        let me = __host()
+            .compile(&Expr::from("me"))
+            .unwrap()
+            .eval(&env)
+            .unwrap();
+        assert!(
+            me.is::<Ex>(),
+            "`me` is the anchor expression, got {}",
+            me.type_name()
+        );
+    }
+
+    #[test]
+    fn query_source_is_bounded() {
+        let err = eval_to_select("loop {}", None).unwrap_err();
+        assert!(err.to_string().contains("limit"), "{err}");
+    }
 }

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -19,6 +19,10 @@ use indexmap::IndexMap;
 use surreal_client::Action;
 use vantage_core::{Result, error};
 use vantage_dataset::traits::{InsertableValueSet, ReadableValueSet, WritableValueSet};
+#[cfg(feature = "rhai")]
+use vantage_rhai::rhai;
+#[cfg(feature = "rhai")]
+use vantage_rhai::{Env, Host, Limits};
 use vantage_table::conditions::ConditionHandle;
 use vantage_table::pagination::Pagination;
 use vantage_table::sorting::{OrderBy, SortDirection as TableSortDirection};
@@ -596,6 +600,13 @@ where
             },
         );
     }
+
+    /// `me`, the current-record anchor, for every script this shell's vistas
+    /// evaluate (`modify:`, augmentation, traversal).
+    #[cfg(feature = "rhai")]
+    fn rhai_env(&self, env: Env) -> Env {
+        crate::rhai_engine::surreal_env(env)
+    }
 }
 
 #[cfg(feature = "rhai")]
@@ -605,9 +616,9 @@ where
 {
     /// Build a reference's traversal target by evaluating its Rhai
     /// `build_script`. The conventional `Vista` vocabulary plus SurrealDB's
-    /// vendor extensions are registered onto a fresh engine; `table(name)`
-    /// resolves a fresh target through the shell's spec resolver, and the parent
-    /// `row` is exposed to the script.
+    /// vendor extensions go onto a host; `table(name)` resolves a fresh target
+    /// through the shell's spec resolver, and the parent `row` (and `me`) are
+    /// exposed to the script.
     fn get_ref_via_script(&self, script: &str, row: &Record<CborValue>) -> Result<Vista> {
         use vantage_vista::VistaFactory;
 
@@ -629,9 +640,10 @@ where
         // `table(name) -> Vista` win over SurrealDB's `table` alias for `ident`
         // (which stays reachable as `ident(...)`), so a build-script's
         // `table("order")` resolves a Vista rather than an identifier.
-        let mut engine = rhai::Engine::new();
-        self.register_rhai_extensions(&mut engine);
-        vantage_vista::register_conventional_onto(&mut engine, target_resolver);
-        vantage_vista::eval_ref_script(&engine, script, row)
+        let host = Host::builder(Limits::background())
+            .vocab_fn(|engine| self.register_rhai_extensions(engine))
+            .vocab(vantage_vista::ConventionalVocab(target_resolver))
+            .build();
+        vantage_vista::eval_ref_script(&host, script, self.rhai_env(Env::new()), row)
     }
 }

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 0.6.25 — 2026-09-05
+
+The `rhai` feature runs on `vantage-rhai` hosts instead of bare engines.
+Every script is bounded (`Limits::background()`), compiled through one
+cache, and no site builds an engine per call any more — `lazy_value_closure`
+used to build one **per record**.
+
+- `ConventionalVocab(TargetResolver)`, `ShellVocab(&Vista)` and
+  `FetchVerbs { limit }` are `Vocab` impls; `register_conventional_onto` /
+  `register_fetch_verbs` stay as one-line shims for callers that still hold
+  an `Engine`.
+- **Breaking:** `eval_ref_script`, `eval_modify_script`, `eval_augment_source`
+  and `eval_lazy_expression` take `&Host` and an `Env` instead of `&Engine`;
+  `row`/`self` arrive as `Env::var` bindings. `lazy_value_closure(&str)`
+  returns `Result<LazyValueFn>` and compiles once. `dynamic_to_json` is gone
+  in favour of `vantage_rhai::to_json`.
+- `run_script` / `preview_script` build a one-shot host each; `preview_script`
+  keeps its no-fetch guarantee by not registering `FetchVerbs`.
+- The CBOR ↔ `Dynamic` converters (`cbor_to_dynamic`, `dynamic_to_cbor`,
+  `record_to_map`, `map_to_record`, `record_to_dynamic`) are public and
+  round-trip arrays and maps, so drivers stop keeping private copies.
+- `TableShell::rhai_env(env)` lets a driver add its constants (SurrealDB's
+  `me`) to an evaluation without an `on_var` hook.
+
 ## 0.6.24 — 2026-09-01
 
 - Nested insert: a bare **scalar** under a relation key links an existing

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -21,7 +21,7 @@ futures-core = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 thiserror = "2.0"
-rhai = { version = "1.25", optional = true }
+vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
 # Not optional: `TableShell::preview_query` returns a driver-shaped
 # `serde_json::Value`, so the type is part of the trait every driver implements.
 serde_json = "1"
@@ -36,7 +36,7 @@ tokio = { version = "1.52", features = ["rt", "rt-multi-thread"], optional = tru
 # (`list`/`get_some`/`count`/`capabilities`/`columns`/`references`) and the
 # `run_script` runner. Backends layer their vendor expression vocabulary on top
 # via `TableShell::register_rhai_extensions`.
-rhai = ["dep:rhai", "dep:tokio", "vantage-types/serde"]
+rhai = ["dep:vantage-rhai", "dep:tokio", "vantage-types/serde"]
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.24"
+version = "0.6.25"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"
@@ -21,7 +21,7 @@ futures-core = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml_ng = "0.10"
 thiserror = "2.0"
-vantage-rhai = { version = "0.6", path = "../vantage-rhai", optional = true }
+vantage-rhai = { version = "0.6.2", path = "../vantage-rhai", optional = true }
 # Not optional: `TableShell::preview_query` returns a driver-shaped
 # `serde_json::Value`, so the type is part of the trait every driver implements.
 serde_json = "1"

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -33,10 +33,11 @@ pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 #[cfg(feature = "rhai")]
 pub use rhai::{
-    AugmentSourceFn, DEFAULT_LIMIT, LazyValueFn, MAX_LIMIT, MIN_LIMIT, RhaiVista, TargetResolver,
-    augment_source_closure, eval_augment_source, eval_lazy_expression, eval_modify_script,
-    eval_ref_script, lazy_value_closure, preview_script, register_conventional_onto,
-    register_fetch_verbs, run_script,
+    AugmentSourceFn, ConventionalVocab, DEFAULT_LIMIT, FetchVerbs, LazyValueFn, MAX_LIMIT,
+    MIN_LIMIT, RhaiVista, ShellVocab, TargetResolver, augment_source_closure, cbor_to_dynamic,
+    dynamic_to_cbor, eval_augment_source, eval_lazy_expression, eval_modify_script,
+    eval_ref_script, lazy_value_closure, map_to_record, preview_script, record_to_dynamic,
+    record_to_map, register_conventional_onto, register_fetch_verbs, run_script,
 };
 pub use sort::SortDirection;
 pub use source::{TableShell, VistaChange, VistaChangeStream};

--- a/vantage-vista/src/rhai.rs
+++ b/vantage-vista/src/rhai.rs
@@ -1,7 +1,7 @@
 //! Rhai scripting surface over the type-erased [`Vista`](crate::vista::Vista).
 //!
-//! vantage-vista owns Rhai engine construction with a *backend-agnostic*
-//! vocabulary, in two layers:
+//! vantage-vista owns the *backend-agnostic* Rhai vocabulary, as
+//! [`vantage_rhai::Vocab`] impls a host assembles, in two layers:
 //!
 //! - [`conventional`] — the chainable query *builder*: `table(name)` resolves a
 //!   fresh target through an injected [`TargetResolver`], and builder verbs
@@ -28,9 +28,12 @@ mod introspect;
 mod runtime;
 
 pub use conventional::{
-    AugmentSourceFn, LazyValueFn, RhaiVista, TargetResolver, augment_source_closure,
-    eval_augment_source, eval_lazy_expression, eval_modify_script, eval_ref_script,
-    lazy_value_closure, register_conventional_onto,
+    AugmentSourceFn, ConventionalVocab, LazyValueFn, RhaiVista, ShellVocab, TargetResolver,
+    augment_source_closure, eval_augment_source, eval_lazy_expression, eval_modify_script,
+    eval_ref_script, lazy_value_closure, register_conventional_onto,
 };
-pub use fetch::register_fetch_verbs;
+pub use convert::{
+    cbor_to_dynamic, dynamic_to_cbor, map_to_record, record_to_dynamic, record_to_map,
+};
+pub use fetch::{FetchVerbs, register_fetch_verbs};
 pub use runtime::{DEFAULT_LIMIT, MAX_LIMIT, MIN_LIMIT, preview_script, run_script};

--- a/vantage-vista/src/rhai/conventional.rs
+++ b/vantage-vista/src/rhai/conventional.rs
@@ -18,7 +18,7 @@
 //! Everything here uses only [`Vista`]'s public API, preserving the one-way
 //! `vantage-table → vantage-vista` dependency (Rhai is a leaf).
 
-use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use ciborium::Value as CborValue;
 use vantage_core::{Result, error};
@@ -34,6 +34,9 @@ use crate::{sort::SortDirection, vista::Vista};
 /// place and return the same handle for chaining. The inner `Option` lets
 /// [`eval_ref_script`] move the finished `Vista` out even if the script kept
 /// extra references.
+///
+/// `Arc<Mutex<…>>` and not `Rc<RefCell<…>>`: `vantage-rhai` compiles rhai with
+/// its `sync` feature, so anything a script holds must be `Send + Sync`.
 #[derive(Clone)]
 pub struct RhaiVista(pub Arc<Mutex<Option<Vista>>>);
 
@@ -100,7 +103,7 @@ impl Vocab for ShellVocab<'_> {
 /// `set_page_size`, `get_ref`). Each verb returns the same handle so scripts can
 /// chain: `table("order").add_condition_eq("client", row.id).add_order("date", "desc")`.
 ///
-/// Prefer [`ConventionalVocab`] on a [`Host`]; this is what it registers.
+/// Prefer [`ConventionalVocab`] on a [`Host`] — this is the registration behind it.
 pub fn register_conventional_onto(engine: &mut Engine, resolver: TargetResolver) {
     engine.register_type_with_name::<RhaiVista>("Vista");
 
@@ -333,19 +336,15 @@ fn eval_lazy_compiled(script: &Compiled<Block>, row: &Record<CborValue>) -> Resu
     dynamic_to_cbor(result).map_err(|e| error!(format!("rhai lazy expression result: {e}")))
 }
 
-/// The host lazy expressions share: no vocabulary — a lazy expression derives
-/// a value from `row`, it doesn't build queries or fetch data — and the
-/// background profile, since it runs inside a fetch, per record.
-fn lazy_host() -> &'static Host {
-    static HOST: LazyLock<Host> = LazyLock::new(|| Host::builder(Limits::background()).build());
-    &HOST
-}
-
 /// Build a reusable [`LazyValueFn`] from a Rhai `code` string. Compiles once,
 /// here — a script that does not parse fails the table build, not the first
 /// row.
 pub fn lazy_value_closure(code: &str) -> Result<LazyValueFn> {
-    let script = compile(lazy_host(), "rhai lazy expression", code)?;
+    let script = compile(
+        vantage_rhai::background_host(),
+        "rhai lazy expression",
+        code,
+    )?;
     Ok(Arc::new(
         move |row: &Record<CborValue>| -> Result<CborValue> { eval_lazy_compiled(&script, row) },
     ))

--- a/vantage-vista/src/rhai/conventional.rs
+++ b/vantage-vista/src/rhai/conventional.rs
@@ -1,11 +1,15 @@
 //! Conventional Rhai vocabulary over the type-erased [`Vista`].
 //!
-//! vantage-vista owns Rhai engine construction with a *backend-agnostic*
-//! vocabulary: `table(name)` resolves a fresh target [`Vista`] through an
-//! injected [`TargetResolver`], and a small set of builder verbs narrow it in
-//! place. Backends layer their vendor-specific vocabulary (expression syntax,
-//! `with_condition`) on top by overriding
+//! vantage-vista owns the *backend-agnostic* vocabulary: `table(name)` resolves
+//! a fresh target [`Vista`] through an injected [`TargetResolver`], and a small
+//! set of builder verbs narrow it in place. Backends layer their vendor-specific
+//! vocabulary (expression syntax, `with_condition`) on top by overriding
 //! [`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions).
+//!
+//! Everything runs on a [`vantage_rhai::Host`]: the vocabulary is a
+//! [`Vocab`] ([`ConventionalVocab`]), every script slot compiles once through
+//! the host's cache, and each evaluation pushes its variables through an
+//! [`Env`] — the parent `row`, the vista as `self`.
 //!
 //! This keeps Rhai out of vantage-table and lets engine-less datasources
 //! (CSV/Mongo/REST) still script the conventional verbs — they only lose the
@@ -14,11 +18,12 @@
 //! Everything here uses only [`Vista`]'s public API, preserving the one-way
 //! `vantage-table → vantage-vista` dependency (Rhai is a leaf).
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
 
 use ciborium::Value as CborValue;
-use rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap, Scope};
 use vantage_core::{Result, error};
+use vantage_rhai::rhai::{Dynamic, Engine, EvalAltResult, Map as RhaiMap};
+use vantage_rhai::{Block, Compiled, Env, Host, Limits, Vocab};
 use vantage_types::Record;
 
 use super::convert::{dynamic_to_cbor, map_to_record, record_to_dynamic};
@@ -29,10 +34,6 @@ use crate::{sort::SortDirection, vista::Vista};
 /// place and return the same handle for chaining. The inner `Option` lets
 /// [`eval_ref_script`] move the finished `Vista` out even if the script kept
 /// extra references.
-///
-/// `Arc<Mutex<…>>` (not `Rc<RefCell<…>>`) so the type satisfies Rhai's
-/// `Send + Sync` bound when a consumer compiles Rhai with its `sync` feature —
-/// `Vista` is itself `Send + Sync` (its `TableShell` is), so nothing is lost.
 #[derive(Clone)]
 pub struct RhaiVista(pub Arc<Mutex<Option<Vista>>>);
 
@@ -53,6 +54,16 @@ impl RhaiVista {
     {
         with_inner(self, f)
     }
+
+    /// Take the `Vista` out, leaving the handle empty. Errors if a script
+    /// already consumed it.
+    pub fn take(&self, what: &str) -> Result<Vista> {
+        self.0
+            .lock()
+            .map_err(|_| error!(format!("{what}: result mutex poisoned")))?
+            .take()
+            .ok_or_else(|| error!(format!("{what}: vista already consumed")))
+    }
 }
 
 /// Resolve a table name to a fresh, unconditioned target [`Vista`]. Injected by
@@ -60,12 +71,36 @@ impl RhaiVista {
 /// backend-agnostic behind this boxed closure.
 pub type TargetResolver = Arc<dyn Fn(&str) -> Result<Vista> + Send + Sync>;
 
+/// The conventional vocabulary as a [`Vocab`]: `table(name)` backed by the
+/// resolver plus the builder verbs. Register it *after* a vendor vocabulary
+/// so its `table` wins over SurrealDB's `table` alias for `ident`.
+pub struct ConventionalVocab(pub TargetResolver);
+
+impl Vocab for ConventionalVocab {
+    fn register(&self, engine: &mut Engine) {
+        register_conventional_onto(engine, self.0.clone());
+    }
+}
+
+/// A shell's vendor vocabulary
+/// ([`TableShell::register_rhai_extensions`](crate::TableShell::register_rhai_extensions))
+/// as a [`Vocab`], so a host can be built from a vista in hand.
+pub struct ShellVocab<'a>(pub &'a Vista);
+
+impl Vocab for ShellVocab<'_> {
+    fn register(&self, engine: &mut Engine) {
+        self.0.source.register_rhai_extensions(engine);
+    }
+}
+
 /// Register the conventional `Vista` vocabulary onto `engine`.
 ///
 /// Adds the `table(name)` constructor (backed by `resolver`) and the in-place
 /// builder verbs (`with_id`, `add_condition_eq`, `add_order`, `add_search`,
 /// `set_page_size`, `get_ref`). Each verb returns the same handle so scripts can
 /// chain: `table("order").add_condition_eq("client", row.id).add_order("date", "desc")`.
+///
+/// Prefer [`ConventionalVocab`] on a [`Host`]; this is what it registers.
 pub fn register_conventional_onto(engine: &mut Engine, resolver: TargetResolver) {
     engine.register_type_with_name::<RhaiVista>("Vista");
 
@@ -173,26 +208,35 @@ pub fn register_conventional_onto(engine: &mut Engine, resolver: TargetResolver)
     );
 }
 
+/// Compile a script slot through the host's cache, wording the error for the
+/// slot that failed.
+fn compile(host: &Host, what: &str, code: &str) -> Result<Compiled<Block>> {
+    host.compile(&Block::from(code))
+        .map_err(|e| error!(format!("{what} failed to compile: {e}")))
+}
+
 /// Evaluate a reference build-script and return the `Vista` it produced.
 ///
-/// `engine` must already have the conventional vocabulary (via
-/// [`register_conventional_onto`]) plus any vendor extensions registered. The
-/// parent `row` is exposed to the script as the `row` map. The script's final
-/// expression must evaluate to a `Vista` (e.g. `table("order").add_…(…)`).
-pub fn eval_ref_script(engine: &Engine, code: &str, row: &Record<CborValue>) -> Result<Vista> {
-    let mut scope = Scope::new();
-    scope.push_dynamic("row", record_to_dynamic(row));
-
-    let result: RhaiVista = engine
-        .eval_with_scope(&mut scope, code)
+/// `host` must carry the conventional vocabulary ([`ConventionalVocab`]) plus
+/// any vendor extensions. `env` is the vendor's base environment (see
+/// [`TableShell::rhai_env`](crate::TableShell::rhai_env)); the parent `row` is
+/// pushed onto it. The script's final expression must evaluate to a `Vista`
+/// (e.g. `table("order").add_…(…)`).
+pub fn eval_ref_script(
+    host: &Host,
+    code: &str,
+    env: Env,
+    row: &Record<CborValue>,
+) -> Result<Vista> {
+    let script = compile(host, "rhai reference build-script", code)?;
+    let env = env.var("row", record_to_dynamic(row));
+    let result = script
+        .eval(&env)
         .map_err(|e| error!(format!("rhai reference build-script failed: {e}")))?;
-
-    result
-        .0
-        .lock()
-        .map_err(|_| error!("rhai reference build-script: result mutex poisoned"))?
-        .take()
-        .ok_or_else(|| error!("rhai reference build-script did not return a Vista"))
+    let handle: RhaiVista = result
+        .try_cast::<RhaiVista>()
+        .ok_or_else(|| error!("rhai reference build-script did not return a Vista"))?;
+    handle.take("rhai reference build-script")
 }
 
 /// Evaluate a *modify* script against an already-built [`Vista`], applying extra
@@ -208,25 +252,18 @@ pub fn eval_ref_script(engine: &Engine, code: &str, row: &Record<CborValue>) -> 
 /// self.with_condition(ident("is_paying_client") == true)
 /// ```
 ///
-/// `engine` must already carry the conventional vocabulary (via
-/// [`register_conventional_onto`]) plus any vendor extensions.
-pub fn eval_modify_script(engine: &Engine, code: &str, vista: Vista) -> Result<Vista> {
+/// `host` must carry the conventional vocabulary plus any vendor extensions;
+/// the vista's own shell contributes its constants via `rhai_env`.
+pub fn eval_modify_script(host: &Host, code: &str, vista: Vista) -> Result<Vista> {
+    let script = compile(host, "rhai modify script", code)?;
+    let env = vista.source.rhai_env(Env::new());
     let handle = RhaiVista::wrap(vista);
-    let mut scope = Scope::new();
-    scope.push("self", handle.clone());
-
-    engine
-        .run_with_scope(&mut scope, code)
+    script
+        .run(&env.var("self", Dynamic::from(handle.clone())))
         .map_err(|e| error!(format!("rhai modify script failed: {e}")))?;
-
     // `take()` succeeds regardless of the scope's lingering `Arc` clone — it
     // empties the shared `Option`, not the `Arc`.
-    handle
-        .0
-        .lock()
-        .map_err(|_| error!("rhai modify script: result mutex poisoned"))?
-        .take()
-        .ok_or_else(|| error!("rhai modify script consumed `self`"))
+    handle.take("rhai modify script")
 }
 
 /// A diorama augmentation *source* closure: given a master `row` and a freshly
@@ -243,29 +280,31 @@ pub type AugmentSourceFn = Arc<dyn Fn(&Record<CborValue>, Vista) -> Result<Vista
 /// ```
 ///
 /// is the canonical form. Mirrors [`eval_modify_script`] but with the parent row
-/// in scope; the engine must already carry the conventional vocabulary (via
-/// [`register_conventional_onto`]) plus any vendor extensions.
+/// in scope.
 pub fn eval_augment_source(
-    engine: &Engine,
+    host: &Host,
     code: &str,
     base: Vista,
     row: &Record<CborValue>,
 ) -> Result<Vista> {
+    let script = compile(host, "rhai augment source script", code)?;
+    eval_augment_compiled(&script, base, row)
+}
+
+fn eval_augment_compiled(
+    script: &Compiled<Block>,
+    base: Vista,
+    row: &Record<CborValue>,
+) -> Result<Vista> {
+    let env = base.source.rhai_env(Env::new());
     let handle = RhaiVista::wrap(base);
-    let mut scope = Scope::new();
-    scope.push("self", handle.clone());
-    scope.push_dynamic("row", record_to_dynamic(row));
-
-    engine
-        .run_with_scope(&mut scope, code)
+    script
+        .run(
+            &env.var("self", Dynamic::from(handle.clone()))
+                .var("row", record_to_dynamic(row)),
+        )
         .map_err(|e| error!(format!("rhai augment source script failed: {e}")))?;
-
-    handle
-        .0
-        .lock()
-        .map_err(|_| error!("rhai augment source: result mutex poisoned"))?
-        .take()
-        .ok_or_else(|| error!("rhai augment source consumed `self`"))
+    handle.take("rhai augment source")
 }
 
 /// A lazy-expression value closure: given the record as built so far, compute
@@ -282,46 +321,61 @@ pub type LazyValueFn = Arc<dyn Fn(&Record<CborValue>) -> Result<CborValue> + Sen
 /// ```rhai
 /// row.contents.split("\n").len() - 1
 /// ```
-pub fn eval_lazy_expression(
-    engine: &Engine,
-    code: &str,
-    row: &Record<CborValue>,
-) -> Result<CborValue> {
-    let mut scope = Scope::new();
-    scope.push_dynamic("row", record_to_dynamic(row));
+pub fn eval_lazy_expression(host: &Host, code: &str, row: &Record<CborValue>) -> Result<CborValue> {
+    let script = compile(host, "rhai lazy expression", code)?;
+    eval_lazy_compiled(&script, row)
+}
 
-    let result: Dynamic = engine
-        .eval_with_scope(&mut scope, code)
+fn eval_lazy_compiled(script: &Compiled<Block>, row: &Record<CborValue>) -> Result<CborValue> {
+    let result = script
+        .eval(&Env::new().var("row", record_to_dynamic(row)))
         .map_err(|e| error!(format!("rhai lazy expression failed: {e}")))?;
     dynamic_to_cbor(result).map_err(|e| error!(format!("rhai lazy expression result: {e}")))
 }
 
-/// Build a reusable [`LazyValueFn`] from a Rhai `code` string. The engine is
-/// plain — a lazy expression derives a value from `row`, it doesn't build
-/// queries or fetch data, so no resolver or vendor vocabulary is needed.
-pub fn lazy_value_closure(code: String) -> LazyValueFn {
-    Arc::new(move |row: &Record<CborValue>| -> Result<CborValue> {
-        let engine = Engine::new();
-        eval_lazy_expression(&engine, code.as_str(), row)
-    })
+/// The host lazy expressions share: no vocabulary — a lazy expression derives
+/// a value from `row`, it doesn't build queries or fetch data — and the
+/// background profile, since it runs inside a fetch, per record.
+fn lazy_host() -> &'static Host {
+    static HOST: LazyLock<Host> = LazyLock::new(|| Host::builder(Limits::background()).build());
+    &HOST
+}
+
+/// Build a reusable [`LazyValueFn`] from a Rhai `code` string. Compiles once,
+/// here — a script that does not parse fails the table build, not the first
+/// row.
+pub fn lazy_value_closure(code: &str) -> Result<LazyValueFn> {
+    let script = compile(lazy_host(), "rhai lazy expression", code)?;
+    Ok(Arc::new(
+        move |row: &Record<CborValue>| -> Result<CborValue> { eval_lazy_compiled(&script, row) },
+    ))
 }
 
 /// Build a reusable [`AugmentSourceFn`] from a Rhai `code` string and a
-/// `resolver` for `table(name)`. Keeps all Rhai engine assembly inside
+/// `resolver` for `table(name)`. Keeps all Rhai host assembly inside
 /// vantage-vista: a consumer (diorama's augmentation lowering) only flips the
 /// `rhai` feature and calls this — it never touches the `rhai` crate directly.
 ///
-/// The engine is rebuilt per call (cheap; `rhai`'s `sync` feature is not assumed,
-/// so an [`Engine`] cannot be stored in a `Send + Sync` closure). Vendor
-/// extensions come from the supplied `base`'s shell, so scripted narrowing can
-/// use a backend's expression syntax when present.
+/// Vendor extensions come from the `base` vista's shell, which is only in hand
+/// per call, so the host is built on the first call and reused after: one
+/// augmentation always narrows the same detail table.
 pub fn augment_source_closure(resolver: TargetResolver, code: String) -> AugmentSourceFn {
+    let compiled: OnceLock<Result<Compiled<Block>>> = OnceLock::new();
     Arc::new(
         move |row: &Record<CborValue>, base: Vista| -> Result<Vista> {
-            let mut engine = Engine::new();
-            base.source.register_rhai_extensions(&mut engine);
-            register_conventional_onto(&mut engine, resolver.clone());
-            eval_augment_source(&engine, code.as_str(), base, row)
+            let script = compiled.get_or_init(|| {
+                // Vendor vocab first, conventional second, so `table(name)`
+                // resolves a Vista rather than a vendor identifier.
+                let host = Host::builder(Limits::background())
+                    .vocab(ShellVocab(&base))
+                    .vocab(ConventionalVocab(resolver.clone()))
+                    .build();
+                compile(&host, "rhai augment source script", &code)
+            });
+            match script {
+                Ok(script) => eval_augment_compiled(script, base, row),
+                Err(e) => Err(error!(e.to_string())),
+            }
         },
     )
 }
@@ -436,25 +490,29 @@ mod tests {
         Vista::new("users", Box::new(source.with_metadata(metadata)))
     }
 
-    fn engine() -> Engine {
-        let resolver: TargetResolver = Arc::new(|name: &str| {
+    fn resolver() -> TargetResolver {
+        Arc::new(|name: &str| {
             if name == "users" {
                 Ok(users_vista())
             } else {
                 Err(error!("unknown table in test resolver", table = name))
             }
-        });
-        let mut engine = Engine::new();
-        register_conventional_onto(&mut engine, resolver);
-        engine
+        })
+    }
+
+    fn host() -> Host {
+        Host::builder(Limits::background())
+            .vocab(ConventionalVocab(resolver()))
+            .build()
     }
 
     #[tokio::test]
     async fn script_narrows_target_with_literal_condition() {
         let row = record(&[("id", cbor_text("1"))]);
         let vista = eval_ref_script(
-            &engine(),
+            &host(),
             r#"table("users").add_condition_eq("vip_flag", true)"#,
+            Env::new(),
             &row,
         )
         .unwrap();
@@ -471,8 +529,9 @@ mod tests {
         // `parse_op`, and dispatch are wired.
         let row = record(&[("id", cbor_text("1"))]);
         let vista = eval_ref_script(
-            &engine(),
+            &host(),
             r#"table("users").add_condition("vip_flag", "eq", true)"#,
+            Env::new(),
             &row,
         )
         .unwrap();
@@ -485,8 +544,9 @@ mod tests {
     fn add_condition_rejects_unknown_operator() {
         let row = record(&[("id", cbor_text("1"))]);
         let result = eval_ref_script(
-            &engine(),
+            &host(),
             r#"table("users").add_condition("vip_flag", "wat", true)"#,
+            Env::new(),
             &row,
         );
         match result {
@@ -499,8 +559,9 @@ mod tests {
     async fn script_can_read_the_parent_row() {
         let row = record(&[("id", cbor_text("3"))]);
         let vista = eval_ref_script(
-            &engine(),
+            &host(),
             r#"table("users").add_condition_eq("id", row.id)"#,
+            Env::new(),
             &row,
         )
         .unwrap();
@@ -515,12 +576,9 @@ mod tests {
         // The YAML built `users`; a post-build modify script narrows it in place
         // via `self`, with no parent row in scope.
         let vista = users_vista();
-        let modified = eval_modify_script(
-            &engine(),
-            r#"self.add_condition_eq("vip_flag", true)"#,
-            vista,
-        )
-        .unwrap();
+        let modified =
+            eval_modify_script(&host(), r#"self.add_condition_eq("vip_flag", true)"#, vista)
+                .unwrap();
 
         let rows = modified.list_values().await.unwrap();
         assert_eq!(rows.len(), 2);
@@ -530,10 +588,43 @@ mod tests {
     #[test]
     fn unknown_table_surfaces_resolver_error() {
         let row = record(&[]);
-        let err = match eval_ref_script(&engine(), r#"table("ghosts")"#, &row) {
+        let err = match eval_ref_script(&host(), r#"table("ghosts")"#, Env::new(), &row) {
             Ok(_) => panic!("expected the resolver to reject an unknown table"),
             Err(e) => e,
         };
         assert!(err.to_string().contains("unknown table"));
+    }
+
+    #[test]
+    fn lazy_closure_compiles_once_and_fails_early() {
+        let f = lazy_value_closure("row.n * 2").unwrap();
+        let row = record(&[("n", CborValue::Integer(21.into()))]);
+        assert_eq!(f(&row).unwrap(), CborValue::Integer(42.into()));
+        assert!(
+            lazy_value_closure("row.n *").is_err(),
+            "syntax fails at build"
+        );
+    }
+
+    #[test]
+    fn lazy_expression_is_bounded() {
+        let f = lazy_value_closure("loop {}").unwrap();
+        let err = f(&record(&[])).unwrap_err();
+        assert!(err.to_string().contains("limit"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn augment_closure_narrows_base_per_row() {
+        let f =
+            augment_source_closure(resolver(), r#"self.add_condition_eq("id", row.key)"#.into());
+        let row = record(&[("key", cbor_text("2"))]);
+        let narrowed = f(&row, users_vista()).unwrap();
+        let rows = narrowed.list_values().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(rows.contains_key("2"));
+        // Second call reuses the compiled script.
+        let row = record(&[("key", cbor_text("3"))]);
+        let rows = f(&row, users_vista()).unwrap().list_values().await.unwrap();
+        assert!(rows.contains_key("3"));
     }
 }

--- a/vantage-vista/src/rhai/convert.rs
+++ b/vantage-vista/src/rhai/convert.rs
@@ -1,19 +1,21 @@
-//! Value conversions between the CBOR carrier, Rhai `Dynamic`, and (for the
-//! fetch surface) `serde_json`.
+//! Value conversions between the CBOR carrier and Rhai `Dynamic`.
 //!
-//! Shared by [`rhai_conventional`](crate::rhai_conventional) (which seeds the
-//! parent `row` map and lowers condition scalars) and
-//! [`rhai_fetch`](crate::rhai_fetch) (which materialises fetched records and
-//! renders a script's final value as JSON). Kept in one place so the two
-//! vocabularies can never drift in how they round-trip a value.
+//! Shared by [`conventional`](super::conventional) (which seeds the parent
+//! `row` map and lowers condition scalars) and [`fetch`](super::fetch) (which
+//! materialises fetched records). Public so the other data-layer crates
+//! (diorama's servo, the faker effects) round-trip values the same way — one
+//! converter, so a record id renders as `"table:id"` in every script.
+//!
+//! JSON goes through `vantage_rhai::{to_json, from_json}`.
 
 use ciborium::Value as CborValue;
-use rhai::{Array, Dynamic, EvalAltResult, Map as RhaiMap};
+use vantage_rhai::rhai::{Array, Blob, Dynamic, EvalAltResult, Map as RhaiMap};
 use vantage_types::Record;
 
-/// Convert a scalar Rhai value into the universal CBOR carrier. Non-scalar
-/// types (arrays, maps) are rejected — only condition/id values pass through.
-pub(crate) fn dynamic_to_cbor(d: Dynamic) -> Result<CborValue, Box<EvalAltResult>> {
+/// Convert a Rhai value into the universal CBOR carrier. Scalars, arrays and
+/// maps pass through (an array is what an `in` condition takes); a value with
+/// no CBOR story — a closure, a custom type — is an error naming the type.
+pub fn dynamic_to_cbor(d: Dynamic) -> Result<CborValue, Box<EvalAltResult>> {
     if d.is_unit() {
         Ok(CborValue::Null)
     } else if d.is::<bool>() {
@@ -24,9 +26,27 @@ pub(crate) fn dynamic_to_cbor(d: Dynamic) -> Result<CborValue, Box<EvalAltResult
         Ok(CborValue::Float(d.cast::<f64>()))
     } else if d.is::<String>() {
         Ok(CborValue::Text(d.cast::<String>()))
+    } else if d.is::<char>() {
+        Ok(CborValue::Text(d.cast::<char>().to_string()))
+    } else if d.is::<Blob>() {
+        Ok(CborValue::Bytes(d.cast::<Blob>()))
+    } else if d.is::<Array>() {
+        let items = d
+            .cast::<Array>()
+            .into_iter()
+            .map(dynamic_to_cbor)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(CborValue::Array(items))
+    } else if d.is::<RhaiMap>() {
+        let pairs = d
+            .cast::<RhaiMap>()
+            .into_iter()
+            .map(|(k, v)| Ok((CborValue::Text(k.to_string()), dynamic_to_cbor(v)?)))
+            .collect::<Result<Vec<_>, Box<EvalAltResult>>>()?;
+        Ok(CborValue::Map(pairs))
     } else {
         Err(format!(
-            "cannot convert rhai value of type '{}' into a condition value",
+            "no CBOR representation for rhai value of type '{}'",
             d.type_name()
         )
         .into())
@@ -36,7 +56,7 @@ pub(crate) fn dynamic_to_cbor(d: Dynamic) -> Result<CborValue, Box<EvalAltResult
 /// CBOR → Rhai `Dynamic`. Tagged values render their presentation form
 /// (record ids as `"table:id"`, datetimes/UUIDs/decimals as their text —
 /// the same shapes the UI grid shows) instead of degrading to unit.
-pub(crate) fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
+pub fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
     match v {
         CborValue::Null => Dynamic::UNIT,
         CborValue::Bool(b) => Dynamic::from_bool(*b),
@@ -79,61 +99,26 @@ pub(crate) fn cbor_to_dynamic(v: &CborValue) -> Dynamic {
 }
 
 /// A whole record as a Rhai map (used to seed `row` and to materialise rows).
-pub(crate) fn record_to_dynamic(rec: &Record<CborValue>) -> Dynamic {
+pub fn record_to_dynamic(rec: &Record<CborValue>) -> Dynamic {
+    Dynamic::from_map(record_to_map(rec))
+}
+
+/// A whole record as a Rhai map.
+pub fn record_to_map(rec: &Record<CborValue>) -> RhaiMap {
     let mut map = RhaiMap::new();
     for (k, v) in rec.iter() {
         map.insert(k.as_str().into(), cbor_to_dynamic(v));
     }
-    Dynamic::from_map(map)
+    map
 }
 
 /// A Rhai map back into a record (used to pass a parent row to `get_ref`).
-pub(crate) fn map_to_record(map: RhaiMap) -> Result<Record<CborValue>, Box<EvalAltResult>> {
+pub fn map_to_record(map: RhaiMap) -> Result<Record<CborValue>, Box<EvalAltResult>> {
     let mut out: Vec<(String, CborValue)> = Vec::with_capacity(map.len());
     for (k, v) in map {
         out.push((k.to_string(), dynamic_to_cbor(v)?));
     }
     Ok(out.into_iter().collect())
-}
-
-/// Rhai `Dynamic` → `serde_json::Value` for handing a script's result back to a
-/// caller (e.g. over MCP). `rhai` is built without its `serde` feature, so the
-/// conversion is explicit; unknown types fall back to their display string.
-pub(crate) fn dynamic_to_json(d: &Dynamic) -> serde_json::Value {
-    use serde_json::Value;
-    if d.is_unit() {
-        return Value::Null;
-    }
-    if d.is::<bool>() {
-        return Value::Bool(d.as_bool().unwrap_or(false));
-    }
-    if d.is::<i64>() {
-        return Value::from(d.as_int().unwrap_or(0));
-    }
-    if d.is::<f64>() {
-        return d
-            .as_float()
-            .ok()
-            .and_then(serde_json::Number::from_f64)
-            .map(Value::Number)
-            .unwrap_or(Value::Null);
-    }
-    if d.is::<String>() {
-        return Value::String(d.clone().into_string().unwrap_or_default());
-    }
-    if d.is::<Array>() {
-        let arr = d.clone().cast::<Array>();
-        return Value::Array(arr.iter().map(dynamic_to_json).collect());
-    }
-    if d.is::<RhaiMap>() {
-        let map = d.clone().cast::<RhaiMap>();
-        let obj = map
-            .iter()
-            .map(|(k, v)| (k.to_string(), dynamic_to_json(v)))
-            .collect();
-        return Value::Object(obj);
-    }
-    Value::String(d.to_string())
 }
 
 #[cfg(test)]
@@ -168,5 +153,30 @@ mod tests {
         let n = i128::from(i64::MIN) - 1;
         let big = CborValue::Integer(n.try_into().unwrap());
         assert_eq!(cbor_to_dynamic(&big).into_string().unwrap(), n.to_string());
+    }
+
+    #[test]
+    fn arrays_and_maps_round_trip() {
+        let mut map = RhaiMap::new();
+        map.insert(
+            "ids".into(),
+            Dynamic::from(vec![Dynamic::from(1_i64), Dynamic::from("x")]),
+        );
+        let cbor = dynamic_to_cbor(Dynamic::from(map)).unwrap();
+        let CborValue::Map(pairs) = &cbor else {
+            panic!("{cbor:?}")
+        };
+        assert_eq!(pairs[0].0, CborValue::Text("ids".into()));
+        assert!(matches!(&pairs[0].1, CborValue::Array(a) if a.len() == 2));
+        let back = cbor_to_dynamic(&cbor);
+        assert!(back.is_map());
+    }
+
+    #[test]
+    fn opaque_values_are_named_in_the_error() {
+        #[derive(Clone)]
+        struct Opaque;
+        let err = dynamic_to_cbor(Dynamic::from(Opaque)).unwrap_err();
+        assert!(err.to_string().contains("Opaque"), "{err}");
     }
 }

--- a/vantage-vista/src/rhai/fetch.rs
+++ b/vantage-vista/src/rhai/fetch.rs
@@ -18,8 +18,9 @@
 //! evaluates inside `tokio::task::spawn_blocking` — see that runner for why.
 
 use ciborium::Value as CborValue;
-use rhai::{Array, Dynamic, Engine, EvalAltResult, Map as RhaiMap};
 use vantage_dataset::ReadableValueSet;
+use vantage_rhai::Vocab;
+use vantage_rhai::rhai::{Array, Dynamic, Engine, EvalAltResult, Map as RhaiMap};
 use vantage_types::Record;
 
 use super::conventional::RhaiVista;
@@ -29,10 +30,25 @@ use crate::vista::Vista;
 
 type RhaiResult<T> = Result<T, Box<EvalAltResult>>;
 
+/// The terminal fetch + introspection verbs as a [`Vocab`]. `limit` caps every
+/// `list()`. Register it beside [`ConventionalVocab`](super::ConventionalVocab);
+/// a host without it structurally cannot fetch (see `preview_script`).
+pub struct FetchVerbs {
+    pub limit: usize,
+}
+
+impl Vocab for FetchVerbs {
+    fn register(&self, engine: &mut Engine) {
+        register_fetch_verbs(engine, self.limit);
+    }
+}
+
 /// Register the terminal fetch + introspection verbs onto `engine`. The engine
 /// must already carry the conventional vocabulary (see
 /// [`register_conventional_onto`](crate::register_conventional_onto)). `limit`
 /// caps every `list()`. Each verb is read-only.
+///
+/// Prefer [`FetchVerbs`] on a host; this is what it registers.
 pub fn register_fetch_verbs(engine: &mut Engine, limit: usize) {
     // `list()` → array of record-maps, capped at `limit`.
     engine.register_fn("list", move |v: &mut RhaiVista| -> RhaiResult<Array> {

--- a/vantage-vista/src/rhai/fetch.rs
+++ b/vantage-vista/src/rhai/fetch.rs
@@ -48,7 +48,7 @@ impl Vocab for FetchVerbs {
 /// [`register_conventional_onto`](crate::register_conventional_onto)). `limit`
 /// caps every `list()`. Each verb is read-only.
 ///
-/// Prefer [`FetchVerbs`] on a host; this is what it registers.
+/// Prefer [`FetchVerbs`] on a host — this is the registration behind it.
 pub fn register_fetch_verbs(engine: &mut Engine, limit: usize) {
     // `list()` → array of record-maps, capped at `limit`.
     engine.register_fn("list", move |v: &mut RhaiVista| -> RhaiResult<Array> {

--- a/vantage-vista/src/rhai/introspect.rs
+++ b/vantage-vista/src/rhai/introspect.rs
@@ -2,7 +2,7 @@
 //! `columns()`, and `references()` fetch verbs. Each turns a [`Vista`]'s
 //! metadata into a plain Rhai value the script can read.
 
-use rhai::{Array, Dynamic, Map as RhaiMap};
+use vantage_rhai::rhai::{Array, Dynamic, Map as RhaiMap};
 
 use crate::vista::Vista;
 

--- a/vantage-vista/src/rhai/runtime.rs
+++ b/vantage-vista/src/rhai/runtime.rs
@@ -18,11 +18,18 @@
 //! }
 //! ```
 
-use rhai::{Dynamic, Engine};
+use vantage_rhai::{Block, Env, Host, Limits};
 
-use super::conventional::{RhaiVista, TargetResolver, register_conventional_onto};
-use super::convert::dynamic_to_json;
-use super::fetch::register_fetch_verbs;
+use super::conventional::{ConventionalVocab, RhaiVista, TargetResolver};
+use super::fetch::FetchVerbs;
+
+/// Compile and run a one-shot script on `host`. These are MCP entry points:
+/// every call is a different script, so the cache is bypassed.
+fn run_once(host: &Host, script: &str) -> Result<vantage_rhai::rhai::Dynamic, String> {
+    host.compile_uncached(&Block::from(script))
+        .and_then(|s| s.eval(&Env::new()))
+        .map_err(|e| e.to_string())
+}
 
 /// Lower bound applied to a requested row limit.
 pub const MIN_LIMIT: usize = 1;
@@ -50,14 +57,16 @@ pub async fn run_script(
     let limit = limit.clamp(MIN_LIMIT, MAX_LIMIT);
 
     tokio::task::spawn_blocking(move || -> Result<serde_json::Value, String> {
-        let mut engine = Engine::new();
-        // The conventional builder vocabulary (table/condition/order/get_ref…)…
-        register_conventional_onto(&mut engine, resolver);
-        // …plus the terminal fetch/introspection verbs.
-        register_fetch_verbs(&mut engine, limit);
-
-        let result: Dynamic = engine.eval::<Dynamic>(&script).map_err(|e| e.to_string())?;
-        Ok(dynamic_to_json(&result))
+        // The conventional builder vocabulary (table/condition/order/get_ref…)
+        // plus the terminal fetch/introspection verbs. Background profile: this
+        // is a blocking thread, and a fetch script may legitimately loop over
+        // rows.
+        let host = Host::builder(Limits::background())
+            .vocab(ConventionalVocab(resolver))
+            .vocab(FetchVerbs { limit })
+            .build();
+        let result = run_once(&host, &script)?;
+        Ok(vantage_rhai::to_json(&result))
     })
     .await
     .map_err(|e| format!("data-fetch script task failed to run: {e}"))?
@@ -66,10 +75,10 @@ pub async fn run_script(
 /// Build a query with the conventional verbs and render what it *would* send,
 /// without sending anything.
 ///
-/// The engine this runs on carries [`register_conventional_onto`] and nothing
-/// else — the terminal fetch verbs are deliberately absent, so there is no path
-/// from a preview script to a backend read. That is the point: preview is safe
-/// to expose in places where fetching is not, and the safety is structural
+/// The host this runs on carries [`ConventionalVocab`] and nothing else — the
+/// terminal fetch verbs ([`FetchVerbs`]) are deliberately absent, so there is no
+/// path from a preview script to a backend read. That is the point: preview is
+/// safe to expose in places where fetching is not, and the safety is structural
 /// rather than a promise about how the verb is used.
 ///
 /// Consequently the script takes no terminal verb at all. Its final expression
@@ -106,25 +115,20 @@ pub fn preview_script(
     script: String,
     resolver: TargetResolver,
 ) -> Result<serde_json::Value, String> {
-    let mut engine = Engine::new();
-    register_conventional_onto(&mut engine, resolver);
+    let host = Host::builder(Limits::background())
+        .vocab(ConventionalVocab(resolver))
+        .build();
 
-    let result: Dynamic = engine.eval::<Dynamic>(&script).map_err(|e| e.to_string())?;
+    let result = run_once(&host, &script)?;
     let handle: RhaiVista = result.try_cast::<RhaiVista>().ok_or_else(|| {
         "preview script must end on the query itself, e.g. \
-         `table(\"orders\").add_condition_eq(\"status\", \"paid\")` — this engine \
+         `table(\"orders\").add_condition_eq(\"status\", \"paid\")` — this host \
          has no terminal verbs (`list`, `count`, `get_some`), because it never \
          fetches"
             .to_string()
     })?;
 
-    let vista = handle
-        .0
-        .lock()
-        .map_err(|_| "preview script: result mutex poisoned".to_string())?
-        .take()
-        .ok_or_else(|| "preview script: vista already consumed".to_string())?;
-
+    let vista = handle.take("preview script").map_err(|e| e.to_string())?;
     Ok(vista.preview_query())
 }
 

--- a/vantage-vista/src/source.rs
+++ b/vantage-vista/src/source.rs
@@ -1,4 +1,6 @@
 use std::pin::Pin;
+#[cfg(feature = "rhai")]
+use vantage_rhai::rhai;
 
 use async_trait::async_trait;
 use ciborium::Value as CborValue;
@@ -610,6 +612,18 @@ pub trait TableShell: Send + Sync + 'static {
     /// graceful degradation, not all-or-nothing.
     #[cfg(feature = "rhai")]
     fn register_rhai_extensions(&self, _engine: &mut rhai::Engine) {}
+
+    /// Vendor constants a script sees beside `row`/`self` — the per-evaluation
+    /// half of [`register_rhai_extensions`](Self::register_rhai_extensions).
+    /// SurrealDB pushes `me`, the current-record anchor. A value here is a
+    /// scope variable, never an engine hook, so it composes with the host's
+    /// own resolver.
+    ///
+    /// Default: `env` unchanged.
+    #[cfg(feature = "rhai")]
+    fn rhai_env(&self, env: vantage_rhai::Env) -> vantage_rhai::Env {
+        env
+    }
 
     // ---- Live subscription -------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Every data-layer crate with a `rhai` feature runs on `vantage-rhai` hosts instead of bare engines: `vantage-vista` (`ConventionalVocab`, `ShellVocab`, `FetchVerbs`; eval functions take `&Host` + `Env`; `lazy_value_closure` compiles once instead of per record), `vantage-sql` (`SqlVocab`, per-dialect lazy host, `Env`-bound args), `vantage-surrealdb` (`SurrealVocab`; `me` moves from an `on_var` hook that collided with the host resolver to `surreal_env`), `vantage-cmd` (`CmdVocab` as the security lock, 1.21 pin gone), `vantage-faker` (compile once, run per tick), `vantage-diorama` (`ServoVocab`, converters shared with vista).
- `vantage-rhai` 0.6.2: value methods on `Compiled<Block>`, `engine()`/`ast()` accessors, slot types gain `Deref<str>`/`Display`/`Default`/`PartialEq<str>` for painless adoption in YAML structs.
- Versions and changelogs: rhai 0.6.2, vista 0.6.25, sql 0.6.22, surrealdb 0.6.18, cmd 0.6.5, faker 0.6.15, diorama 0.12.5, api-client 0.6.13. No engine is unlimited: `Engine::new()` outside tests exists only in `vantage-rhai`.
- Plan and live status: `plans/2026-09-05-rhai-unification-status.md`.

## Publish order

`vantage-rhai` first (already in the CD order), then vista, then the rest. vantage-ui `rhai-unification` pins these versions and regenerates its lock once they are on crates.io.

## Test plan

- [x] per-crate `cargo test --features rhai` (vista 60+4+5, sql 739, surrealdb 103, cmd 19, faker 44, diorama all suites, vantage-rhai 50)
- [x] clippy on vantage-rhai; workspace check of the bumped crates; standalone cmd and faker compile against the bumped siblings
- [x] `rhai_test_sql` / `rhai_test_surreal` fixture runners (surreal 16/18; the two `'x'` vs `"x"` quoting mismatches fail identically on main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified script execution across SQL, data views, command workflows, forms, and mutation effects.
  * Scripts compile once and reuse cached results, improving repeated evaluations.
  * Added shared conversion support for script values, records, maps, and arrays.
  * SurrealDB scripts retain access to the current record through `me`, including custom resolver scenarios.
  * Added reusable bounded hosts for UI and background script execution.

* **Bug Fixes**
  * Invalid scripts now report syntax errors during setup or table construction.
  * Background script execution now applies bounded runtime limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->