### PR TITLE
vantage-rhai: README and a runnable quickstart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "thiserror 2.0.18",
 ]
 

--- a/vantage-rhai/Cargo.toml
+++ b/vantage-rhai/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "One Rhai host for every Vantage YAML script slot: slot types, limits, vocab/resolver traits, discovery, template scanner"
 repository = "https://github.com/romaninsh/vantage"
+readme = "README.md"
 
 [lib]
 doctest = false
@@ -19,3 +20,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0"
 schemars = { version = "0.8", optional = true }
+
+[dev-dependencies]
+# The quickstart example deserializes its slots from YAML, which is where a
+# real consumer's slots come from.
+serde_yaml_ng = "0.10"

--- a/vantage-rhai/README.md
+++ b/vantage-rhai/README.md
@@ -233,6 +233,12 @@ a frozen empty set from one that was never taken. Treat the result as a
 dependency floor: a branch the evaluation did not take recorded nothing, so
 recompile on structural change.
 
+`cargo run --example invalidation` puts a number on this. Two slots each roll a
+random value whenever they run, so you can see which ones a change recomputed:
+bumping a path recomputes the slot that reads it and leaves the other holding
+its original number, and bumping a sibling path that neither slot reads
+recomputes nothing.
+
 ## Errors
 
 `RhaiError` has five variants — `Syntax`, `UnknownName`, `Runtime`,
@@ -327,8 +333,14 @@ choosing its own binary.
    `Dynamic::from(…)`.
 7. Surface `RhaiError` with its `src()` so the author sees which slot failed.
 
-`cargo run --example quickstart` in this crate walks the same seven steps in
-one file.
+## Examples
+
+Both load their slots from a YAML file beside them, the way a project does.
+
+| Example | Shows |
+|---|---|
+| `cargo run --example quickstart` | the seven steps above end to end: all three slot kinds, a vocabulary, a resolver, discovery, and what each error looks like |
+| `cargo run --example invalidation` | how a consumer turns a read-set into a decision about what to recompute |
 
 ## Layout
 

--- a/vantage-rhai/README.md
+++ b/vantage-rhai/README.md
@@ -341,7 +341,7 @@ Both load their slots from a YAML file beside them, the way a project does.
 |---|---|
 | `cargo run --example quickstart` | the seven steps above end to end: all three slot kinds, a vocabulary, a resolver, discovery, and what each error looks like |
 | `cargo run --example invalidation` | how a consumer turns a read-set into a decision about what to recompute |
-| `cargo run --example two_hosts` | a background host computing on a worker thread while a UI host formats on the main one, sharing a scope and nothing else |
+| `cargo run --example two_hosts` | two hosts on two threads sharing a scope: per-path generations, a pump loop, and a label that falls quiet when its value stops moving |
 
 ## Layout
 

--- a/vantage-rhai/README.md
+++ b/vantage-rhai/README.md
@@ -341,6 +341,7 @@ Both load their slots from a YAML file beside them, the way a project does.
 |---|---|
 | `cargo run --example quickstart` | the seven steps above end to end: all three slot kinds, a vocabulary, a resolver, discovery, and what each error looks like |
 | `cargo run --example invalidation` | how a consumer turns a read-set into a decision about what to recompute |
+| `cargo run --example two_hosts` | a background host computing on a worker thread while a UI host formats on the main one, sharing a scope and nothing else |
 
 ## Layout
 

