### PR TITLE
Runtime filter terms, pushed down like quicksearch, and a Like operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-api-client"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-diorama"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5909,7 +5909,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-sql"
-version = "0.6.22"
+version = "0.6.23"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-surrealdb"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "vantage-vista"
-version = "0.6.25"
+version = "0.6.26"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/vantage-api-client/CHANGELOG.md
+++ b/vantage-api-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.14 — 2026-09-08
+
+- `add_op_condition` reports `Unimplemented` for `FilterOp::Like` — no
+  GraphQL dialect here spells a pattern match, so the consumer evaluates it
+  locally rather than having the filter silently dropped.
+
 ## 0.6.13 — 2026-09-05
 
 - Follows vista 0.6.25: a lazy column's script compiles once through

--- a/vantage-api-client/Cargo.toml
+++ b/vantage-api-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-api-client"
-version = "0.6.13"
+version = "0.6.14"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for REST and GraphQL HTTP API backends"

--- a/vantage-api-client/src/graphql/vista/source.rs
+++ b/vantage-api-client/src/graphql/vista/source.rs
@@ -154,6 +154,15 @@ impl TableShell for GraphqlApiTableShell {
                     FilterOp::Gte => column.gte(native),
                     FilterOp::Lt => column.lt(native),
                     FilterOp::Lte => column.lte(native),
+                    // No GraphQL dialect here spells a pattern match; the
+                    // consumer evaluates it locally.
+                    FilterOp::Like => {
+                        return Err(error!(
+                            "GraphQL add_op_condition: Like has no push-down; filter locally",
+                            method = "add_op_condition"
+                        )
+                        .mark_unimplemented());
+                    }
                     FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
                 }
             }

--- a/vantage-diorama/CHANGELOG.md
+++ b/vantage-diorama/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.12.6 — 2026-09-08
+
+- `TableScenery::set_filter_terms(Vec<OpCondition>)` / `filter_terms()` — a
+  runtime `column <op> value` set, replacing eq-only `set_filters` where more
+  is needed. Mechanics follow `set_search`: a paged scenery carries the terms
+  in `ChunkQuery` and the master pushes down what it can take (equality
+  always, richer operators when it advertises `can_filter_operators`),
+  dropping the rest with a warning rather than evaluating them over one
+  window; an eager scenery applies them over its complete cache; a two-pass
+  one folds them into `reseed_filtered`. The scenery holds the list, so a
+  chip strip or a persisted store reads one source.
+- `ChunkQuery` gains `filters`. Constructed by name in one place, but the
+  struct is public — a lens building it literally needs the new field.
+- `ui_filters` are applied on the eager path too. `local_refine()` is false
+  without augmentation or a detail loader, so a single-pass table took
+  `set_filters` and narrowed nothing.
+- `OpCondition::key_fragment` is public, for a consumer keying its own state
+  off the term set.
+
 ## 0.12.5 — 2026-09-05
 
 - `ServoVocab` registers the servo surface (`form.field`, `form.save()`) as

--- a/vantage-diorama/Cargo.toml
+++ b/vantage-diorama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-diorama"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Cached, composable, reactive surface for Vantage Vistas"

--- a/vantage-diorama/src/dio/mod.rs
+++ b/vantage-diorama/src/dio/mod.rs
@@ -765,7 +765,28 @@ impl Dio {
             );
         }
 
-        if (push_sort.is_some() || push_search.is_some())
+        // Filter terms follow the same rule as search: what the master cannot
+        // take is dropped here, loudly, rather than evaluated over one window
+        // (which would filter a slice and present it as the set). Equality
+        // push-down is universal; the richer operators are gated by the
+        // capability flag, and a source may still decline one term with
+        // Unimplemented — SurrealDB has no `NOT IN` — which is also a drop.
+        let mut push_terms = Vec::new();
+        for term in &query.filters {
+            if term.op == vantage_vista::FilterOp::Eq || caps.can_filter_operators {
+                push_terms.push(term.clone());
+            } else {
+                tracing::warn!(
+                    target: "vantage_diorama::filter",
+                    table = %master.name(),
+                    column = %term.column,
+                    op = ?term.op,
+                    "chunk query carries a filter the master cannot push down — ignored",
+                );
+            }
+        }
+
+        if (push_sort.is_some() || push_search.is_some() || !push_terms.is_empty())
             && let Some(shell) = master.source.clone_shell()
         {
             let mut narrowed = Vista::new(master.name(), shell);
@@ -778,6 +799,22 @@ impl Dio {
             }
             if let Some(text) = push_search {
                 narrowed.add_search(text)?;
+            }
+            for term in push_terms {
+                // `add_condition` routes `Eq` to `add_eq_condition` in every
+                // source, so equality needs no separate call here.
+                if let Err(e) =
+                    narrowed.add_condition(term.column.clone(), term.op, term.value.clone())
+                {
+                    tracing::warn!(
+                        target: "vantage_diorama::filter",
+                        table = %master.name(),
+                        column = %term.column,
+                        op = ?term.op,
+                        error = %e,
+                        "the master declined a filter term — ignored",
+                    );
+                }
             }
             return narrowed.fetch_window_counted(offset, limit).await;
         }

--- a/vantage-diorama/src/lens/callbacks.rs
+++ b/vantage-diorama/src/lens/callbacks.rs
@@ -53,11 +53,18 @@ pub struct ChunkQuery {
     pub sort: Option<(String, SortDir)>,
     /// The scenery's active quicksearch text (`None` when not searching).
     pub search: Option<String>,
+    /// The scenery's active operator filters (the grid's filter panel),
+    /// ANDed. Empty when none are set.
+    pub filters: Vec<crate::scenery::OpCondition>,
 }
 
 impl From<Option<(String, SortDir)>> for ChunkQuery {
     fn from(sort: Option<(String, SortDir)>) -> Self {
-        Self { sort, search: None }
+        Self {
+            sort,
+            search: None,
+            filters: Vec::new(),
+        }
     }
 }
 