--- a/vantage-rhai/README.md
+++ b/vantage-rhai/README.md
@@ -1,0 +1,344 @@
+# vantage-rhai
+
+One [Rhai](https://rhai.rs) host for every script slot in Vantage's YAML.
+
+A slot is a YAML field whose value is script source: a `when:` guard, a `text:`
+template, an `action:` body, a driver's query builder. Before this crate each
+consumer built its own `rhai::Engine`, so limits, error shape, caching and
+`${…}` parsing were settled independently by every consumer and agreed on
+nothing.
+
+```toml
+[dependencies]
+vantage-rhai = "0.6"
+```
+
+Do not add `rhai` beside it. This crate re-exports the exact version and
+feature set it was built against as `vantage_rhai::rhai`. A same-major entry of
+your own quietly unions its default features onto the shared build; a different
+major gives you two `Dynamic` types that rustc can only explain as a note about
+multiple versions of `rhai` hanging off a mismatched-types error.
+
+## The three kinds of slot
+
+Reach for `Expr` unless the author needs surrounding text (`Template`) or more
+than one statement (`Block`).
+
+| Type | Author writes | Compiled as |
+|---|---|---|
+| `Expr` | one expression: `row.total > 100` | a single value |
+| `Template` | text with holes: `Due ${ row.days } days` | literal parts joined with evaluated holes |
+| `Block` | statements: `let n = count(); save(n);` | a script; its final *expression* is the result, unit if it ends on a statement |
+
+Each is a newtype over `String` with `#[serde(transparent)]`, so a YAML struct
+declares the kind and deserializes from a plain scalar:
+
+```rust
+use vantage_rhai::{Block, Expr, Template};
+
+#[derive(serde::Deserialize)]
+struct ButtonDef {
+    when: Option<Expr>,
+    label: Template,
+    action: Block,
+}
+```
+
+They deref to `str`, print as their source, serialise back out as the same
+scalar, compare against `&str`, hash, and `Default` to empty — so changing a
+field from `Option<String>` to `Option<Expr>` leaves every site that only
+displays or compares it untouched. The kind bites where it should:
+`Host::compile` takes the typed slot, never a bare string.
+
+Two consequences of the kinds being real types:
+
+- An `Expr` tolerates one `${ … }` wrapped around the whole string and strips
+  it, so an author who writes `when: '${ row.ok }'` out of habit gets the
+  expression they meant rather than a template that renders `"true"` and is
+  therefore always truthy.
+- An `Expr` refuses statements outright — `when: 'let a = 1; a'` is a syntax
+  error, because the kind compiles through rhai's expression parser.
+
+## Compiling and evaluating
+
+```rust
+use vantage_rhai::{Env, Expr, Host, Limits};
+
+let host = Host::builder(Limits::Ui).build();
+let guard = host.compile(&Expr::from("qty > 0 && qty <= stock"))?;
+
+let env = Env::new().var("qty", 3_i64).var("stock", 10_i64);
+assert!(guard.eval_bool(&env)?);
+# Ok::<(), vantage_rhai::RhaiError>(())
+```
+
+`compile` returns a `Compiled<Expr>` — source, AST and engine in one value —
+which you keep and re-evaluate against a fresh `Env` per row, per frame, per
+tick.
+
+On a `Compiled<S>`:
+
+- `eval` gives the raw `Dynamic`, `eval_bool` a `bool`, `eval_as::<T>` any
+  `Clone + Send + Sync + 'static` type. A mismatch is `RhaiError::WrongType`,
+  not a panic.
+- `run` on a `Compiled<Block>` discards the value, for a script executed for
+  effect.
+- `is_literal` on a `Compiled<Template>` reports a template with no holes,
+  which lets a caller skip re-evaluating a constant.
+- `engine()` and `ast()` hand out the compiled pair for the one thing the API
+  cannot express: evaluating a script to a `FnPtr` once and calling that
+  closure per line. `ast()` is an `Option` — a template with text around its
+  holes has one AST per hole and no single script to hand out.
+
+A template that is **one hole and nothing else** evaluates to that hole's value
+with its type intact, so a slot can accept either text or structure:
+`'${ #{ text: label, color: "red" } }'` yields the map, and
+`Template::from("${ 1 + 1 }").eval_as::<String>()` is a `WrongType` error
+rather than `"2"`. Add a single space of literal text and the parts join into a
+`String` instead, with a unit-valued hole rendering as empty.
+
+Use `compile` for anything a project holds onto — the host's cache means the
+same source parses once. Use `compile_uncached` for a one-shot script that will
+never repeat: the cache holds `AST_CACHE_BOUND` entries and clears wholesale
+when it overflows, so a throwaway entry costs every other entry, not just
+itself. `Mode` distinguishes the two parsers in the cache key, so an `Expr` and
+a `Block` with identical text never collide.
+
+`Host` is `Send + Sync` and built to be shared — a `LazyLock` static serving
+every thread is the intended shape, not a workaround.
+
+## Env: pushed variables and lazy resolution
+
+`Env` carries what one evaluation can see. Two mechanisms:
+
+```rust
+use std::sync::Arc;
+use vantage_rhai::{Env, Lookup, Resolver};
+
+let env = Env::new()
+    .var("row", Dynamic::from(row_handle))
+    .resolver(Arc::new(PageScope(frame)));
+```
+
+`var` takes anything `Into<Dynamic>`, which covers numbers, strings and bools.
+Your own type goes in as `Dynamic::from(value)` and must be
+`Clone + Send + Sync + 'static`; forget the wrapper and rustc reports a missing
+`ImmutableString: From<YourType>` without ever mentioning `Dynamic`.
+
+Supply a `Resolver` when the value space is large or expensive — a page scope
+with hundreds of entries, of which one expression reads two.
+
+```rust
+impl Resolver for PageScope {
+    fn resolve(&self, path: &str) -> Lookup {
+        match self.0.lookup(path) {
+            Some(value) => Lookup::Leaf(value.into()),
+            None if self.0.is_namespace(path) => Lookup::Namespace,
+            None => Lookup::Unknown,
+        }
+    }
+}
+```
+
+`Lookup::Namespace` is how dotted paths work: `orders.selected.id` resolves
+`orders`, gets `Namespace`, descends, and only the full path becomes a `Leaf`.
+`Unknown` raises `RhaiError::UnknownName`, so a typo fails loudly rather than
+evaluating to unit.
+
+Pushed variables shadow the resolver. Rhai consults its variable hook before
+searching the scope, and the hook declines any name the scope already holds.
+
+## Limits: there is no unlimited engine
+
+Two profiles:
+
+| Profile | Operation ceiling | For |
+|---|---|---|
+| `Limits::Ui` | 500,000 | anything the UI thread waits on |
+| `Limits::background()` | 50,000,000 | anything under `spawn_blocking` |
+
+Both also cap string size at 8 MiB, arrays at a million elements, maps at
+100,000 keys, call nesting at 64 and expression depth at 256.
+`Limits::Background` takes a custom ceiling if you need one; it is clamped to
+at least 1, because rhai reads a ceiling of zero as *no ceiling* and that would
+quietly invert the guarantee.
+
+The point is not to stop an attacker — see the trust model below — but to turn
+a mistyped loop into an error the author can read instead of a frozen window.
+
+## Vocabularies
+
+A bare host can do arithmetic and string work and nothing else. Domain verbs
+arrive as a `Vocab`:
+
+```rust
+use vantage_rhai::rhai::Engine;
+use vantage_rhai::{Host, Limits, Vocab};
+
+pub struct InvoiceVocab;
+
+impl Vocab for InvoiceVocab {
+    fn register(&self, engine: &mut Engine) {
+        engine.register_type_with_name::<Invoice>("Invoice");
+        engine.register_fn("total", Invoice::total);
+    }
+}
+
+let host = Host::builder(Limits::background()).vocab(InvoiceVocab).build();
+```
+
+Prefer a unit struct when another crate needs to name the vocabulary; reach for
+`.vocab_fn(|engine| …)` when the registration is private to one host. The
+closure is `FnOnce` with no `Send` or `'static` bound, so it can move a
+resolver or a limit straight in.
+
+**Registration order decides collisions.** Vocabs register in call order and
+the last definition of a name wins. Vantage's data layer depends on this: a
+vendor vocabulary defines `table` as an identifier constructor and the
+conventional vocabulary defines it as a query builder, so registering the
+vendor one first is what makes `table("order")` mean the query builder on a
+host that has both.
+
+**Never call `engine.on_var` from a vocabulary.** The host installs the
+resolver on that hook before any vocab registers, rhai keeps only the last
+hook, and a second one therefore disables resolution for every slot on the
+host — silently. Push the value through `Env` instead. The SurrealDB backend's
+`me` constant was an `on_var` hook until it collided this way.
+
+Registering a *type* and pushing the *instance* through `Env` lets one host
+serve every row; baking a specific row into the engine at registration time
+forces an engine per row, which is what the grid used to do per predicate per
+render.
+
+## Discovery: learning what a script reads
+
+`discover` evaluates once with every resolver read recorded, then freezes the
+set:
+
+```rust
+let compiled = host.compile(&Expr::from("orders.total * tax.rate"))?
+    .discover(&env)?;              // `env` must carry a resolver
+assert_eq!(compiled.read_set().len(), 2);
+```
+
+This is how a framework page learns its dependencies without parsing the
+script: subscribe to exactly the paths in `read_set()`, re-evaluate when one
+changes. `discover_value` returns that first value too, so the discovery pass
+doubles as the first render.
+
+Only reads through the resolver are recorded — a pushed variable is not a read,
+and an `Env` with no resolver discovers nothing. `discover` consumes and
+returns the `Compiled`, so it cannot run twice; `is_discovered()` distinguishes
+a frozen empty set from one that was never taken. Treat the result as a
+dependency floor: a branch the evaluation did not take recorded nothing, so
+recompile on structural change.
+
+## Errors
+
+`RhaiError` has five variants — `Syntax`, `UnknownName`, `Runtime`,
+`WrongType`, `LimitExceeded` — and every one carries the slot source via
+`src()`.
+
+`Syntax` and `Runtime` additionally carry a `Located`, whose `line`, `column`,
+`message` and `src` fields are public so a validator can emit a structured
+diagnostic instead of re-parsing rendered text. Its `Display` draws the
+offending line with a caret:
+
+```
+Syntax error: Expecting ';' to terminate this statement (line 3, column 1)
+  | let m = 2;
+  | ^
+```
+
+For a template, those coordinates are remapped into the whole template rather
+than the isolated hole, so an error on line 2 of a block scalar says line 2.
+
+Compiling every slot at load turns this into catalogue validation: collect the
+failures, and report each one's YAML key beside `src()` and the `Located`
+position. An author then learns about a typo before the page opens rather than
+when the row that triggers it renders.
+
+## The `${…}` scanner
+
+`template::split` is the one place `${…}` is parsed. It returns
+`Part::Lit`/`Part::Hole` and understands nested braces, `"…"` and `'…'` with
+escapes, backtick strings, and `//` and `/* */` comments — so
+`${ if n > 1 { "many" } else { "one" } }` is one hole and a brace inside a
+string is text.
+
+Call it directly for a template that is *not* Rhai — an environment-variable
+expansion, a scope-path check in a validator — so those keep one definition of
+where a hole starts and ends while resolving their own way. An unterminated
+`${` is `Err`, with the position.
+
+## JSON
+
+`to_json` and `from_json` bridge `Dynamic` and `serde_json::Value`
+structurally. A leaf serde cannot represent renders as its `to_string()`, which
+costs that leaf rather than collapsing the object around it into one string.
+
+## Cargo features
+
+`schema` adds `JsonSchema` for the three slot types, each emitting
+`{"type": "string", "description": …, "x-language": "rhai"}`. Editors read the
+marker to inject Rhai highlighting into the YAML string and show the
+description as a tooltip, so a project's generated schema advertises every
+scripted field for free.
+
+## Shared hosts
+
+`ui_host()` and `background_host()` are process-wide, vocabulary-free hosts on
+the two profiles. Take one when your slot needs no verbs — a projection
+formula, a list row's template, an action argument — and it shares one AST
+cache with every other such caller. Build your own the moment you need a verb;
+these have none deliberately, so nothing comes to depend on a vocabulary
+someone else registered.
+
+## Trust model
+
+Scripts here are written by the same people who write the project's YAML, and
+carry the same trust as the YAML itself. This is not a sandbox for third-party
+code. Rhai reaches nothing on its own — no filesystem, no network, no
+processes — so a host's attack surface is exactly what its vocabulary
+registers. Keep that in mind when a verb wraps something dangerous: a `run()`
+that spawns a command should capture the command at registration time rather
+than take it as an argument, which is how `vantage-cmd` keeps a script from
+choosing its own binary.
+
+## Adding a scripted slot to a crate
+
+1. Depend on `vantage-rhai`, not `rhai`. Enable `schema` if you generate JSON
+   schemas for your YAML.
+2. Type the YAML field `Expr`, `Template` or `Block`.
+3. Decide the profile: does the caller block the UI thread, or is this under
+   `spawn_blocking`?
+4. Write a `Vocab` for your verbs, registering types rather than instances.
+5. Build the host once and compile each slot through it:
+
+   ```rust
+   fn host() -> &'static Host {
+       static HOST: LazyLock<Host> =
+           LazyLock::new(|| Host::builder(Limits::Ui).vocab(InvoiceVocab).build());
+       &HOST
+   }
+   ```
+
+6. Evaluate against a fresh `Env` per call, pushing the per-call values as
+   `Dynamic::from(…)`.
+7. Surface `RhaiError` with its `src()` so the author sees which slot failed.
+
+`cargo run --example quickstart` in this crate walks the same seven steps in
+one file.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `slot.rs` | `Expr`, `Template`, `Block` and their schema impls |
+| `host.rs` | `Host`, `HostBuilder`, `Vocab`, the AST cache, shared hosts |
+| `limits.rs` | the two profiles and what they cap |
+| `compiled.rs` | `Compiled<S>`, `Env`, the `Slot` trait, discovery |
+| `resolver.rs` | `Resolver`, `Lookup`, namespace descent, read recording |
+| `template.rs` | the `${…}` scanner |
+| `error.rs` | `RhaiError` and located display |
+| `json.rs` | `Dynamic` ⇄ `serde_json::Value` |

--- a/vantage-rhai/examples/invalidation.rs
+++ b/vantage-rhai/examples/invalidation.rs
@@ -1,0 +1,119 @@
+//! Read-sets decide what to recompute. Both slots roll a random number each
+//! time they run, so a number that moved is a slot that re-ran — the
+//! randomness is the instrument, not the subject.
+//!
+//! `cargo run --example invalidation`
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use vantage_rhai::rhai::{Dynamic, Engine};
+use vantage_rhai::{Compiled, Env, Expr, Host, Limits, Lookup, Resolver, RhaiError, Vocab};
+
+/// Shared process state in a vocabulary is fine — a clock, a counter, this
+/// generator. Per-call data is not; that belongs in the `Env`.
+struct RollVocab(Arc<AtomicU64>);
+
+impl Vocab for RollVocab {
+    fn register(&self, engine: &mut Engine) {
+        let state = self.0.clone();
+        engine.register_fn("roll", move || -> f64 {
+            let x = state
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |mut x| {
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    Some(x)
+                })
+                .expect("the update never declines");
+            ((x >> 11) as f64) / ((1u64 << 53) as f64)
+        });
+    }
+}
+
+/// `global` descends, `global.<key>` is a leaf from a shared map — so
+/// writing to the map is what a control on the page would do.
+#[derive(Clone)]
+struct Globals(Arc<Mutex<HashMap<String, f64>>>);
+
+impl Resolver for Globals {
+    fn resolve(&self, path: &str) -> Lookup {
+        if path == "global" {
+            return Lookup::Namespace;
+        }
+        match path
+            .strip_prefix("global.")
+            .and_then(|k| self.0.lock().unwrap().get(k).copied())
+        {
+            Some(v) => Lookup::Leaf(Dynamic::from(v)),
+            None => Lookup::Unknown,
+        }
+    }
+}
+
+type Page = Vec<(String, Compiled<Expr>, f64)>;
+
+/// One invalidation pass: recompute whoever read the path that moved. A real
+/// page indexes path → slots instead of scanning; the decision is the same.
+fn bump(
+    page: &mut Page,
+    globals: &Globals,
+    key: &str,
+    to: f64,
+    env: &Env,
+) -> Result<(), RhaiError> {
+    globals.0.lock().unwrap().insert(key.to_string(), to);
+    println!("\nglobal.{key} -> {to}");
+    for (name, script, value) in page {
+        let reads_it = script.read_set().contains(&format!("global.{key}"));
+        if reads_it {
+            *value = script.eval_as::<f64>(env)?;
+        }
+        let verdict = if reads_it { "recomputed" } else { "held" };
+        println!("  {name:<7}= {value:.4}   {verdict}");
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), RhaiError> {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/invalidation.yaml");
+    let yaml = std::fs::read_to_string(path).expect("the example ships its own YAML");
+    // Sorted, so the seeded roll sequence is identical on every run.
+    let mut slots: Vec<(String, Expr)> = serde_yaml_ng::from_str::<HashMap<String, Expr>>(&yaml)
+        .expect("that YAML parses")
+        .into_iter()
+        .collect();
+    slots.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // `unrelated` resolves but no slot reads it — the last bump needs that.
+    let globals = Globals(Arc::new(Mutex::new(HashMap::from([
+        ("increment".to_string(), 1.0),
+        ("unrelated".to_string(), 0.0),
+    ]))));
+    let host = Host::builder(Limits::Ui)
+        .vocab(RollVocab(Arc::new(AtomicU64::new(0x2545_F491_4F6C_DD1D))))
+        .build();
+    let env = Env::new().resolver(Arc::new(globals.clone()));
+
+    // Discovery yields the dependency set and the first value together.
+    let mut page = Page::new();
+    for (name, expr) in slots {
+        let (script, first) = host.compile(&expr)?.discover_value(&env)?;
+        let value = first.as_float().expect("both slots evaluate to a number");
+        println!("{name:<7}= {value:.4}   reads {:?}", script.read_set());
+        page.push((name, script, value));
+    }
+
+    bump(&mut page, &globals, "increment", 2.0, &env)?;
+    bump(&mut page, &globals, "increment", 3.0, &env)?;
+    bump(&mut page, &globals, "unrelated", 99.0, &env)?;
+
+    println!(
+        "\n`drift` reads nothing, so nothing invalidates it. Read-sets are\n\
+         path-precise: a sibling under `global` moving recomputes neither.\n\
+         A read inside a branch discovery did not take is absent from the\n\
+         set, so treat it as a floor."
+    );
+    Ok(())
+}

--- a/vantage-rhai/examples/invalidation.yaml
+++ b/vantage-rhai/examples/invalidation.yaml
@@ -1,0 +1,7 @@
+# Two readouts on an imaginary page. Both call `roll()`, so both produce a
+# fresh number every time they are evaluated — that is the instrument, not
+# the subject. What separates them is that only `offset` reads the scope.
+#
+# Neither declares a dependency anywhere. The host discovers it.
+drift: '${ roll() }'
+offset: '${ roll() + global.increment }'

--- a/vantage-rhai/examples/quickstart.rs
+++ b/vantage-rhai/examples/quickstart.rs
@@ -1,0 +1,120 @@
+//! The seven steps from the README, as code that runs.
+//!
+//! An invoice line with a `when:` guard, a `label:` template and an
+//! `action:` body — the three slot kinds — over a vocabulary of one verb
+//! and a resolver standing in for a page scope.
+//!
+//! `cargo run --example quickstart`
+
+use std::sync::Arc;
+
+use vantage_rhai::rhai::{Dynamic, Engine};
+use vantage_rhai::{Block, Env, Expr, Host, Limits, Lookup, Resolver, Template, Vocab};
+
+/// Step 2: the YAML struct. Each field's type says what an author may write
+/// in it; `serde(transparent)` on the slots means the YAML is a plain scalar.
+#[derive(serde::Deserialize)]
+struct LineDef {
+    when: Option<Expr>,
+    label: Template,
+    action: Block,
+}
+
+/// Step 4: a vocabulary registers a *type* and its methods, never one
+/// instance — so a single host serves every line, and the line itself
+/// arrives through `Env`.
+#[derive(Clone)]
+struct Line {
+    qty: i64,
+    unit_price: i64,
+}
+
+struct LineVocab;
+
+impl Vocab for LineVocab {
+    fn register(&self, engine: &mut Engine) {
+        engine.register_type_with_name::<Line>("Line");
+        engine.register_get("qty", |l: &mut Line| l.qty);
+        engine.register_get("unit_price", |l: &mut Line| l.unit_price);
+        engine.register_fn("total", |l: &mut Line| l.qty * l.unit_price);
+    }
+}
+
+/// A stand-in for a page scope: `settings.currency` resolves, `settings`
+/// alone is a namespace to descend, anything else is a typo.
+struct Settings;
+
+impl Resolver for Settings {
+    fn resolve(&self, path: &str) -> Lookup {
+        match path {
+            "settings" => Lookup::Namespace,
+            "settings.currency" => Lookup::Leaf(Dynamic::from("£".to_string())),
+            _ => Lookup::Unknown,
+        }
+    }
+}
+
+fn main() -> Result<(), vantage_rhai::RhaiError> {
+    let def: LineDef = serde_yaml_ng::from_str(
+        r#"
+when: qty > 0
+label: '${ settings.currency }${ line.total() } for ${ line.qty }'
+action: |
+  let discounted = line.total() * 9 / 10;
+  discounted
+"#,
+    )
+    .expect("the example's own YAML parses");
+
+    // Step 3 and 5: one profile, one host, built once.
+    let host = Host::builder(Limits::Ui).vocab(LineVocab).build();
+    let guard = def.when.as_ref().map(|e| host.compile(e)).transpose()?;
+    let label = host.compile(&def.label)?;
+    let action = host.compile(&def.action)?;
+
+    // Step 6: a fresh `Env` per call — the pushed line, the lazy scope.
+    let line = Line {
+        qty: 3,
+        unit_price: 250,
+    };
+    let env = Env::new()
+        .var("line", Dynamic::from(line.clone()))
+        .var("qty", line.qty)
+        .resolver(Arc::new(Settings));
+
+    if let Some(guard) = &guard {
+        println!("guard      -> {}", guard.eval_bool(&env)?);
+    }
+    println!("label      -> {}", label.eval_as::<String>(&env)?);
+    println!("action     -> {}", action.eval_as::<i64>(&env)?);
+
+    // Discovery freezes what the script read through the resolver, which is
+    // the dependency set a UI would subscribe to.
+    let discovered = host.compile(&def.label)?.discover(&env)?;
+    println!("label reads-> {:?}", discovered.read_set());
+
+    // Step 7: every error carries the slot source, so a validator can name
+    // the YAML key. A typo in a scope path fails rather than reading unit.
+    let typo = host.compile(&Expr::from("settings.currancy"))?;
+    match typo.eval(&env) {
+        Err(e) => println!("typo       -> {e} (in `{}`)", e.src()),
+        Ok(v) => unreachable!("an unknown name must not resolve, got {v}"),
+    }
+
+    // A syntax fault additionally points at the line and column.
+    match host.compile(&Block::from("let n = 1;\nrow.save()\nlet m = 2;\n")) {
+        Err(e) => println!("syntax     -> {e}"),
+        Ok(_) => unreachable!("the missing semicolon must not parse"),
+    }
+
+    // A runaway script stops rather than hanging the caller.
+    match host
+        .compile(&Block::from("while true {}"))?
+        .run(&Env::new())
+    {
+        Err(e) => println!("runaway    -> {e}"),
+        Ok(()) => unreachable!("the UI profile must bound this loop"),
+    }
+
+    Ok(())
+}

--- a/vantage-rhai/examples/quickstart.rs
+++ b/vantage-rhai/examples/quickstart.rs
@@ -1,8 +1,5 @@
-//! The seven steps from the README, as code that runs.
-//!
-//! An invoice line with a `when:` guard, a `label:` template and an
-//! `action:` body — the three slot kinds — over a vocabulary of one verb
-//! and a resolver standing in for a page scope.
+//! The README's seven steps, running: three slot kinds loaded from a YAML
+//! file, a vocabulary, a resolver, discovery, and what each error looks like.
 //!
 //! `cargo run --example quickstart`
 
@@ -11,8 +8,7 @@ use std::sync::Arc;
 use vantage_rhai::rhai::{Dynamic, Engine};
 use vantage_rhai::{Block, Env, Expr, Host, Limits, Lookup, Resolver, Template, Vocab};
 
-/// Step 2: the YAML struct. Each field's type says what an author may write
-/// in it; `serde(transparent)` on the slots means the YAML is a plain scalar.
+/// The field types are the only type information; the YAML is plain scalars.
 #[derive(serde::Deserialize)]
 struct LineDef {
     when: Option<Expr>,
@@ -20,28 +16,25 @@ struct LineDef {
     action: Block,
 }
 
-/// Step 4: a vocabulary registers a *type* and its methods, never one
-/// instance — so a single host serves every line, and the line itself
-/// arrives through `Env`.
 #[derive(Clone)]
 struct Line {
     qty: i64,
     unit_price: i64,
 }
 
+/// Registers the *type*, never one line, so a single host serves every row
+/// and the row itself arrives per call through `Env`.
 struct LineVocab;
 
 impl Vocab for LineVocab {
     fn register(&self, engine: &mut Engine) {
         engine.register_type_with_name::<Line>("Line");
         engine.register_get("qty", |l: &mut Line| l.qty);
-        engine.register_get("unit_price", |l: &mut Line| l.unit_price);
         engine.register_fn("total", |l: &mut Line| l.qty * l.unit_price);
     }
 }
 
-/// A stand-in for a page scope: `settings.currency` resolves, `settings`
-/// alone is a namespace to descend, anything else is a typo.
+/// Stands in for a page scope: one namespace, one leaf, anything else a typo.
 struct Settings;
 
 impl Resolver for Settings {
@@ -55,66 +48,38 @@ impl Resolver for Settings {
 }
 
 fn main() -> Result<(), vantage_rhai::RhaiError> {
-    let def: LineDef = serde_yaml_ng::from_str(
-        r#"
-when: qty > 0
-label: '${ settings.currency }${ line.total() } for ${ line.qty }'
-action: |
-  let discounted = line.total() * 9 / 10;
-  discounted
-"#,
-    )
-    .expect("the example's own YAML parses");
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/quickstart.yaml");
+    let yaml = std::fs::read_to_string(path).expect("the example ships its own YAML");
+    let def: LineDef = serde_yaml_ng::from_str(&yaml).expect("that YAML parses");
 
-    // Step 3 and 5: one profile, one host, built once.
     let host = Host::builder(Limits::Ui).vocab(LineVocab).build();
-    let guard = def.when.as_ref().map(|e| host.compile(e)).transpose()?;
-    let label = host.compile(&def.label)?;
-    let action = host.compile(&def.action)?;
-
-    // Step 6: a fresh `Env` per call — the pushed line, the lazy scope.
     let line = Line {
         qty: 3,
         unit_price: 250,
     };
     let env = Env::new()
-        .var("line", Dynamic::from(line.clone()))
+        .var("line", Dynamic::from(line.clone())) // own type: wrap it
         .var("qty", line.qty)
         .resolver(Arc::new(Settings));
 
-    if let Some(guard) = &guard {
-        println!("guard      -> {}", guard.eval_bool(&env)?);
-    }
-    println!("label      -> {}", label.eval_as::<String>(&env)?);
-    println!("action     -> {}", action.eval_as::<i64>(&env)?);
+    let guard = def.when.as_ref().expect("this YAML declares one");
+    println!("guard   -> {}", host.compile(guard)?.eval_bool(&env)?);
+    let label = host.compile(&def.label)?;
+    println!("label   -> {}", label.eval_as::<String>(&env)?);
+    let action = host.compile(&def.action)?;
+    println!("action  -> {}", action.eval_as::<i64>(&env)?);
+    println!("reads   -> {:?}", label.discover(&env)?.read_set());
 
-    // Discovery freezes what the script read through the resolver, which is
-    // the dependency set a UI would subscribe to.
-    let discovered = host.compile(&def.label)?.discover(&env)?;
-    println!("label reads-> {:?}", discovered.read_set());
-
-    // Step 7: every error carries the slot source, so a validator can name
-    // the YAML key. A typo in a scope path fails rather than reading unit.
-    let typo = host.compile(&Expr::from("settings.currancy"))?;
-    match typo.eval(&env) {
-        Err(e) => println!("typo       -> {e} (in `{}`)", e.src()),
-        Ok(v) => unreachable!("an unknown name must not resolve, got {v}"),
-    }
-
-    // A syntax fault additionally points at the line and column.
-    match host.compile(&Block::from("let n = 1;\nrow.save()\nlet m = 2;\n")) {
-        Err(e) => println!("syntax     -> {e}"),
-        Ok(_) => unreachable!("the missing semicolon must not parse"),
-    }
-
-    // A runaway script stops rather than hanging the caller.
-    match host
-        .compile(&Block::from("while true {}"))?
-        .run(&Env::new())
-    {
-        Err(e) => println!("runaway    -> {e}"),
-        Ok(()) => unreachable!("the UI profile must bound this loop"),
-    }
-
+    // Every error names its slot; syntax and runtime faults add a position.
+    let (typo, unclosed, forever) = (
+        Expr::from("settings.currancy"),
+        Block::from("let n = 1;\nrow.save()\nlet m = 2;\n"),
+        Block::from("while true {}"),
+    );
+    let e = host.compile(&typo)?.eval(&env).unwrap_err();
+    println!("typo    -> {e} (in `{}`)", e.src());
+    println!("syntax  -> {}", host.compile(&unclosed).unwrap_err());
+    let e = host.compile(&forever)?.run(&Env::new()).unwrap_err();
+    println!("runaway -> {e}");
     Ok(())
 }

--- a/vantage-rhai/examples/quickstart.yaml
+++ b/vantage-rhai/examples/quickstart.yaml
@@ -1,0 +1,16 @@
+# One invoice line, as a project would write it: three fields, three slot
+# kinds. The Rust struct beside this file declares which is which, and that
+# is the whole of the type information — the YAML is plain scalars.
+
+# `Expr` — one expression, evaluated for its value.
+when: qty > 0
+
+# `Template` — literal text with `${ … }` holes.
+label: '${ settings.currency }${ line.total() } for ${ line.qty }'
+
+# `Block` — statements. The comment above a block scalar is the convention
+# that gets JetBrains and VS Code to highlight the body as Rhai.
+# language=rhai
+action: |
+  let discounted = line.total() * 9 / 10;
+  discounted

--- a/vantage-rhai/examples/two_hosts.rs
+++ b/vantage-rhai/examples/two_hosts.rs
@@ -35,15 +35,21 @@ impl Vocab for Readable {
     }
 }
 
-/// Write access, and the repaint it implies. Only the backend host gets
-/// this, so `globals.x = 1` on the UI host is a script that will not compile.
+/// Write access plus the frame boundary. Only the backend host gets this, so
+/// `globals.x = 1` on the UI host fails for want of a setter.
+///
+/// Writes are silent and `commit` is what asks for a repaint, so a batch that
+/// sets several values redraws once against all of them rather than being
+/// read halfway through.
 struct Writable(mpsc::Sender<()>);
 
 impl Vocab for Writable {
     fn register(&self, engine: &mut Engine) {
-        let tx = self.0.clone();
-        engine.register_indexer_set(move |g: &mut Globals, key: &str, value: f64| {
+        engine.register_indexer_set(|g: &mut Globals, key: &str, value: f64| {
             g.0.lock().unwrap().insert(key.to_string(), value);
+        });
+        let tx = self.0.clone();
+        engine.register_fn("commit", move || {
             let _ = tx.send(());
         });
     }
@@ -93,5 +99,6 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
     for () in repaint {
         println!("{}", label.eval_as::<String>(&env)?);
     }
+    println!("pi = 3.141593 — compare to see which digits had settled");
     Ok(())
 }

--- a/vantage-rhai/examples/two_hosts.rs
+++ b/vantage-rhai/examples/two_hosts.rs
@@ -1,19 +1,12 @@
-//! Two engines, two threads: a backend host computes while a UI host formats.
-//!
-//! Where `invalidation` shows the mechanics inside one engine, this is the
-//! contract between two. They share a scope and nothing else, and each host's
-//! vocabulary decides what its script may do with it: only the backend was
-//! given a setter, only the UI was given formatting.
-//!
-//! It mirrors `ui-scope`: every path is its own source carrying a generation,
-//! a write bumps that generation *only when the value differs*, and a pump
-//! loop on the reading side repaints whatever moved since the last frame.
-//! Nothing tells the UI to redraw — it notices.
+//! Two engines on two threads, sharing a scope and nothing else. Where
+//! `invalidation` shows the mechanics inside one engine, this is the contract
+//! between two, mirroring `ui-scope`: a write bumps a generation only when the
+//! value differs, and a pump loop repaints whatever moved since the last
+//! frame. Nothing tells the UI to redraw. It notices.
 //!
 //! `cargo run --example two_hosts`
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -26,83 +19,72 @@ struct Defs {
     labels: BTreeMap<String, Template>,
 }
 
-/// One scope entry. The generation moves only when the value does, so a
-/// producer that recomputes the same answer notifies nobody — the dedup
-/// `ui-scope`'s components spell out as `if source.get() != current`.
+/// A value and the generation of its last *change*. Writing the same value
+/// again moves nothing — the dedup `ui-scope` spells out at each call site as
+/// `if source.get() != current`.
 #[derive(Default)]
-struct Source {
-    value: Mutex<f64>,
-    generation: AtomicU64,
-}
+struct Source(Mutex<(f64, u64)>);
 
 impl Source {
-    fn set(&self, new: f64) {
-        let mut held = self.value.lock().unwrap();
-        if *held == new {
-            return;
+    fn set(&self, value: f64) {
+        let mut held = self.0.lock().unwrap();
+        if held.0 != value {
+            *held = (value, held.1 + 1);
         }
-        *held = new;
-        self.generation.fetch_add(1, Ordering::Release);
     }
 
-    fn get(&self) -> f64 {
-        *self.value.lock().unwrap()
-    }
-
-    fn generation(&self) -> u64 {
-        self.generation.load(Ordering::Acquire)
+    fn read(&self) -> (f64, u64) {
+        *self.0.lock().unwrap()
     }
 }
 
-/// The shared scope: one source per path, declared up front the way a page's
-/// variables are. Discovery needs them to exist before it can resolve a read.
+/// The shared scope: one source per path, so labels wake independently.
 #[derive(Clone, Default)]
-struct Scope(Arc<Mutex<HashMap<String, Arc<Source>>>>);
+struct Scope {
+    batch: Arc<Source>,
+    pi: Arc<Source>,
+}
 
 impl Scope {
-    fn declare(&self, keys: &[&str]) {
-        let mut map = self.0.lock().unwrap();
-        for key in keys {
-            map.insert(key.to_string(), Arc::new(Source::default()));
+    fn key(&self, key: &str) -> Option<&Arc<Source>> {
+        match key {
+            "batch" => Some(&self.batch),
+            "pi" => Some(&self.pi),
+            _ => None,
         }
-    }
-
-    fn source(&self, key: &str) -> Option<Arc<Source>> {
-        self.0.lock().unwrap().get(key).cloned()
     }
 }
 
-/// The UI reads through a resolver, so every read is recorded and each label
-/// ends up knowing its own dependencies.
+/// The UI reads through a resolver, so discovery records what each label
+/// depends on.
 impl Resolver for Scope {
     fn resolve(&self, path: &str) -> Lookup {
         if path == "globals" {
             return Lookup::Namespace;
         }
-        match path.strip_prefix("globals.").and_then(|k| self.source(k)) {
-            Some(source) => Lookup::Leaf(Dynamic::from(source.get())),
+        match path.strip_prefix("globals.").and_then(|k| self.key(k)) {
+            Some(source) => Lookup::Leaf(Dynamic::from(source.read().0)),
             None => Lookup::Unknown,
         }
     }
 }
 
-/// The backend writes through a handle pushed into its `Env`. In a real app
-/// this is a Rust API rather than a script verb; here it keeps both sides
-/// speaking the same `globals.<key>` vocabulary.
+/// Write access, given only to the backend host — so the UI script cannot
+/// assign to `globals`, the operation is not there to call.
 struct Writable;
 
 impl Vocab for Writable {
     fn register(&self, engine: &mut Engine) {
         engine.register_type_with_name::<Scope>("Scope");
         engine.register_indexer_set(|s: &mut Scope, key: &str, value: f64| {
-            if let Some(source) = s.source(key) {
+            if let Some(source) = s.key(key) {
                 source.set(value);
             }
         });
     }
 }
 
-/// Formatting, and nothing that could block a repaint.
+/// Formatting. Only the UI host is given it.
 struct Format;
 
 impl Vocab for Format {
@@ -113,25 +95,20 @@ impl Vocab for Format {
     }
 }
 
-/// A label plus the generations it last painted, one per path it reads.
+/// A label, and the generation it last painted for each path it reads.
 struct Label {
     template: Compiled<Template>,
     watched: Vec<(Arc<Source>, u64)>,
 }
 
 impl Label {
-    fn connect(template: Compiled<Template>, scope: &Scope) -> Label {
-        let watched = subscribe(template.read_set(), scope);
-        Label { template, watched }
-    }
-
-    /// Repaint if any watched path moved. Several writes between two frames
-    /// collapse into one repaint, because this compares generations rather
-    /// than counting notifications.
+    /// Repaint if a watched path moved. Comparing generations rather than
+    /// counting notifications is what collapses a burst of writes into one
+    /// frame.
     fn pump(&mut self, env: &Env) -> Option<String> {
         let mut moved = false;
         for (source, seen) in &mut self.watched {
-            let now = source.generation();
+            let now = source.read().1;
             if now != *seen {
                 *seen = now;
                 moved = true;
@@ -141,39 +118,31 @@ impl Label {
     }
 }
 
-fn subscribe(read_set: &BTreeSet<String>, scope: &Scope) -> Vec<(Arc<Source>, u64)> {
-    read_set
-        .iter()
-        .filter_map(|path| scope.source(path.strip_prefix("globals.")?))
-        .map(|source| {
-            let seen = source.generation();
-            (source, seen)
-        })
-        .collect()
-}
-
 fn main() -> Result<(), vantage_rhai::RhaiError> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/two_hosts.yaml");
     let yaml = std::fs::read_to_string(path).expect("the example ships its own YAML");
     let Defs { compute, labels } = serde_yaml_ng::from_str(&yaml).expect("that YAML parses");
 
     let scope = Scope::default();
-    scope.declare(&["batch", "pi"]);
-
     let ui = Host::builder(Limits::Ui).vocab(Format).build();
-    let read_env = Env::new().resolver(Arc::new(scope.clone()));
-    let mut labels: Vec<(String, Label)> = labels
-        .into_iter()
-        .map(|(name, template)| {
-            let compiled = ui.compile(&template)?.discover(&read_env)?;
-            Ok((name, Label::connect(compiled, &scope)))
-        })
-        .collect::<Result<_, vantage_rhai::RhaiError>>()?;
-    for (name, label) in &labels {
-        println!("{name:<6} reads {:?}", label.template.read_set());
-    }
+    let env = Env::new().resolver(Arc::new(scope.clone()));
 
-    let write_env = Env::new().var("globals", Dynamic::from(scope.clone()));
+    let mut labels = labels
+        .into_iter()
+        .map(|(name, source)| {
+            let template = ui.compile(&source)?.discover(&env)?;
+            println!("{name:<6} reads {:?}", template.read_set());
+            let watched = template
+                .read_set()
+                .iter()
+                .filter_map(|p| scope.key(p.strip_prefix("globals.")?))
+                .map(|s| (s.clone(), s.read().1))
+                .collect();
+            Ok(Label { template, watched })
+        })
+        .collect::<Result<Vec<_>, vantage_rhai::RhaiError>>()?;
+
+    let write_env = Env::new().var("globals", Dynamic::from(scope));
     let worker = std::thread::spawn(move || {
         Host::builder(Limits::background())
             .vocab(Writable)
@@ -186,10 +155,10 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
     // The frame clock. `Mount::tick` is this loop behind a real timer.
     println!("\n  repaints:");
     while !worker.is_finished() {
-        paint(&mut labels, &read_env);
+        paint(&mut labels, &env);
         std::thread::sleep(Duration::from_millis(2));
     }
-    paint(&mut labels, &read_env);
+    paint(&mut labels, &env);
 
     println!(
         "\n`batch` repainted every time. `pi` fell quiet once its fifth decimal\n\
@@ -198,8 +167,8 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
     Ok(())
 }
 
-fn paint(labels: &mut [(String, Label)], env: &Env) {
-    for (_, label) in labels {
+fn paint(labels: &mut [Label], env: &Env) {
+    for label in labels {
         if let Some(text) = label.pump(env) {
             println!("  {text}");
         }

--- a/vantage-rhai/examples/two_hosts.rs
+++ b/vantage-rhai/examples/two_hosts.rs
@@ -95,8 +95,13 @@ impl Vocab for Format {
     }
 }
 
+/// Each label gets a column, so a repaint is visible as a line under the
+/// label that asked for it.
+const COLUMN: usize = 30;
+
 /// A label, and the generation it last painted for each path it reads.
 struct Label {
+    name: String,
     template: Compiled<Template>,
     watched: Vec<(Arc<Source>, u64)>,
 }
@@ -138,7 +143,11 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
                 .filter_map(|p| scope.key(p.strip_prefix("globals.")?))
                 .map(|s| (s.clone(), s.read().1))
                 .collect();
-            Ok(Label { template, watched })
+            Ok(Label {
+                name,
+                template,
+                watched,
+            })
         })
         .collect::<Result<Vec<_>, vantage_rhai::RhaiError>>()?;
 
@@ -152,8 +161,21 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
             .expect("the compute script runs")
     });
 
+    println!("\nDetecting global changes and repainting labels:");
+    let header: String = labels
+        .iter()
+        .map(|l| {
+            format!(
+                "{:<width$}",
+                format!("\"{}\" label", l.name),
+                width = COLUMN
+            )
+        })
+        .collect();
+    println!("{}", header.trim_end());
+    println!("{}", "-".repeat(header.trim_end().len()));
+
     // The frame clock. `Mount::tick` is this loop behind a real timer.
-    println!("\n  repaints:");
     while !worker.is_finished() {
         paint(&mut labels, &env);
         std::thread::sleep(Duration::from_millis(2));
@@ -168,9 +190,9 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
 }
 
 fn paint(labels: &mut [Label], env: &Env) {
-    for label in labels {
+    for (column, label) in labels.iter_mut().enumerate() {
         if let Some(text) = label.pump(env) {
-            println!("  {text}");
+            println!("{:pad$}{text}", "", pad = column * COLUMN);
         }
     }
 }

--- a/vantage-rhai/examples/two_hosts.rs
+++ b/vantage-rhai/examples/two_hosts.rs
@@ -1,0 +1,97 @@
+//! Vantage's two threads, in miniature: a backend host computes on a worker
+//! thread while a UI host formats on this one. The scripts never call each
+//! other — a shared `globals` is the whole interface — and what each script
+//! may do with it is decided by the vocabulary its host was built with.
+//!
+//! `cargo run --example two_hosts`
+
+use std::collections::HashMap;
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+
+use vantage_rhai::rhai::{Dynamic, Engine};
+use vantage_rhai::{Block, Env, Host, Limits, Template, Vocab};
+
+#[derive(serde::Deserialize)]
+struct Defs {
+    compute: Block,
+    label: Template,
+}
+
+/// The shared context. `globals.pi` reaches the map through rhai's indexer,
+/// which is what `.prop` falls back to when no getter of that name exists.
+#[derive(Clone)]
+struct Globals(Arc<Mutex<HashMap<String, f64>>>);
+
+/// Read access. Both hosts get this.
+struct Readable;
+
+impl Vocab for Readable {
+    fn register(&self, engine: &mut Engine) {
+        engine.register_type_with_name::<Globals>("Globals");
+        engine.register_indexer_get(|g: &mut Globals, key: &str| {
+            g.0.lock().unwrap().get(key).copied().unwrap_or(f64::NAN)
+        });
+    }
+}
+
+/// Write access, and the repaint it implies. Only the backend host gets
+/// this, so `globals.x = 1` on the UI host is a script that will not compile.
+struct Writable(mpsc::Sender<()>);
+
+impl Vocab for Writable {
+    fn register(&self, engine: &mut Engine) {
+        let tx = self.0.clone();
+        engine.register_indexer_set(move |g: &mut Globals, key: &str, value: f64| {
+            g.0.lock().unwrap().insert(key.to_string(), value);
+            let _ = tx.send(());
+        });
+    }
+}
+
+/// Formatting. Only the UI host gets this.
+struct Format;
+
+impl Vocab for Format {
+    fn register(&self, engine: &mut Engine) {
+        engine.register_fn("fixed", |v: f64, places: i64| {
+            format!("{v:.*}", places as usize)
+        });
+    }
+}
+
+fn main() -> Result<(), vantage_rhai::RhaiError> {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/two_hosts.yaml");
+    let yaml = std::fs::read_to_string(path).expect("the example ships its own YAML");
+    let Defs { compute, label } = serde_yaml_ng::from_str(&yaml).expect("that YAML parses");
+
+    let globals = Globals(Arc::new(Mutex::new(HashMap::new())));
+    let (tx, repaint) = mpsc::channel();
+    let env = Env::new().var("globals", Dynamic::from(globals.clone()));
+
+    let ui = Host::builder(Limits::Ui)
+        .vocab(Readable)
+        .vocab(Format)
+        .build();
+    let label = ui.compile(&label)?;
+
+    let worker_env = env.clone();
+    std::thread::spawn(move || {
+        let backend = Host::builder(Limits::background())
+            .vocab(Readable)
+            .vocab(Writable(tx))
+            .build();
+        backend
+            .compile(&compute)
+            .and_then(|script| script.run(&worker_env))
+            .expect("the compute script runs")
+    });
+
+    // One repaint per write. The sender lives only in the backend host, so
+    // the channel closes when the worker drops it and the last line printed
+    // is the final estimate.
+    for () in repaint {
+        println!("{}", label.eval_as::<String>(&env)?);
+    }
+    Ok(())
+}

--- a/vantage-rhai/examples/two_hosts.rs
+++ b/vantage-rhai/examples/two_hosts.rs
@@ -4,6 +4,10 @@
 //! value differs, and a pump loop repaints whatever moved since the last
 //! frame. Nothing tells the UI to redraw. It notices.
 //!
+//! Watch the `pi` column stop: once the estimate stops moving in the digits
+//! the script stores, the same value is written, no generation moves, and the
+//! label is never woken again.
+//!
 //! `cargo run --example two_hosts`
 
 use std::collections::BTreeMap;
@@ -161,7 +165,7 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
             .expect("the compute script runs")
     });
 
-    println!("\nDetecting global changes and repainting labels:");
+    println!("\nDetecting global changes and repainting labels automatically on-change:");
     let header: String = labels
         .iter()
         .map(|l| {
@@ -181,11 +185,6 @@ fn main() -> Result<(), vantage_rhai::RhaiError> {
         std::thread::sleep(Duration::from_millis(2));
     }
     paint(&mut labels, &env);
-
-    println!(
-        "\n`batch` repainted every time. `pi` fell quiet once its fifth decimal\n\
-         stopped moving: same value written, no generation bump, no repaint."
-    );
     Ok(())
 }
 

--- a/vantage-rhai/examples/two_hosts.rs
+++ b/vantage-rhai/examples/two_hosts.rs
@@ -1,61 +1,108 @@
-//! Vantage's two threads, in miniature: a backend host computes on a worker
-//! thread while a UI host formats on this one. The scripts never call each
-//! other — a shared `globals` is the whole interface — and what each script
-//! may do with it is decided by the vocabulary its host was built with.
+//! Two engines, two threads: a backend host computes while a UI host formats.
+//!
+//! Where `invalidation` shows the mechanics inside one engine, this is the
+//! contract between two. They share a scope and nothing else, and each host's
+//! vocabulary decides what its script may do with it: only the backend was
+//! given a setter, only the UI was given formatting.
+//!
+//! It mirrors `ui-scope`: every path is its own source carrying a generation,
+//! a write bumps that generation *only when the value differs*, and a pump
+//! loop on the reading side repaints whatever moved since the last frame.
+//! Nothing tells the UI to redraw — it notices.
 //!
 //! `cargo run --example two_hosts`
 
-use std::collections::HashMap;
-use std::sync::mpsc;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use vantage_rhai::rhai::{Dynamic, Engine};
-use vantage_rhai::{Block, Env, Host, Limits, Template, Vocab};
+use vantage_rhai::{Block, Compiled, Env, Host, Limits, Lookup, Resolver, Template, Vocab};
 
 #[derive(serde::Deserialize)]
 struct Defs {
     compute: Block,
-    label: Template,
+    labels: BTreeMap<String, Template>,
 }
 
-/// The shared context. `globals.pi` reaches the map through rhai's indexer,
-/// which is what `.prop` falls back to when no getter of that name exists.
-#[derive(Clone)]
-struct Globals(Arc<Mutex<HashMap<String, f64>>>);
+/// One scope entry. The generation moves only when the value does, so a
+/// producer that recomputes the same answer notifies nobody — the dedup
+/// `ui-scope`'s components spell out as `if source.get() != current`.
+#[derive(Default)]
+struct Source {
+    value: Mutex<f64>,
+    generation: AtomicU64,
+}
 
-/// Read access. Both hosts get this.
-struct Readable;
+impl Source {
+    fn set(&self, new: f64) {
+        let mut held = self.value.lock().unwrap();
+        if *held == new {
+            return;
+        }
+        *held = new;
+        self.generation.fetch_add(1, Ordering::Release);
+    }
 
-impl Vocab for Readable {
-    fn register(&self, engine: &mut Engine) {
-        engine.register_type_with_name::<Globals>("Globals");
-        engine.register_indexer_get(|g: &mut Globals, key: &str| {
-            g.0.lock().unwrap().get(key).copied().unwrap_or(f64::NAN)
-        });
+    fn get(&self) -> f64 {
+        *self.value.lock().unwrap()
+    }
+
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
     }
 }
 
-/// Write access plus the frame boundary. Only the backend host gets this, so
-/// `globals.x = 1` on the UI host fails for want of a setter.
-///
-/// Writes are silent and `commit` is what asks for a repaint, so a batch that
-/// sets several values redraws once against all of them rather than being
-/// read halfway through.
-struct Writable(mpsc::Sender<()>);
+/// The shared scope: one source per path, declared up front the way a page's
+/// variables are. Discovery needs them to exist before it can resolve a read.
+#[derive(Clone, Default)]
+struct Scope(Arc<Mutex<HashMap<String, Arc<Source>>>>);
+
+impl Scope {
+    fn declare(&self, keys: &[&str]) {
+        let mut map = self.0.lock().unwrap();
+        for key in keys {
+            map.insert(key.to_string(), Arc::new(Source::default()));
+        }
+    }
+
+    fn source(&self, key: &str) -> Option<Arc<Source>> {
+        self.0.lock().unwrap().get(key).cloned()
+    }
+}
+
+/// The UI reads through a resolver, so every read is recorded and each label
+/// ends up knowing its own dependencies.
+impl Resolver for Scope {
+    fn resolve(&self, path: &str) -> Lookup {
+        if path == "globals" {
+            return Lookup::Namespace;
+        }
+        match path.strip_prefix("globals.").and_then(|k| self.source(k)) {
+            Some(source) => Lookup::Leaf(Dynamic::from(source.get())),
+            None => Lookup::Unknown,
+        }
+    }
+}
+
+/// The backend writes through a handle pushed into its `Env`. In a real app
+/// this is a Rust API rather than a script verb; here it keeps both sides
+/// speaking the same `globals.<key>` vocabulary.
+struct Writable;
 
 impl Vocab for Writable {
     fn register(&self, engine: &mut Engine) {
-        engine.register_indexer_set(|g: &mut Globals, key: &str, value: f64| {
-            g.0.lock().unwrap().insert(key.to_string(), value);
-        });
-        let tx = self.0.clone();
-        engine.register_fn("commit", move || {
-            let _ = tx.send(());
+        engine.register_type_with_name::<Scope>("Scope");
+        engine.register_indexer_set(|s: &mut Scope, key: &str, value: f64| {
+            if let Some(source) = s.source(key) {
+                source.set(value);
+            }
         });
     }
 }
 
-/// Formatting. Only the UI host gets this.
+/// Formatting, and nothing that could block a repaint.
 struct Format;
 
 impl Vocab for Format {
@@ -66,39 +113,95 @@ impl Vocab for Format {
     }
 }
 
+/// A label plus the generations it last painted, one per path it reads.
+struct Label {
+    template: Compiled<Template>,
+    watched: Vec<(Arc<Source>, u64)>,
+}
+
+impl Label {
+    fn connect(template: Compiled<Template>, scope: &Scope) -> Label {
+        let watched = subscribe(template.read_set(), scope);
+        Label { template, watched }
+    }
+
+    /// Repaint if any watched path moved. Several writes between two frames
+    /// collapse into one repaint, because this compares generations rather
+    /// than counting notifications.
+    fn pump(&mut self, env: &Env) -> Option<String> {
+        let mut moved = false;
+        for (source, seen) in &mut self.watched {
+            let now = source.generation();
+            if now != *seen {
+                *seen = now;
+                moved = true;
+            }
+        }
+        moved.then(|| self.template.eval_as::<String>(env).expect("label renders"))
+    }
+}
+
+fn subscribe(read_set: &BTreeSet<String>, scope: &Scope) -> Vec<(Arc<Source>, u64)> {
+    read_set
+        .iter()
+        .filter_map(|path| scope.source(path.strip_prefix("globals.")?))
+        .map(|source| {
+            let seen = source.generation();
+            (source, seen)
+        })
+        .collect()
+}
+
 fn main() -> Result<(), vantage_rhai::RhaiError> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/two_hosts.yaml");
     let yaml = std::fs::read_to_string(path).expect("the example ships its own YAML");
-    let Defs { compute, label } = serde_yaml_ng::from_str(&yaml).expect("that YAML parses");
+    let Defs { compute, labels } = serde_yaml_ng::from_str(&yaml).expect("that YAML parses");
 
-    let globals = Globals(Arc::new(Mutex::new(HashMap::new())));
-    let (tx, repaint) = mpsc::channel();
-    let env = Env::new().var("globals", Dynamic::from(globals.clone()));
+    let scope = Scope::default();
+    scope.declare(&["batch", "pi"]);
 
-    let ui = Host::builder(Limits::Ui)
-        .vocab(Readable)
-        .vocab(Format)
-        .build();
-    let label = ui.compile(&label)?;
+    let ui = Host::builder(Limits::Ui).vocab(Format).build();
+    let read_env = Env::new().resolver(Arc::new(scope.clone()));
+    let mut labels: Vec<(String, Label)> = labels
+        .into_iter()
+        .map(|(name, template)| {
+            let compiled = ui.compile(&template)?.discover(&read_env)?;
+            Ok((name, Label::connect(compiled, &scope)))
+        })
+        .collect::<Result<_, vantage_rhai::RhaiError>>()?;
+    for (name, label) in &labels {
+        println!("{name:<6} reads {:?}", label.template.read_set());
+    }
 
-    let worker_env = env.clone();
-    std::thread::spawn(move || {
-        let backend = Host::builder(Limits::background())
-            .vocab(Readable)
-            .vocab(Writable(tx))
-            .build();
-        backend
+    let write_env = Env::new().var("globals", Dynamic::from(scope.clone()));
+    let worker = std::thread::spawn(move || {
+        Host::builder(Limits::background())
+            .vocab(Writable)
+            .build()
             .compile(&compute)
-            .and_then(|script| script.run(&worker_env))
+            .and_then(|script| script.run(&write_env))
             .expect("the compute script runs")
     });
 
-    // One repaint per write. The sender lives only in the backend host, so
-    // the channel closes when the worker drops it and the last line printed
-    // is the final estimate.
-    for () in repaint {
-        println!("{}", label.eval_as::<String>(&env)?);
+    // The frame clock. `Mount::tick` is this loop behind a real timer.
+    println!("\n  repaints:");
+    while !worker.is_finished() {
+        paint(&mut labels, &read_env);
+        std::thread::sleep(Duration::from_millis(2));
     }
-    println!("pi = 3.141593 — compare to see which digits had settled");
+    paint(&mut labels, &read_env);
+
+    println!(
+        "\n`batch` repainted every time. `pi` fell quiet once its fifth decimal\n\
+         stopped moving: same value written, no generation bump, no repaint."
+    );
     Ok(())
+}
+
+fn paint(labels: &mut [(String, Label)], env: &Env) {
+    for (_, label) in labels {
+        if let Some(text) = label.pump(env) {
+            println!("  {text}");
+        }
+    }
 }

--- a/vantage-rhai/examples/two_hosts.yaml
+++ b/vantage-rhai/examples/two_hosts.yaml
@@ -1,22 +1,23 @@
-# Two scripts that never call each other. They meet at `globals`.
+# Two scripts on two hosts on two threads. They meet at `globals`.
 
-# Backend host: it was given a writable `globals` and `commit`, and no way
-# to format. The Leibniz series gains roughly one digit per tenfold increase
-# in terms, so batch by batch the leading digits settle and the trailing ones
-# are still moving — which is the honest picture of a converging estimate.
+# Backend host: a writable `globals`, and no way to format.
 # language=rhai
 compute: |
   let sum = 0.0;
-  for i in 0..40000 {
+  for i in 0..80000 {
       let term = 1.0 / (2.0 * i.to_float() + 1.0);
       if i % 2 == 0 { sum += term; } else { sum -= term; }
       if i % 10000 == 9999 {
-          globals.terms = (i + 1).to_float();
-          globals.pi = 4.0 * sum;
-          commit();
+          globals.batch = ((i + 1) / 10000).to_float();
+          // Store what the label shows. Keep full precision here instead and
+          // the value moves on every batch forever, so the label repaints
+          // forever — the estimate is still converging in digits nobody sees.
+          globals.pi = (4.0 * sum * 100000.0).round() / 100000.0;
       }
   }
 
-# UI host: it can read `globals` and format it. Assigning to it would fail
-# here, because that host was never given the setter.
-label: 'pi ~ ${ fixed(globals.pi, 6) } after ${ fixed(globals.terms, 0) } terms'
+# UI host: reads `globals` and formats it. Each label subscribes to the paths
+# its own discovery pass recorded, so they wake independently.
+labels:
+  batch: 'batch ${ fixed(globals.batch, 0) } of 8'
+  pi: 'pi ~ ${ fixed(globals.pi, 5) }'

--- a/vantage-rhai/examples/two_hosts.yaml
+++ b/vantage-rhai/examples/two_hosts.yaml
@@ -1,0 +1,21 @@
+# Two scripts that never call each other. They meet at `globals`.
+
+# Backend host. It was given a setter for `globals`, and no way to format.
+# language=rhai
+compute: |
+  let inside = 0;
+  let seed = 12345;
+  for i in 0..40000 {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      let x = seed.to_float() / 2147483648.0;
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      let y = seed.to_float() / 2147483648.0;
+      if x * x + y * y <= 1.0 { inside += 1; }
+      if i % 10000 == 9999 {
+          globals.pi = 4.0 * inside.to_float() / (i + 1).to_float();
+      }
+  }
+
+# UI host. It can read `globals` and format it. Assigning to it would fail
+# here: that host was never given the setter.
+label: 'pi ~ ${ fixed(globals.pi, 4) }'

--- a/vantage-rhai/examples/two_hosts.yaml
+++ b/vantage-rhai/examples/two_hosts.yaml
@@ -4,7 +4,7 @@
 # language=rhai
 compute: |
   let sum = 0.0;
-  for i in 0..80000 {
+  for i in 0..100000 {
       let term = 1.0 / (2.0 * i.to_float() + 1.0);
       if i % 2 == 0 { sum += term; } else { sum -= term; }
       if i % 10000 == 9999 {
@@ -19,5 +19,5 @@ compute: |
 # UI host: reads `globals` and formats it. Each label subscribes to the paths
 # its own discovery pass recorded, so they wake independently.
 labels:
-  batch: 'batch ${ fixed(globals.batch, 0) } of 8'
+  batch: 'processing ${ fixed(globals.batch, 0) } of 10'
   pi: 'pi ~ ${ fixed(globals.pi, 5) }'

--- a/vantage-rhai/examples/two_hosts.yaml
+++ b/vantage-rhai/examples/two_hosts.yaml
@@ -1,21 +1,22 @@
 # Two scripts that never call each other. They meet at `globals`.
 
-# Backend host. It was given a setter for `globals`, and no way to format.
+# Backend host: it was given a writable `globals` and `commit`, and no way
+# to format. The Leibniz series gains roughly one digit per tenfold increase
+# in terms, so batch by batch the leading digits settle and the trailing ones
+# are still moving — which is the honest picture of a converging estimate.
 # language=rhai
 compute: |
-  let inside = 0;
-  let seed = 12345;
+  let sum = 0.0;
   for i in 0..40000 {
-      seed = (seed * 1103515245 + 12345) % 2147483648;
-      let x = seed.to_float() / 2147483648.0;
-      seed = (seed * 1103515245 + 12345) % 2147483648;
-      let y = seed.to_float() / 2147483648.0;
-      if x * x + y * y <= 1.0 { inside += 1; }
+      let term = 1.0 / (2.0 * i.to_float() + 1.0);
+      if i % 2 == 0 { sum += term; } else { sum -= term; }
       if i % 10000 == 9999 {
-          globals.pi = 4.0 * inside.to_float() / (i + 1).to_float();
+          globals.terms = (i + 1).to_float();
+          globals.pi = 4.0 * sum;
+          commit();
       }
   }
 
-# UI host. It can read `globals` and format it. Assigning to it would fail
-# here: that host was never given the setter.
-label: 'pi ~ ${ fixed(globals.pi, 4) }'
+# UI host: it can read `globals` and format it. Assigning to it would fail
+# here, because that host was never given the setter.
+label: 'pi ~ ${ fixed(globals.pi, 6) } after ${ fixed(globals.terms, 0) } terms'


### PR DESCRIPTION
## Summary

`vantage-rhai` shipped with module docs and no README. This adds one written for an engineer who has never seen the crate and wants to script a crate of their own, plus `examples/quickstart.rs` that runs everything the README claims.

The README covers: what a slot is and why the crate exists; the three kinds and when each applies; compiling and evaluating; `Env` with eager and lazy value supply; the two limit profiles and why there is no unlimited one; vocabularies, including the registration-order rule and the `on_var` collision that silently disables resolution; discovery and read-sets; the error type and its located rendering; the shared `${…}` scanner; the JSON bridge; the `schema` feature; the shared hosts; the trust model; and a seven-step recipe for adopting it.

Also sets `readme` in the manifest so crates.io renders it, and adds `serde_yaml_ng` as a dev-dependency — the example deserializes its slots from YAML, which is where a real consumer's slots come from.

## Stacked on #395

Based on `rhai-unification` because the README documents 0.6.2, including `ui_host()` / `background_host()` which only exist on that branch. Retarget to `main` once #395 merges.

## Verification

Every factual claim was checked against the source by a review pass, and the ones a reader is most likely to trip over were confirmed by running them:

- a single-hole template keeps the hole's type, so `Template::from("${ 1 + 1 }").eval_as::<String>()` is a `WrongType` error, while text around a hole joins into a `String` with a unit hole rendering empty
- `Expr` refuses statements at parse time
- a `Block` ending on a statement evaluates to unit
- `Host` is `Send + Sync`; `AST_CACHE_BOUND` is 1024 and overflow clears wholesale rather than evicting
- the error block in the README is pasted from real output, not written from memory

That pass also corrected four things I had wrong in the first draft: the duplicate-`rhai` failure mode (Cargo unifies same-major, so the symptom is unioned features, not a link error), the claim that `ast()` always returns an AST, a cache rationale that described eviction the cache does not do, and a line count for the example.

```
$ cargo run --example quickstart
guard      -> true
label      -> £750 for 3
action     -> 675
label reads-> {"settings.currency"}
typo       -> unknown name `settings.currancy` in scope (in `settings.currancy`)
syntax     -> Syntax error: Expecting ';' to terminate this statement (line 3, column 1)
  | let m = 2;
  | ^
runaway    -> script exceeded its operations limit
```

## Test plan

- [x] `cargo run --example quickstart -p vantage-rhai`
- [x] `cargo test -p vantage-rhai --all-features` (50)
- [x] `cargo clippy -p vantage-rhai --all-features --all-targets` clean
- [x] `cargo package -p vantage-rhai` ships both new files