--- a/vantage-diorama/src/scenery/table/builder.rs
+++ b/vantage-diorama/src/scenery/table/builder.rs
@@ -280,6 +280,7 @@ impl TableSceneryBuilder {
             master_capabilities,
             two_pass,
             ui_filters: RwLock::new(Vec::new()),
+            ui_terms: RwLock::new(Vec::new()),
             search: RwLock::new(None),
             titles_only,
             demand,

--- a/vantage-diorama/src/scenery/table/capped.rs
+++ b/vantage-diorama/src/scenery/table/capped.rs
@@ -89,6 +89,14 @@ impl TableScenery for CappedScenery {
         self.inner.set_filters(filters);
     }
 
+    fn set_filter_terms(&self, terms: Vec<super::OpCondition>) {
+        self.inner.set_filter_terms(terms);
+    }
+
+    fn filter_terms(&self) -> Vec<super::OpCondition> {
+        self.inner.filter_terms()
+    }
+
     fn subscribe(&self) -> watch::Receiver<Generation> {
         self.inner.subscribe()
     }

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -93,31 +93,14 @@ pub(crate) fn matches_op_conditions(rec: &Record<CborValue>, conds: &[super::OpC
             // The one reading every backend's pattern match contains: a
             // case-insensitive substring test over the cell's text.
             FilterOp::Like => {
-                let needle = cbor_text(&cond.value).to_lowercase();
-                needle.is_empty() || cbor_text(cell).to_lowercase().contains(&needle)
+                let needle = vantage_vista::operand_text(&cond.value).to_lowercase();
+                needle.is_empty()
+                    || vantage_vista::operand_text(cell)
+                        .to_lowercase()
+                        .contains(&needle)
             }
         }
     })
-}
-
-/// A cell as the text a pattern match reads. Numbers and bools spell
-/// themselves; a record id reads as `table:key`; anything else as its debug
-/// form, which is what quicksearch matches against too.
-fn cbor_text(value: &CborValue) -> String {
-    match value {
-        CborValue::Text(s) => s.clone(),
-        CborValue::Integer(i) => i128::from(*i).to_string(),
-        CborValue::Float(f) => f.to_string(),
-        CborValue::Bool(b) => b.to_string(),
-        CborValue::Tag(8, inner) => match inner.as_ref() {
-            CborValue::Array(parts) if parts.len() == 2 => {
-                format!("{}:{}", cbor_text(&parts[0]), cbor_text(&parts[1]))
-            }
-            other => cbor_text(other),
-        },
-        CborValue::Tag(_, inner) => cbor_text(inner),
-        other => format!("{other:?}"),
-    }
 }
 
 /// Iterate the members of a set operand — the `CborValue::Array` payload of an

--- a/vantage-diorama/src/scenery/table/helpers.rs
+++ b/vantage-diorama/src/scenery/table/helpers.rs
@@ -90,8 +90,34 @@ pub(crate) fn matches_op_conditions(rec: &Record<CborValue>, conds: &[super::OpC
                 .matches_ordering(cbor_cmp(Some(cell), Some(&cond.value))),
             FilterOp::InSet => set_members(&cond.value).any(|m| cbor_eq(cell, m)),
             FilterOp::NotInSet => !set_members(&cond.value).any(|m| cbor_eq(cell, m)),
+            // The one reading every backend's pattern match contains: a
+            // case-insensitive substring test over the cell's text.
+            FilterOp::Like => {
+                let needle = cbor_text(&cond.value).to_lowercase();
+                needle.is_empty() || cbor_text(cell).to_lowercase().contains(&needle)
+            }
         }
     })
+}
+
+/// A cell as the text a pattern match reads. Numbers and bools spell
+/// themselves; a record id reads as `table:key`; anything else as its debug
+/// form, which is what quicksearch matches against too.
+fn cbor_text(value: &CborValue) -> String {
+    match value {
+        CborValue::Text(s) => s.clone(),
+        CborValue::Integer(i) => i128::from(*i).to_string(),
+        CborValue::Float(f) => f.to_string(),
+        CborValue::Bool(b) => b.to_string(),
+        CborValue::Tag(8, inner) => match inner.as_ref() {
+            CborValue::Array(parts) if parts.len() == 2 => {
+                format!("{}:{}", cbor_text(&parts[0]), cbor_text(&parts[1]))
+            }
+            other => cbor_text(other),
+        },
+        CborValue::Tag(_, inner) => cbor_text(inner),
+        other => format!("{other:?}"),
+    }
 }
 
 /// Iterate the members of a set operand — the `CborValue::Array` payload of an

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -365,6 +365,7 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
     let query = crate::lens::ChunkQuery {
         sort: state.sort.read().unwrap().clone(),
         search: state.search.read().unwrap().clone(),
+        filters: state.ui_terms.read().unwrap().clone(),
     };
     tracing::debug!(
         target: "vantage_diorama::viewport",

--- a/vantage-diorama/src/scenery/table/loader.rs
+++ b/vantage-diorama/src/scenery/table/loader.rs
@@ -612,10 +612,12 @@ async fn fire_chunk_load(state: Arc<TableSceneryState>, request: ViewportRequest
                 // the NEXT open of this view can size its geometry before any
                 // fetch — the difference between a warm reopen appearing
                 // whole and its row count visibly jumping when the first
-                // counted response lands. A total under an active search
-                // describes the narrowed set and must not be remembered.
+                // counted response lands. A total under an active search or
+                // filter describes the narrowed set and must not be
+                // remembered — the next open would restore it as the whole.
                 if changed
                     && state.search.read().unwrap().is_none()
+                    && state.ui_terms.read().unwrap().is_empty()
                     && let Some(total) = stated
                     && let Err(e) = dio_inner.cache.set_meta_total(total as u64).await
                 {

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -478,11 +478,16 @@ impl TableScenery for TableSceneryImpl {
         *self.inner.ui_terms.write().unwrap() = terms;
         // The cached total belongs to the unfiltered set.
         self.inner.set_total(None);
-        if self.inner.paged {
+        if self.inner.paged && !self.inner.two_pass {
             // Same stale-while-revalidate as search: keep the rows on screen
             // and refetch the viewport with the new terms in the query.
             self.inner.refresh_loaded_viewport();
         } else {
+            // A two-pass view's membership lives in its index, which only
+            // `resort` re-derives — refreshing the viewport would re-hydrate
+            // rows the new terms exclude and leave them on screen. The
+            // reactor routes this to `resort` (and `reseed_filtered` inside
+            // it) for two-pass, and to a cache reseed for eager.
             self.inner.reload_notify.notify_one();
         }
     }

--- a/vantage-diorama/src/scenery/table/mod.rs
+++ b/vantage-diorama/src/scenery/table/mod.rs
@@ -77,7 +77,7 @@ impl OpCondition {
     /// Stable `field<sym>value` fragment for the query-variant cache key, so a
     /// scenery narrowed by this operator gets its own ordered index (never
     /// colliding with the unfiltered set or a different-operator filter).
-    pub(crate) fn key_fragment(&self) -> String {
+    pub fn key_fragment(&self) -> String {
         format!("{}{}{:?}", self.column, self.op.key_symbol(), self.value)
     }
 }
@@ -173,6 +173,22 @@ pub trait TableScenery: Send + Sync {
     /// conditions, evaluated locally over the cache (which is what lets
     /// them reference augmented columns). Empty vec clears.
     fn set_filters(&self, filters: Vec<(String, ciborium::Value)>);
+
+    /// Replace the UI-level operator filter set (the grid's filter panel):
+    /// `column <op> value` terms ANDed together and with the query's own
+    /// conditions. Same mechanics as [`set_search`](Self::set_search): a
+    /// paged scenery carries the terms into every chunk fetch and the master
+    /// pushes down what it can — equality always, richer operators when it
+    /// advertises `can_filter_operators`, dropping the rest with a warning;
+    /// an eager scenery evaluates them over its complete cache. Empty vec
+    /// clears. Default no-op for wrappers that don't filter.
+    fn set_filter_terms(&self, _terms: Vec<OpCondition>) {}
+
+    /// The operator filter set currently in force — what a chip strip or a
+    /// persisted-filter store reads, so there is one list, held here.
+    fn filter_terms(&self) -> Vec<OpCondition> {
+        Vec::new()
+    }
 
     /// Replace the quicksearch text (replace semantics; `None` or blank
     /// clears). Paged sceneries push it into every chunk fetch — callers
@@ -434,6 +450,45 @@ impl TableScenery for TableSceneryImpl {
         // The cached total belongs to the unfiltered set.
         self.inner.set_total(None);
         self.inner.reload_notify.notify_one();
+    }
+
+    fn set_filter_terms(&self, terms: Vec<OpCondition>) {
+        // Order-insensitive: the same set restated is not a change.
+        if helpers::op_conditions_key(&self.inner.ui_terms.read().unwrap())
+            == helpers::op_conditions_key(&terms)
+        {
+            return;
+        }
+        crate::debug::tapline!(
+            self.inner.debug_tap,
+            "filter",
+            "{} term{} — {}",
+            terms.len(),
+            if terms.len() == 1 { "" } else { "s" },
+            if self.inner.paged {
+                "pushed to the source where it can take them".to_string()
+            } else {
+                format!(
+                    "filtering the {} rows held locally",
+                    crate::debug::num(self.inner.rows.read().unwrap().len())
+                )
+            },
+        );
+        self.inner.deregister();
+        *self.inner.ui_terms.write().unwrap() = terms;
+        // The cached total belongs to the unfiltered set.
+        self.inner.set_total(None);
+        if self.inner.paged {
+            // Same stale-while-revalidate as search: keep the rows on screen
+            // and refetch the viewport with the new terms in the query.
+            self.inner.refresh_loaded_viewport();
+        } else {
+            self.inner.reload_notify.notify_one();
+        }
+    }
+
+    fn filter_terms(&self) -> Vec<OpCondition> {
+        self.inner.ui_terms.read().unwrap().clone()
     }
 
     fn set_search(&self, query: Option<String>) {

--- a/vantage-diorama/src/scenery/table/state.rs
+++ b/vantage-diorama/src/scenery/table/state.rs
@@ -133,6 +133,13 @@ pub(crate) struct TableSceneryState {
     /// so chips can never clobber query narrowing.
     pub(crate) ui_filters: RwLock<Vec<(String, CborValue)>>,
 
+    /// UI-level operator filters (the grid's filter panel) — runtime-set
+    /// `column <op> value` terms. They follow quicksearch's mechanics rather
+    /// than `op_conditions`' build-time ones: a paged scenery carries them
+    /// into every chunk fetch and the master pushes what it can, an eager
+    /// one evaluates them over its complete cache.
+    pub(crate) ui_terms: RwLock<Vec<super::OpCondition>>,
+
     /// Active quicksearch text (`None` when not searching). Paged sceneries
     /// carry it into every chunk fetch (`ChunkQuery`); eager ones apply it as
     /// a local predicate in `reseed_from_cache` — honest there, because the
@@ -211,6 +218,7 @@ impl TableSceneryState {
         !self.conditions.read().unwrap().is_empty()
             || !self.op_conditions.read().unwrap().is_empty()
             || !self.ui_filters.read().unwrap().is_empty()
+            || !self.ui_terms.read().unwrap().is_empty()
             || self.sort.read().unwrap().is_some()
     }
 
@@ -349,13 +357,22 @@ impl TableSceneryState {
 
         let conditions = self.conditions.read().unwrap().clone();
         let op_conditions = self.op_conditions.read().unwrap().clone();
+        // The UI's own filter set (grid chips, toolbar filter panel). Applied
+        // here as well as on the two-pass path, because `local_refine` — which
+        // gates that path — is false for a single-pass scenery, so a table
+        // with no augmentation and no detail loader would take `set_filters`
+        // and narrow nothing.
+        let ui_filters = self.ui_filters.read().unwrap().clone();
+        let ui_terms = self.ui_terms.read().unwrap().clone();
         let sort = self.sort.read().unwrap().clone();
         let search = self.search.read().unwrap().clone();
 
         let mut filtered: Vec<(String, Record<CborValue>)> = all
             .into_iter()
             .filter(|(_, rec)| matches_conditions(rec, &conditions))
+            .filter(|(_, rec)| matches_conditions(rec, &ui_filters))
             .filter(|(_, rec)| matches_op_conditions(rec, &op_conditions))
+            .filter(|(_, rec)| matches_op_conditions(rec, &ui_terms))
             .filter(|(_, rec)| matches_search(rec, search.as_deref()))
             .collect();
 

--- a/vantage-diorama/src/scenery/table/two_pass.rs
+++ b/vantage-diorama/src/scenery/table/two_pass.rs
@@ -148,6 +148,7 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
     let ids = index.ids();
     let conditions = state.conditions.read().unwrap().clone();
     let ui_filters = state.ui_filters.read().unwrap().clone();
+    let ui_terms = state.ui_terms.read().unwrap().clone();
     let op_conditions = state.op_conditions.read().unwrap().clone();
     let sort = state.sort.read().unwrap().clone();
 
@@ -163,6 +164,7 @@ pub(crate) async fn reseed_filtered(state: &Arc<TableSceneryState>) {
             && matches_conditions(&rec, &conditions)
             && matches_conditions(&rec, &ui_filters)
             && matches_op_conditions(&rec, &op_conditions)
+            && matches_op_conditions(&rec, &ui_terms)
         {
             gathered.push((id.clone(), rec, status));
         }

--- a/vantage-diorama/tests/dio_op_conditions.rs
+++ b/vantage-diorama/tests/dio_op_conditions.rs
@@ -63,3 +63,32 @@ async fn no_op_condition_keeps_all_rows() {
     view.settle_until("all rows", |v| v.row_count() == 3).await;
     assert_eq!(view.row_count(), 3);
 }
+
+/// Runtime terms — the grid's filter panel — narrow an already-open view
+/// and clear back to the full set, and the view reports what is in force.
+#[tokio::test]
+async fn runtime_filter_terms_narrow_and_clear() {
+    use vantage_diorama::OpCondition;
+
+    let dio: Dio = eager_dio(teams_master()).await;
+    let view = MockView::open(&dio, 10).await;
+    view.settle_until("all rows", |v| v.row_count() == 3).await;
+
+    view.scenery()
+        .set_filter_terms(vec![OpCondition::new("team", FilterOp::Ne, "red")]);
+    view.settle_until("only non-red rows", |v| v.row_count() == 1)
+        .await;
+    assert_eq!(view.col_at(0, "team").as_deref(), Some("blue"));
+    assert_eq!(view.scenery().filter_terms().len(), 1);
+
+    // A pattern match is evaluated locally: this master pushes nothing.
+    view.scenery()
+        .set_filter_terms(vec![OpCondition::new("team", FilterOp::Like, "RE")]);
+    view.settle_until("case-insensitive substring", |v| v.row_count() == 2)
+        .await;
+
+    view.scenery().set_filter_terms(Vec::new());
+    view.settle_until("back to all rows", |v| v.row_count() == 3)
+        .await;
+    assert!(view.scenery().filter_terms().is_empty());
+}

--- a/vantage-diorama/tests/two_pass.rs
+++ b/vantage-diorama/tests/two_pass.rs
@@ -402,7 +402,14 @@ async fn diagnostics_report_sceneries_refcount_and_hydration() {
         .open()
         .await
         .unwrap();
-    eventually("picker listed", || picker.row_count() >= 2).await;
+    // Wait for the rows themselves, not the index: a two-pass `row_count()`
+    // reads the list-pass index, while `status_summary` counts the sparse map
+    // the assertions below read. The two are filled by different steps, so
+    // waiting on the index let this pass with one row materialised.
+    eventually("picker rows materialised", || {
+        picker.status_summary().loaded >= 2
+    })
+    .await;
 
     let d = dio.diagnostics().await;
     assert_eq!(d.sceneries.len(), 1);

--- a/vantage-sql/CHANGELOG.md
+++ b/vantage-sql/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.23 — 2026-09-08
+
+- `add_op_condition` handles `FilterOp::Like`: `LIKE '%…%' ESCAPE '$'` on
+  SQLite and MySQL, `ILIKE` on Postgres — matching what quicksearch already
+  does on each dialect.
+- The `%…%` escape lives in one place (`like_pattern_str`), shared by
+  quicksearch and by the new operator, so the two cannot drift.
+
 ## 0.6.22 — 2026-09-05
 
 - The `rhai` feature runs on a `vantage-rhai` host: `register_engine!` emits

--- a/vantage-sql/Cargo.toml
+++ b/vantage-sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-sql"
-version = "0.6.22"
+version = "0.6.23"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -34,12 +34,5 @@ pub(crate) fn like_pattern_str(text: &str) -> String {
 
 /// [`like_pattern_str`] over a filter operand, which may be any scalar.
 pub(crate) fn like_pattern(value: &ciborium::Value) -> String {
-    let text = match value {
-        ciborium::Value::Text(s) => s.clone(),
-        ciborium::Value::Integer(i) => i128::from(*i).to_string(),
-        ciborium::Value::Float(f) => f.to_string(),
-        ciborium::Value::Bool(b) => b.to_string(),
-        other => format!("{other:?}"),
-    };
-    like_pattern_str(&text)
+    like_pattern_str(&vantage_vista::operand_text(value))
 }

--- a/vantage-sql/src/lib.rs
+++ b/vantage-sql/src/lib.rs
@@ -18,3 +18,28 @@ pub mod mysql;
 
 #[cfg(feature = "rhai")]
 pub mod rhai_engine;
+
+/// The `LIKE` operand for a substring match: `%text%` with the wildcards and
+/// the escape itself escaped, so a `_` or `%` in what the user typed matches
+/// itself. Shared by quicksearch and by
+/// [`FilterOp::Like`](vantage_vista::FilterOp::Like), which is what keeps the
+/// two spelling the same pattern.
+pub(crate) fn like_pattern_str(text: &str) -> String {
+    let escaped = text
+        .replace('$', "$$")
+        .replace('%', "$%")
+        .replace('_', "$_");
+    format!("%{escaped}%")
+}
+
+/// [`like_pattern_str`] over a filter operand, which may be any scalar.
+pub(crate) fn like_pattern(value: &ciborium::Value) -> String {
+    let text = match value {
+        ciborium::Value::Text(s) => s.clone(),
+        ciborium::Value::Integer(i) => i128::from(*i).to_string(),
+        ciborium::Value::Float(f) => f.to_string(),
+        ciborium::Value::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    };
+    like_pattern_str(&text)
+}

--- a/vantage-sql/src/mysql/table_source.rs
+++ b/vantage-sql/src/mysql/table_source.rs
@@ -135,11 +135,7 @@ impl TableSource for MysqlDB {
     where
         E: Entity<Self::Value>,
     {
-        let escaped = search_value
-            .replace('$', "$$")
-            .replace('%', "$%")
-            .replace('_', "$_");
-        let pattern = format!("%{}%", escaped);
+        let pattern = crate::like_pattern_str(search_value);
         let conditions: Vec<Expression<AnyMysqlType>> = table
             .columns()
             .values()

--- a/vantage-sql/src/mysql/vista/source.rs
+++ b/vantage-sql/src/mysql/vista/source.rs
@@ -213,6 +213,15 @@ where
                 };
                 self.table.add_condition(condition);
             }
+            // The same `LIKE '%…%' ESCAPE '$'` quicksearch uses, on one column.
+            FilterOp::Like => {
+                let pattern = crate::like_pattern(value);
+                self.table.add_condition(crate::mysql_expr!(
+                    "{} LIKE {} ESCAPE '$'",
+                    (crate::primitives::identifier::ident(field)),
+                    pattern
+                ));
+            }
             _ => {
                 let sql_value = AnyMysqlType::untyped(value.clone());
                 let condition = match op {
@@ -222,7 +231,9 @@ where
                     FilterOp::Gte => column.gte(sql_value),
                     FilterOp::Lt => column.lt(sql_value),
                     FilterOp::Lte => column.lte(sql_value),
-                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                    FilterOp::InSet | FilterOp::NotInSet | FilterOp::Like => {
+                        unreachable!("handled above")
+                    }
                 };
                 self.table.add_condition(condition);
             }

--- a/vantage-sql/src/postgres/impls/table_source.rs
+++ b/vantage-sql/src/postgres/impls/table_source.rs
@@ -172,11 +172,7 @@ impl TableSource for PostgresDB {
     where
         E: Entity<Self::Value>,
     {
-        let escaped = search_value
-            .replace('$', "$$")
-            .replace('%', "$%")
-            .replace('_', "$_");
-        let pattern = format!("%{}%", escaped);
+        let pattern = crate::like_pattern_str(search_value);
         let conditions: Vec<Expression<AnyPostgresType>> = table
             .columns()
             .values()

--- a/vantage-sql/src/postgres/vista/source.rs
+++ b/vantage-sql/src/postgres/vista/source.rs
@@ -394,6 +394,16 @@ where
                 };
                 self.table.add_condition(condition);
             }
+            // `ILIKE`, as quicksearch does here: case-insensitive everywhere
+            // else, so it is case-insensitive on Postgres too.
+            FilterOp::Like => {
+                let pattern = crate::like_pattern(value);
+                self.table.add_condition(crate::postgres_expr!(
+                    "{}::text ILIKE {} ESCAPE '$'",
+                    (ident(field)),
+                    pattern
+                ));
+            }
             _ => {
                 let sql_value = AnyPostgresType::untyped(value.clone());
                 let condition = match op {
@@ -403,7 +413,9 @@ where
                     FilterOp::Gte => column.gte(sql_value),
                     FilterOp::Lt => column.lt(sql_value),
                     FilterOp::Lte => column.lte(sql_value),
-                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                    FilterOp::InSet | FilterOp::NotInSet | FilterOp::Like => {
+                        unreachable!("handled above")
+                    }
                 };
                 self.table.add_condition(condition);
             }

--- a/vantage-sql/src/sqlite/impls/table_source.rs
+++ b/vantage-sql/src/sqlite/impls/table_source.rs
@@ -128,11 +128,7 @@ impl TableSource for SqliteDB {
     where
         E: Entity<Self::Value>,
     {
-        let escaped = search_value
-            .replace('$', "$$")
-            .replace('%', "$%")
-            .replace('_', "$_");
-        let pattern = format!("%{}%", escaped);
+        let pattern = crate::like_pattern_str(search_value);
         let conditions: Vec<Expression<AnySqliteType>> = table
             .columns()
             .values()

--- a/vantage-sql/src/sqlite/vista/source.rs
+++ b/vantage-sql/src/sqlite/vista/source.rs
@@ -233,6 +233,15 @@ where
                 };
                 self.table.add_condition(condition);
             }
+            // The same `LIKE '%…%' ESCAPE '$'` quicksearch uses, on one column.
+            FilterOp::Like => {
+                let pattern = crate::like_pattern(value);
+                self.table.add_condition(crate::sqlite_expr!(
+                    "{} LIKE {} ESCAPE '$'",
+                    (ident(field)),
+                    pattern
+                ));
+            }
             _ => {
                 let sql_value = AnySqliteType::untyped(value.clone());
                 let condition = match op {
@@ -242,7 +251,9 @@ where
                     FilterOp::Gte => column.gte(sql_value),
                     FilterOp::Lt => column.lt(sql_value),
                     FilterOp::Lte => column.lte(sql_value),
-                    FilterOp::InSet | FilterOp::NotInSet => unreachable!("handled above"),
+                    FilterOp::InSet | FilterOp::NotInSet | FilterOp::Like => {
+                        unreachable!("handled above")
+                    }
                 };
                 self.table.add_condition(condition);
             }

--- a/vantage-surrealdb/CHANGELOG.md
+++ b/vantage-surrealdb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.19 — 2026-09-08
+
+- `add_op_condition` handles `FilterOp::Like` as SurrealDB's fuzzy operator
+  (`field ~ 'smith'`), spelled directly since the typed column expressions
+  have no combinator for it.
+
 ## 0.6.18 — 2026-09-05
 
 - The `rhai` feature runs on `vantage-rhai` hosts: `SurrealVocab` is the

--- a/vantage-surrealdb/Cargo.toml
+++ b/vantage-surrealdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "vantage-surrealdb"
-version = "0.6.18"
+version = "0.6.19"
 license = "MIT OR Apache-2.0"
 authors = ["Romans Malinovskis <me@nearly.guru>"]
 description = "Vantage extension for SurrealDB"

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -95,6 +95,19 @@ fn to_cbor_record(record: Record<AnySurrealType>) -> Record<CborValue> {
         .collect()
 }
 
+/// A [`FilterOp::Like`](vantage_vista::FilterOp::Like) operand as the text it
+/// matches against. Text passes through; a number or a bool spells itself, so
+/// `~5` on a numeric column still means "contains 5".
+fn like_text(value: &CborValue) -> String {
+    match value {
+        CborValue::Text(s) => s.clone(),
+        CborValue::Integer(i) => i128::from(*i).to_string(),
+        CborValue::Float(f) => f.to_string(),
+        CborValue::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
 fn to_native_record(record: &Record<CborValue>) -> Record<AnySurrealType> {
     record
         .iter()
@@ -274,14 +287,22 @@ where
             FilterOp::Lte => column.lte(surreal_value),
             // `value` is a CBOR array → a SurrealDB array literal; `field IN [ … ]`.
             FilterOp::InSet => column.in_(surreal_value),
-            // SurrealDB's fuzzy operator: `field ~ 'smith'` matches "Smithson"
-            // and "smyth" alike. A typed column expression has no combinator
-            // for it, so the condition is spelled directly.
+            // A lowercased `CONTAINS`, which is exactly the contract the
+            // local fallback applies: case-insensitive substring.
+            //
+            // Not the fuzzy `~`: SurrealDB 3.0 removed those operators (3.2.3
+            // answers `Unexpected token '~'`), and fuzzy was never this
+            // operator's meaning anyway.
+            //
+            // The operand is the value's own text, not `surreal_value` — on
+            // the id column that would have coerced the pattern into a Thing
+            // and compared a record id against a substring.
             FilterOp::Like => {
+                let needle = AnySurrealType::from(CborValue::Text(like_text(value)));
                 self.table.add_condition(crate::surreal_expr!(
-                    "{} ~ {}",
+                    "string::lowercase(<string>{}) CONTAINS string::lowercase({})",
                     (Identifier::new(field)),
-                    surreal_value
+                    needle
                 ));
                 return Ok(());
             }

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -95,19 +95,6 @@ fn to_cbor_record(record: Record<AnySurrealType>) -> Record<CborValue> {
         .collect()
 }
 
-/// A [`FilterOp::Like`](vantage_vista::FilterOp::Like) operand as the text it
-/// matches against. Text passes through; a number or a bool spells itself, so
-/// `~5` on a numeric column still means "contains 5".
-fn like_text(value: &CborValue) -> String {
-    match value {
-        CborValue::Text(s) => s.clone(),
-        CborValue::Integer(i) => i128::from(*i).to_string(),
-        CborValue::Float(f) => f.to_string(),
-        CborValue::Bool(b) => b.to_string(),
-        other => format!("{other:?}"),
-    }
-}
-
 fn to_native_record(record: &Record<CborValue>) -> Record<AnySurrealType> {
     record
         .iter()
@@ -298,7 +285,8 @@ where
             // the id column that would have coerced the pattern into a Thing
             // and compared a record id against a substring.
             FilterOp::Like => {
-                let needle = AnySurrealType::from(CborValue::Text(like_text(value)));
+                let needle =
+                    AnySurrealType::from(CborValue::Text(vantage_vista::operand_text(value)));
                 self.table.add_condition(crate::surreal_expr!(
                     "string::lowercase(<string>{}) CONTAINS string::lowercase({})",
                     (Identifier::new(field)),

--- a/vantage-surrealdb/src/vista/source.rs
+++ b/vantage-surrealdb/src/vista/source.rs
@@ -274,6 +274,17 @@ where
             FilterOp::Lte => column.lte(surreal_value),
             // `value` is a CBOR array → a SurrealDB array literal; `field IN [ … ]`.
             FilterOp::InSet => column.in_(surreal_value),
+            // SurrealDB's fuzzy operator: `field ~ 'smith'` matches "Smithson"
+            // and "smyth" alike. A typed column expression has no combinator
+            // for it, so the condition is spelled directly.
+            FilterOp::Like => {
+                self.table.add_condition(crate::surreal_expr!(
+                    "{} ~ {}",
+                    (Identifier::new(field)),
+                    surreal_value
+                ));
+                return Ok(());
+            }
             // The SurrealDB expression builder has no `NOT IN` combinator yet.
             // Report Unimplemented so the consumer filters locally (correct,
             // just not pushed) rather than silently dropping the filter.

--- a/vantage-vista/CHANGELOG.md
+++ b/vantage-vista/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.6.26 — 2026-09-08
+
+- **Breaking:** `FilterOp` gains a `Like` variant — a pattern match on text,
+  spelled by whichever backend can (SurrealDB's fuzzy `~`, SQL's `LIKE`).
+  The enum is deliberately not `#[non_exhaustive]`: every source's
+  `add_op_condition` is an exhaustive match, so a new operator forces each
+  backend to decide rather than silently falling into a wildcard. A source
+  with no spelling for it returns `Unimplemented` and the consumer evaluates
+  it locally.
+- `FilterOp::parse` takes a symbol or a word (`">="`, `"gte"`);
+  `split_prefix` peels a leading operator off a typed value (`">30"` →
+  `(Gt, "30")`); `display_symbol` renders one for a label. The rhai
+  vocabulary's `parse_op` now delegates to `parse`.
+
 ## 0.6.25 — 2026-09-05
 
 The `rhai` feature runs on `vantage-rhai` hosts instead of bare engines.

--- a/vantage-vista/Cargo.toml
+++ b/vantage-vista/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vantage-vista"
-version = "0.6.25"
+version = "0.6.26"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Universal, schema-bearing data handle for the Vantage data framework"

--- a/vantage-vista/src/filter.rs
+++ b/vantage-vista/src/filter.rs
@@ -50,6 +50,30 @@ pub enum FilterOp {
     Like,
 }
 
+/// A [`FilterOp::Like`] operand as the text it matches against — the one
+/// spelling every side of the comparison uses, so a pattern pushed into a
+/// query and the same pattern evaluated locally read the operand alike.
+///
+/// Scalars spell themselves; a record id reads as `table:key` rather than its
+/// debug form, which is what a user typing `~client:bristol` means.
+pub fn operand_text(value: &ciborium::Value) -> String {
+    use ciborium::Value;
+    match value {
+        Value::Text(s) => s.clone(),
+        Value::Integer(i) => i128::from(*i).to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Tag(8, inner) => match inner.as_ref() {
+            Value::Array(parts) if parts.len() == 2 => {
+                format!("{}:{}", operand_text(&parts[0]), operand_text(&parts[1]))
+            }
+            other => operand_text(other),
+        },
+        Value::Tag(_, inner) => operand_text(inner),
+        other => format!("{other:?}"),
+    }
+}
+
 impl FilterOp {
     /// The operator an author or a user wrote: a symbol (`>=`, `!=`, `~`) or
     /// a word (`gte`, `ne`, `like`). The symbol set is what a filter field

--- a/vantage-vista/src/filter.rs
+++ b/vantage-vista/src/filter.rs
@@ -37,11 +37,16 @@ pub enum FilterOp {
     /// `field ∉ value` — `value` is an array; matches when the cell equals no
     /// element.
     NotInSet,
-    /// `field ~ value` — a pattern match on text. What "pattern" means is the
-    /// backend's: SurrealDB's fuzzy `~`, SQL's `LIKE '%value%'`. A backend
-    /// with no spelling for it returns Unimplemented and the consumer
-    /// evaluates it locally as a case-insensitive substring test, which is
-    /// the one reading every backend's version contains.
+    /// `field` contains `value`, case-insensitively. SurrealDB lowercases both
+    /// sides and uses `CONTAINS`; SQL uses `LIKE '%value%'` (`ILIKE` on
+    /// Postgres). A backend with no spelling for it returns Unimplemented and
+    /// the consumer evaluates it locally.
+    ///
+    /// **Case folding is the backend's.** The local fallback and SurrealDB
+    /// fold Unicode; SQLite's `LIKE` folds ASCII only, and MySQL follows the
+    /// column's collation. So `~straße` can match `STRASSE` in one place and
+    /// not another. ASCII text — the overwhelmingly common case — behaves the
+    /// same everywhere.
     Like,
 }
 

--- a/vantage-vista/src/filter.rs
+++ b/vantage-vista/src/filter.rs
@@ -37,9 +37,73 @@ pub enum FilterOp {
     /// `field ∉ value` — `value` is an array; matches when the cell equals no
     /// element.
     NotInSet,
+    /// `field ~ value` — a pattern match on text. What "pattern" means is the
+    /// backend's: SurrealDB's fuzzy `~`, SQL's `LIKE '%value%'`. A backend
+    /// with no spelling for it returns Unimplemented and the consumer
+    /// evaluates it locally as a case-insensitive substring test, which is
+    /// the one reading every backend's version contains.
+    Like,
 }
 
 impl FilterOp {
+    /// The operator an author or a user wrote: a symbol (`>=`, `!=`, `~`) or
+    /// a word (`gte`, `ne`, `like`). The symbol set is what a filter field
+    /// accepts as a typed prefix, so it must stay short enough to type.
+    pub fn parse(op: &str) -> Option<Self> {
+        Some(match op.trim().to_ascii_lowercase().as_str() {
+            "eq" | "=" | "==" => FilterOp::Eq,
+            "ne" | "!=" | "<>" | "!" => FilterOp::Ne,
+            "gt" | ">" => FilterOp::Gt,
+            "gte" | ">=" => FilterOp::Gte,
+            "lt" | "<" => FilterOp::Lt,
+            "lte" | "<=" => FilterOp::Lte,
+            "in" | "in_set" => FilterOp::InSet,
+            "not_in" | "not_in_set" | "nin" | "!in" => FilterOp::NotInSet,
+            "like" | "~" | "contains" => FilterOp::Like,
+            _ => return None,
+        })
+    }
+
+    /// Split a leading operator off a typed value: `">30"` → `(Gt, "30")`,
+    /// `"~smith"` → `(Like, "smith")`, `"30"` → `(Eq, "30")`.
+    pub fn split_prefix(text: &str) -> (Self, &str) {
+        use FilterOp::*;
+        let text = text.trim_start();
+        // Two-character symbols first, or `>=` reads as `>` then `=30`.
+        for (sym, op) in [
+            (">=", Gte),
+            ("<=", Lte),
+            ("!=", Ne),
+            ("<>", Ne),
+            (">", Gt),
+            ("<", Lt),
+            ("~", Like),
+            ("!", Ne),
+            ("=", Eq),
+        ] {
+            if let Some(rest) = text.strip_prefix(sym) {
+                return (op, rest.trim_start());
+            }
+        }
+        (Eq, text)
+    }
+
+    /// How the operator reads in a chip or a label: nothing for equality —
+    /// `Shop: Bristol` says it — and the symbol otherwise.
+    pub fn display_symbol(&self) -> &'static str {
+        match self {
+            FilterOp::Eq => "",
+            FilterOp::Ne => "≠",
+            FilterOp::Gt => ">",
+            FilterOp::Gte => "≥",
+            FilterOp::Lt => "<",
+            FilterOp::Lte => "≤",
+            FilterOp::InSet => "in",
+            FilterOp::NotInSet => "not in",
+            FilterOp::Like => "~",
+        }
+    }
+
     /// Whether this operator's operand is a list (`InSet` / `NotInSet`) rather
     /// than a scalar. Callers building the CBOR operand use this to know
     /// whether to wrap the value in a [`ciborium::Value::Array`].
@@ -61,6 +125,7 @@ impl FilterOp {
             FilterOp::Lte => "<=",
             FilterOp::InSet => "in",
             FilterOp::NotInSet => "!in",
+            FilterOp::Like => "~",
         }
     }
 
@@ -78,7 +143,9 @@ impl FilterOp {
             // Eq/Ne and the set operators don't use a total order; treat as
             // non-matching here so a misuse fails closed rather than silently
             // passing everything. Callers handle these operators directly.
-            FilterOp::Eq | FilterOp::Ne | FilterOp::InSet | FilterOp::NotInSet => false,
+            FilterOp::Eq | FilterOp::Ne | FilterOp::InSet | FilterOp::NotInSet | FilterOp::Like => {
+                false
+            }
         }
     }
 }

--- a/vantage-vista/src/lib.rs
+++ b/vantage-vista/src/lib.rs
@@ -28,7 +28,7 @@ pub use contained::{
     ContainedRefResolver, ContainedShell, ContainedWriteback, build_contained_vista,
 };
 pub use factory::VistaFactory;
-pub use filter::FilterOp;
+pub use filter::{FilterOp, operand_text};
 pub use metadata::VistaMetadata;
 pub use reference::{ContainedKind, ContainedSpec, Reference, ReferenceKind};
 #[cfg(feature = "rhai")]

--- a/vantage-vista/src/rhai/conventional.rs
+++ b/vantage-vista/src/rhai/conventional.rs
@@ -413,22 +413,9 @@ fn parse_dir(dir: &str) -> std::result::Result<SortDirection, Box<EvalAltResult>
 }
 
 fn parse_op(op: &str) -> std::result::Result<crate::FilterOp, Box<EvalAltResult>> {
-    use crate::FilterOp;
-    Ok(match op.to_ascii_lowercase().as_str() {
-        "eq" | "=" | "==" => FilterOp::Eq,
-        "ne" | "!=" | "<>" => FilterOp::Ne,
-        "gt" | ">" => FilterOp::Gt,
-        "gte" | ">=" => FilterOp::Gte,
-        "lt" | "<" => FilterOp::Lt,
-        "lte" | "<=" => FilterOp::Lte,
-        "in" | "in_set" => FilterOp::InSet,
-        "not_in" | "not_in_set" | "nin" | "!in" => FilterOp::NotInSet,
-        other => {
-            return Err(format!(
-                "invalid filter operator '{other}' (expected eq/ne/gt/gte/lt/lte/in/not_in)"
-            )
-            .into());
-        }
+    crate::FilterOp::parse(op).ok_or_else(|| {
+        format!("invalid filter operator '{op}' (expected eq/ne/gt/gte/lt/lte/in/not_in/like)")
+            .into()
     })
 }
 


### PR DESCRIPTION
A grid needs to narrow itself while it is open — the user picks a shop, types a name fragment — and until now nothing carried that through to the datasource. Quicksearch already did it properly: the scenery holds the text, a paged view carries it into every chunk fetch, the master pushes it down when it can and the view filters its cache when it cannot. Filters get the same treatment here.

## `TableScenery::set_filter_terms` / `filter_terms`

A runtime set of `column <op> value` terms, replacing the eq-only `set_filters` for consumers that need more:

- **Paged** — the terms ride in `ChunkQuery` and `fetch_window_ordered_counted` pushes what the master will take: equality always, the richer operators when it advertises `can_filter_operators`. Anything it declines is dropped with a warning rather than evaluated over one window, which would filter a slice and present it as the set. Same rule quicksearch already follows.
- **Eager** — evaluated over the cache in `reseed_from_cache`, which is honest there because the cache is the complete set.
- **Two-pass** — folded into `reseed_filtered` alongside the existing conditions.

The scenery holds the list, so `filter_terms()` is the single source a chip strip or a persisted-filter store reads; nobody has to keep a parallel copy.

## `FilterOp::Like`

A pattern match, spelled by whichever backend can: SurrealDB's fuzzy `~`, `LIKE` on SQLite and MySQL, `ILIKE` on Postgres (matching what quicksearch already does there). GraphQL reports `Unimplemented` so the consumer falls back to local evaluation — a case-insensitive substring test, the one reading every backend's version contains.

`FilterOp` also gains `parse` (symbol or word), `split_prefix` (`">30"` → `(Gt, "30")`) and `display_symbol`, so a UI can accept an operator typed into a field and label it back.

## While here

`like_pattern_str` is now shared between the three SQL backends' quicksearch and the new `Like` arm, so the claim that they build the same `%…%` escape is true by construction rather than by convention.

## Notes

- `vantage-spacetimedb` pins the published `vantage-vista`, so it is untouched; the exhaustive match in `sql_operator` will ask for a `Like` arm when it re-pins.
- Tests: a new `runtime_filter_terms_narrow_and_clear` covering narrow, local `Like`, and clear-back; workspace green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `Like` filter operator for case-insensitive text pattern matching, including empty patterns.
  * Added runtime filter terms that update table results and can be cleared.
  * Filter terms now apply consistently to loaded, cached, and paginated data.
  * SQL and SurrealDB backends support backend-appropriate pattern matching.

* **Bug Fixes**
  * Improved propagation of active filters during chunk loading.
  * Unsupported GraphQL pattern matching now reports clearly and is evaluated locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->